### PR TITLE
Fix typo in mainpage parameter name in preload.ts

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -17,7 +17,7 @@ export function preLoadCheck(){
         localStorage.setItem('mainpage', 'visited');
     }
     else if(searchParams.has('mainpage')) {
-        localStorage.setItem('mainpage', searchParams.get('main-page'));
+        localStorage.setItem('mainpage', searchParams.get('mainpage'));
     }
     
     


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
