### PR TITLE
GlobalFetch 리팩토링, Elevenlabs 다국어모델 정보 body에 삽입, DeepLX 로직구현(미작동)

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -391,6 +391,8 @@ export const languageChinese = {
 	"translatorType": "翻译类型",
 	"deeplKey": "deepl API密钥",
 	"deeplFreeKey": "deepl 免费 API密钥",
+	"deeplXUrl": "deepLX URL",
+	"deeplXToken": "deepLX Token",
 	"exportPersona": "导出角色",
 	"importPersona": "导入角色",
 	"export": "导出",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -421,6 +421,8 @@ export const languageGerman = {
     translatorType: "Übersetzer-Typ",
     deeplKey: "DeepL API-Schlüssel",
     deeplFreeKey: "DeepL Gratis API-Schlüssel",
+    deeplXUrl: "deepLX URL",
+    deeplXToken: "deepLX Token",
     exportPersona: "Profil exportieren",
     importPersona: "Profil importieren",
     export: "Exportieren",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -456,6 +456,8 @@ export const languageEnglish = {
     translatorType: "Translator Type",
     deeplKey: "deepL API Key",
     deeplFreeKey: "deepL Free API Key",
+    deeplXUrl: "deepLX URL",
+    deeplXToken: "deepLX Token",
     exportPersona: "Export Persona",
     importPersona: "Import Persona",
     export: "Export",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -394,6 +394,8 @@ export const languageKorean = {
     translatorType: "번역기 타입",
     deeplKey: "deepL API 키",
     deeplFreeKey: "deepL 무료 API 키",
+    deeplXUrl: "deepLX URL",
+    deeplXToken: "deepLX Token",
     exportPersona: "페르소나 엑스포트",
     importPersona: "페르소나 임포트",
     export: "엑스포트",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -392,6 +392,8 @@ export const LanguageVietnamese = {
     "translatorType": "Loại dịch giả",
     "deeplKey": "Khóa API deepL",
     "deeplFreeKey": "Khóa API miễn phí deepL",
+    "deeplXUrl": "deepLX URL",
+    "deeplXToken": "deepLX Token",
     "exportPersona": "Xuất khẩu nhân vật",
     "importPersona": "Nhập khẩu nhân vật",
     "export": "Xuất khẩu",

--- a/src/lib/Setting/Pages/LanguageSettings.svelte
+++ b/src/lib/Setting/Pages/LanguageSettings.svelte
@@ -58,6 +58,7 @@
         <OptionInput value="google" >Google</OptionInput>
         <OptionInput value="deepl" >DeepL</OptionInput>
         <OptionInput value="llm" >Ax. Model</OptionInput>
+        <OptionInput value="deeplX" >DeepL X</OptionInput>
     </SelectInput>
 
     {#if $DataBase.translatorType === 'deepl'}
@@ -70,6 +71,14 @@
         <div class="flex items-center mt-2">
             <Check bind:check={$DataBase.deeplOptions.freeApi} name={language.deeplFreeKey}/>
         </div>
+    {/if}
+
+    {#if $DataBase.translatorType === 'deeplX'}
+        <span class="text-textcolor mt-4">{language.deeplXUrl}</span>
+        <TextInput bind:value={$DataBase.deeplXOptions.url} />
+        
+        <span class="text-textcolor mt-4">{language.deeplXToken}</span>
+        <TextInput bind:value={$DataBase.deeplXOptions.token} />
     {/if}
     
     {#if $DataBase.translatorType === 'llm'}

--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -56,7 +56,8 @@ export async function sayTTS(character:character,text:string) {
                 const audioContext = new AudioContext();
                 const da = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${character.ttsSpeech}`, {
                     body: JSON.stringify({
-                        text: text
+                        text: text,
+                        model_id: "eleven_multilingual_v2"
                     }),
                     method: "POST",
                     headers: {

--- a/src/ts/storage/database.ts
+++ b/src/ts/storage/database.ts
@@ -332,6 +332,10 @@ export function setDatabase(data:Database){
         key:'',
         freeApi: false
     }
+    data.deeplXOptions ??= {
+        url:'',
+        token:''
+    } 
     data.NAIadventure ??= false
     data.NAIappendName ??= true
     data.NAIsettings.cfg_scale ??= 1
@@ -555,12 +559,16 @@ export interface Database{
     mancerHeader:string
     emotionProcesser:'submodel'|'embedding',
     showMenuChatList?:boolean,
-    translatorType:'google'|'deepl'|'none'|'llm',
+    translatorType:'google'|'deepl'|'none'|'llm'|'deeplX',
     NAIadventure?:boolean,
     NAIappendName?:boolean,
     deeplOptions:{
         key:string,
         freeApi:boolean
+    }
+    deeplXOptions:{
+        url:string,
+        token:string    
     }
     localStopStrings?:string[]
     autofillRequestUrl:boolean

--- a/src/ts/storage/globalApi.ts
+++ b/src/ts/storage/globalApi.ts
@@ -555,7 +555,6 @@ export async function globalFetch(url: string, arg: GlobalFetchArgs = {}): Promi
     return { ok: false, headers: {}, data: 'You are trying local request on web version. This is not allowed due to browser security policy. Use the desktop version instead, or use a tunneling service like ngrok and set the CORS to allow all.' }
 
     // Simplify the globalFetch function: Detach built-in functions
-    const fetchData = async (url, arg) => {
       if (forcePlainFetch) {
         return await fetchWithPlainFetch(url, arg);
       }
@@ -566,7 +565,6 @@ export async function globalFetch(url: string, arg: GlobalFetchArgs = {}): Promi
         return await fetchWithCapacitor(url, arg);
       }
       return await fetchWithProxy(url, arg);
-    };
     
   } catch (error) {
     console.error(error);

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -128,20 +128,26 @@ async function translateMain(text:string, arg:{from:string, to:string, host:stri
 
     }
     if(db.translatorType === 'deeplX'){
-        const body = {
+        const body = JSON.stringify({
             text: [text],
             target_lang: arg.to.toLocaleUpperCase(),
             source_lang: arg.from.toLocaleUpperCase()
+        })
+        let url = db.deeplXOptions.url;
+        let headers = {
+            "Content-Type": "application/json"
         }
-        let url = db.deeplXOptions.url
+    
+        // token이 비어있지 않으면 headers에 Authorization 추가
+        if(db.deeplXOptions.token.trim() !== '') {
+            headers["Authorization"] = "Bearer " + db.deeplXOptions.token;
+        }
+    
         const f = await globalFetch(url, {
-            headers: {
-                "Content-Type": "application/json",
-                "Authorization" : "Bearer " + db.deeplXOptions.token
-            },
+            method: "POST", // 요청 메소드 추가
+            headers: headers,
             body: body
         })
-
         if(!f.ok){
             return 'ERR::DeepLX API Error' + (await f.data)
         }

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -128,31 +128,23 @@ async function translateMain(text:string, arg:{from:string, to:string, host:stri
 
     }
     if(db.translatorType === 'deeplX'){
-        const body = JSON.stringify({
-            text: [text],
-            target_lang: arg.to.toLocaleUpperCase(),
-            source_lang: arg.from.toLocaleUpperCase()
-        })
+        // URL이 DeeplX 프로그램 실행시키면 CMD에서는 0.0.0.0:1188라고 뜨는데 https://0.0.0.0:1188/translate 로 호출 보내야함
+        // 유저가 https://0.0.0.0:1188/translate라고 입력하게 할지, 아니면 0.0.0.0:1188만 입력하면 /translate를 자동으로 붙여줄지 결정필요
         let url = db.deeplXOptions.url;
-        let headers = {
-            "Content-Type": "application/json"
-        }
-    
-        // token이 비어있지 않으면 headers에 Authorization 추가
-        if(db.deeplXOptions.token.trim() !== '') {
-            headers["Authorization"] = "Bearer " + db.deeplXOptions.token;
-        }
-    
-        const f = await globalFetch(url, {
-            method: "POST", // 요청 메소드 추가
-            headers: headers,
-            body: body
-        })
-        if(!f.ok){
-            return 'ERR::DeepLX API Error' + (await f.data)
-        }
-        return f.data.translations[0].text
+        let headers = { "Content-Type": "application/json" }
 
+        const body = {text: text, target_lang: arg.to.toLocaleUpperCase(), source_lang: arg.from.toLocaleUpperCase()}
+
+    
+        if(db.deeplXOptions.token.trim() !== '') { headers["Authorization"] = "Bearer " + db.deeplXOptions.token}
+        
+        console.log(body)
+        const f = await globalFetch(url, { method: "POST", headers: headers, body: body })
+
+        if(!f.ok){ return 'ERR::DeepLX API Error' + (await f.data) }
+
+        const jsonResponse = JSON.stringify(f.data.data)
+        return jsonResponse
     }
 
 

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -127,6 +127,29 @@ async function translateMain(text:string, arg:{from:string, to:string, host:stri
         return f.data.translations[0].text
 
     }
+    if(db.translatorType === 'deeplX'){
+        const body = {
+            text: [text],
+            target_lang: arg.to.toLocaleUpperCase(),
+            source_lang: arg.from.toLocaleUpperCase()
+        }
+        let url = db.deeplXOptions.url
+        const f = await globalFetch(url, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization" : "Bearer " + db.deeplXOptions.token
+            },
+            body: body
+        })
+
+        if(!f.ok){
+            return 'ERR::DeepLX API Error' + (await f.data)
+        }
+        return f.data.translations[0].text
+
+    }
+
+
     const url = `https://${arg.host}/translate_a/single?client=gtx&dt=t&sl=${arg.from}&tl=${arg.to}&q=` + encodeURIComponent(text)
 
 
@@ -171,7 +194,7 @@ async function jaTrans(text:string) {
 
 export function isExpTranslator(){
     const db = get(DataBase)
-    return db.translatorType === 'llm' || db.translatorType === 'deepl'
+    return db.translatorType === 'llm' || db.translatorType === 'deepl' || db.translatorType === 'deeplX'
 }
 
 export async function translateHTML(html: string, reverse:boolean, charArg:simpleCharacterArgument|string = ''): Promise<string> {


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
1. DeepLX 를 번역 옵션에 넣고 URL, Token을 넣을 수 있게 하였습니다.
2. DeepLX 를 호출하는 로직을 넣었는데, DeepLX의 Body 중 Text는 완전한 텍스트로만 이루어져야 해서 번역 실행시 에러가 발생하는 중입니다. (DeepLX에 globalFetech로 호출은 정상적으로 가는중, body의 text타입만 해결하면 작동,)
3. TTS -> 일레븐랩스 호출시 body에 model을 다국어모델로 지정하였습니다. (정상작동)
4. globalFetch 함수를 리팩토링 하였습니다.

DeepLX 쪽만 해결방법을 찾으면 좋을 것 같은데 로직이 제가 생각한 것과 달라서 파악하는데 시간이 오래걸리고 있습니다.

DeepLX 부분 저도 더 로직 분석해볼 예정이지만, 
Body 부분에서 특수문자 제거 및 본문 텍스트만 파싱해서 번역 후 재조립하는 게 구현 가능하시다면 
해당 부분만 업데이트 해주시면 좋을 것 같습니다.
