### PR TITLE
Fixed ollama's hardcoded url

### DIFF
--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -1490,7 +1490,7 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
             }
         }
         case 'ollama-hosted':{
-            const ollama = new Ollama({host: 'http://localhost:11434'})
+            const ollama = new Ollama({host: db.ollamaURL})
 
             const response = await ollama.chat({
                 model: db.ollamaModel,


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
 it does not need models
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions? 
due to me using nixos i cant really build it for my system. but i tested the web version and do not see why it would not work for other versions. furhtermore this is a backend issue so i doubt the ui changed anything
- [ ] Did you added a type def?
idk what that is. but i changed one line so i assume no

# Description
As described in #402 RisuAI would always try to reach localhost:11434 to connect to ollama. completely ignoring the user supplied adress. this fix addresses that. now it actually uses the correct url