### PR TITLE
[fix] send message double time by enter when input's composition is not end

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -226,7 +226,7 @@
         <MainMenu />
     {:else}
         <div class="h-full w-full flex flex-col-reverse overflow-y-auto relative"  on:scroll={(e) => {
-            //@ts-ignore
+            //@ts-ignore  
             const scrolled = (e.target.scrollHeight - e.target.clientHeight + e.target.scrollTop)
             if(scrolled < 100 && $DataBase.characters[$selectedCharID].chats[$DataBase.characters[$selectedCharID].chatPage].message.length > loadPages){
                 loadPages += 30
@@ -237,7 +237,7 @@
                     bind:value={messageInput}
                     bind:this={inputEle}
                     on:keydown={(e) => {
-                        if(e.key.toLocaleLowerCase() === "enter" && (!e.shiftKey)){
+                        if(e.key.toLocaleLowerCase() === "enter" && (!e.shiftKey) && !e.isComposing){
                             if($DataBase.sendWithEnter){
                                 send()
                                 e.preventDefault()


### PR DESCRIPTION
# PR Checklist
- [v] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [v] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [NO] Did you added a type def?

# Description
### Bug 
send message double time by enter when writing korean. 
This issue occurs when input's composition is not end. 

https://github.com/kwaroran/RisuAI/assets/60877502/758b3168-d63c-4b64-8ca0-6a5afefad749



### fix
block send message when event is composing.






