### PR TITLE
Fix errors when use Oobabooga mode

### DIFF
--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -904,7 +904,7 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
             }
 
             const url = new URL(db.textgenWebUIBlockingURL)
-            url.pathname = "/v1/chat/completions"
+            url.pathname = "/v1/completions"
             const urlStr = url.toString()
 
             const OobaBodyTemplate = db.reverseProxyOobaArgs


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [✓] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
![image](https://github.com/kwaroran/RisuAI/assets/62899533/afc87b7b-b216-443a-964d-2e3525627fb8)
Now Oobabooga mode uses instruct mode when they request to server, but in the request code it still uses v1/chat/completions when request to server, which cause error when use it. After I change that part to v1/completions, it works well for me.