### PR TITLE
Fixed the 'failed to fetch', 'Decoding failed' errors occurring in some environments in NodeJS

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -69,6 +69,7 @@ const reverseProxyFunc = async (req, res, next) => {
         head.delete('content-security-policy-report-only');
         head.delete('clear-site-data');
         head.delete('Cache-Control');
+        head.delete('Content-Encoding');
         const headObj = {};
         for (let [k, v] of head) {
             headObj[k] = v;


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
Fixed a bug caused by the "Content-Encoding" header returned from the server in some environments in the Risu environment of the NodeJS server.
In reality, the server does not return compressed data, but the issue arises from sending that header.
