### PR TITLE
Add gpt-3.5-turbo-0125, fix gpt-4-0314

### DIFF
--- a/src/lib/UI/ModelList.svelte
+++ b/src/lib/UI/ModelList.svelte
@@ -126,10 +126,11 @@
                 <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gptvi4_1106')}}>GPT-4 Turbo 1106 Vision</button>
                 {#if showUnrec}
                     <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt35_16k')}}>GPT-3.5 Turbo 16K</button>
-                    <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt4_0301')}}>GPT-4 0301</button>
+                    <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt4_0314')}}>GPT-4 0314</button>
                     <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt4_0613')}}>GPT-4 0613</button>
                     <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt4_32k_0613')}}>GPT-4 32K 0613</button>
                     <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt4_1106')}}>GPT-4 Turbo 1106</button>
+                    <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt35_0125')}}>GPT-3.5 Turbo 0125</button>
                     <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt35_1106')}}>GPT-3.5 Turbo 1106</button>
                     <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt35_0613')}}>GPT-3.5 Turbo 0613</button>
                     <button class="p-2 hover:text-green-500" on:click={() => {changeModel('gpt35_16k_0613')}}>GPT-3.5 Turbo 16K 0613</button>

--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -152,9 +152,10 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
         case 'gpt4_32k_0613':
         case 'gpt4_1106':
         case 'gpt4_0125':
+        case 'gpt35_0125':
         case 'gpt35_1106':
         case 'gpt35_0301':
-        case 'gpt4_0301':
+        case 'gpt4_0314':
         case 'gptvi4_1106':
         case 'openrouter':
         case 'mistral-tiny':
@@ -405,9 +406,10 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
                     : requestModel === "gpt4_1106" ? 'gpt-4-1106-preview'
                     : requestModel === 'gpt4_0125' ? 'gpt-4-0125-preview'
                     : requestModel === "gptvi4_1106" ? 'gpt-4-vision-preview'
+                    : requestModel === "gpt35_0125" ? 'gpt-3.5-turbo-0125'
                     : requestModel === "gpt35_1106" ? 'gpt-3.5-turbo-1106'
                     : requestModel === 'gpt35_0301' ? 'gpt-3.5-turbo-0301'
-                    : requestModel === 'gpt4_0301' ? 'gpt-4-0301'
+                    : requestModel === 'gpt4_0314' ? 'gpt-4-0314'
                     : (!requestModel) ? 'gpt-3.5-turbo'
                     : requestModel,
                 messages: formatedChat,


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [x] Did you added a type def?

# Description

Reference: 
https://platform.openai.com/docs/models/gpt-3-5-turbo
https://platform.openai.com/docs/deprecations

1. Added gpt-3.5-turbo-0125 model: The current gpt-3.5-turbo is pointed to the 0613 model, but the official documentation says it will automatically upgrade to the 0125 model on February 16 anyway.
2. Fixed the model name of gpt-4-0314, although it is deprecated.