### PR TITLE
[fix] apply plain fetch option when use Streaming

### DIFF
--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -193,7 +193,7 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
             }
             if(db.useStreaming && arg.useStreaming){
                 body.stream = true
-                const da =  ((!isTauri) && (!isNodeServer))
+                const da =  ((!isTauri) && (!isNodeServer) && (!db.usePlainFetch))
                     ? await fetch(`/proxy2`, {
                         body: JSON.stringify(body),
                         headers: {


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [x] Did you added a type def?

# Description
Apply plain fetch option when use Streaming