### PR TITLE
Fixing the issue with quote escape when serializing strings in JSON i…

### DIFF
--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -159,8 +159,7 @@ async function translateMain(text:string, arg:{from:string, to:string, host:stri
 
         if(!f.ok){ return 'ERR::DeepLX API Error' + (await f.data) }
 
-        const jsonResponse = JSON.stringify(f.data.data)
-        return jsonResponse
+        return f.data.data;
     }
 
 


### PR DESCRIPTION
…n DeepLX.

# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description

Fix the issue of escape characters in quotes caused by unnecessary JSON serialization of translation strings in DeepLX.