### PR TITLE
Add missed break statement

### DIFF
--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -145,6 +145,7 @@ export async function sayTTS(character:character,text:string) {
                     alertError((language.errors.httpError + `${Buffer.from(res.data).toString()}`))
                 }
             }
+            break;
 
         }
         case 'novelai': {


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
breaks statement was missed in 'openai' tts case.
It makes a bug that requesting openai TTS and novelai TTS both.

This commit will fix this issue.