### PR TITLE
Fixed a bug where checking an inlay in the emotion bot would delete all assets.

### DIFF
--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -397,9 +397,9 @@
 
         <CheckInput bind:check={currentChar.data.inlayViewScreen} name={language.inlayViewScreen} onChange={() => {
             if(currentChar.type === 'character'){
-                if(currentChar.data.inlayViewScreen || currentChar.data.additionalAssets === undefined){
+                if(currentChar.data.inlayViewScreen && currentChar.data.additionalAssets === undefined){
                     currentChar.data.additionalAssets = []
-                }else if(!currentChar.data.inlayViewScreen || currentChar.data.additionalAssets.length === 0){
+                }else if(!currentChar.data.inlayViewScreen && currentChar.data.additionalAssets.length === 0){
                     currentChar.data.additionalAssets = undefined
                 }
                 


### PR DESCRIPTION
Signed-off-by: hashcoko <hashcoko@gmail.com>

# PR Checklist
- [ v ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ v ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ v ] Did you added a type def?

# Description
