### PR TITLE
Fixed event stream header check

### DIFF
--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -209,7 +209,7 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
                     }
                 }
 
-                if(da.headers.get('Content-Type') !== 'text/event-stream'){
+                if (!da.headers.get('Content-Type').includes('text/event-stream')){
                     return {
                         type: "fail",
                         result: await da.text()


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [x] Did you added a type def?

# Description
I am running local llama in own API server. In streaming mode, the `Content-Type` is sometimes appended with something like `text/event-stream; charset=UTF-8`, so we just need to make sure the header contains the string `text/event-stream`.