### PR TITLE
fix VOICEVOX transelate

### DIFF
--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -155,5 +155,5 @@ export async function translateVox(text:string) {
 
 
 async function jaTrans(text:string) {
-    return await runTranslator(text,false, 'en','ja')
+    return await runTranslator(text, true, 'en','ja')
 }


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [v] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description

Fixed an error that caused VOICEVOX TTS to not output properly due to translation errors.