### PR TITLE
Fix: Now combineTranslation applies the markdown to the result

### DIFF
--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -437,4 +437,5 @@ export const languageKorean = {
     modules: "모듈",
     useAdvancedEditor: "고급 에디터 사용",
     hanuraiMemory: "하느라이메모리",
+    combineTranslation: "결합 번역",
 }

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -316,6 +316,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
             let translated = await translate(node.textContent || "", reverse);
             if (!reprocessDisplayScript) {
                 node.textContent = translated;
+                applyMarkdownToNode(node);
                 return;
             }
             
@@ -325,12 +326,6 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
                 "editdisplay",
                 chatID
             );
-            
-            // If the translation is the same, don't replace the node
-            if (translated == processedTranslated) {
-                node.textContent = processedTranslated;
-                return;
-            }
 
             // Replace the old node with the new one
             const newNode = document.createElement(

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -316,7 +316,6 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
             let translated = await translate(node.textContent || "", reverse);
             if (!reprocessDisplayScript) {
                 node.textContent = translated;
-                applyMarkdownToNode(node);
                 return;
             }
             
@@ -326,6 +325,12 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
                 "editdisplay",
                 chatID
             );
+            // If the translation is the same, don't replace the node
+            if (translated == processedTranslated) {
+                node.textContent = processedTranslated;
+                applyMarkdownToNode(node)
+                return;
+            }
 
             // Replace the old node with the new one
             const newNode = document.createElement(

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -8,7 +8,7 @@ import { doingChat } from "../process"
 import type { simpleCharacterArgument } from "../parser"
 import { selectedCharID } from "../stores"
 import { getModuleRegexScripts } from "../process/modules"
-import { getNodetextWithNewline, sleep } from "../util"
+import { getNodetextToSentence, sleep, applyMarkdownToNode } from "../util"
 import { processScriptFull } from "../process/scripts"
 
 let cache={
@@ -318,7 +318,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
                 node.textContent = translated;
                 return;
             }
-
+            
             const { data: processedTranslated } = await processScriptFull(
                 alwaysExistChar,
                 translated,
@@ -338,6 +338,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
             );
             newNode.innerHTML = processedTranslated;
             node.parentNode.replaceChild(newNode, node);
+            applyMarkdownToNode(newNode);
         }
     }
 
@@ -374,7 +375,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
                     blacklist.includes(child.nodeName.toLowerCase())
                 );
                 if (!hasBlacklistChild && (node as Element)?.getAttribute('translate') !== 'no'){
-                    const text = getNodetextWithNewline(node);
+                    const text = getNodetextToSentence(node);
                     const sentences = text.split("\n");
                     if (sentences.length > 1) {
                         // Multiple sentences seperated by <br> tags
@@ -389,6 +390,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
                         }
                     } else {
                         // Single sentence
+                        node.innerHTML = sentences[0];
                         await translateNodeText(node, true);
                     }
                     return;

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -574,10 +574,12 @@ export function applyMarkdownToNode(node: Node) {
                 span.innerHTML = markdown;
                 
                 // inherit inline style from the parent node
-                const parentStyle = (node.parentNode as HTMLElement).style;
-                for(let i=0;i<parentStyle.length;i++){
-                    span.style.setProperty(parentStyle[i], parentStyle.getPropertyValue(parentStyle[i]))
-                }   
+                const parentStyle = (node.parentNode as HTMLElement)?.style;
+                if(parentStyle){
+                    for(let i=0;i<parentStyle.length;i++){
+                        span.style.setProperty(parentStyle[i], parentStyle.getPropertyValue(parentStyle[i]))
+                    }   
+                }
                 (node as Element)?.replaceWith(span);
                 return
             }

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -569,7 +569,6 @@ export function applyMarkdownToNode(node: Node) {
         const text = node.textContent;
         if (text) {
             let markdown = mconverted.parseInline(text);
-            markdown = mconverted.parseInline(markdown)
             if (markdown !== text) {
                 const span = document.createElement('span');
                 span.innerHTML = markdown;

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -573,6 +573,12 @@ export function applyMarkdownToNode(node: Node) {
             if (markdown !== text) {
                 const span = document.createElement('span');
                 span.innerHTML = markdown;
+                
+                // inherit inline style from the parent node
+                const parentStyle = (node.parentNode as HTMLElement).style;
+                for(let i=0;i<parentStyle.length;i++){
+                    span.style.setProperty(parentStyle[i], parentStyle.getPropertyValue(parentStyle[i]))
+                }   
                 (node as Element)?.replaceWith(span);
                 return
             }

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -8,6 +8,16 @@ import { basename } from "@tauri-apps/api/path"
 import { createBlankChar, getCharImage } from "./characters"
 import { appWindow } from '@tauri-apps/api/window';
 import { isTauri } from "./storage/globalApi"
+import { Marked } from "marked"
+
+const mconverted = new Marked({
+    gfm: true,
+    breaks: true,
+    silent: true,
+    tokenizer: {
+
+    }
+})
 
 export interface Messagec extends Message{
     index: number
@@ -525,18 +535,18 @@ export function appendLastPath(url, lastPath) {
 }
 
 /**
- * Retrieves the text content of a given Node object, including line breaks represented by <br> elements.
+ * Converts the text content of a given Node object, including HTML elements, into a plain text sentence.
  *
  * @param {Node} node - The Node object from which the text content will be extracted.
- * @returns {string} The text content of the Node, with line breaks represented by newline characters ('\n').
+ * @returns {string} The plain text sentence representing the content of the Node object.
  *
  * @example
  * const div = document.createElement('div');
- * div.innerHTML = 'Hello<br>World';
- * const text = getNodetextWithNewline(div);
- * console.log(text); // Output: "Hello\nWorld"
+ * div.innerHTML = 'Hello<br>World<del>Deleted</del>';
+ * const sentence = getNodetextToSentence(div);
+ * console.log(sentence); // Output: "Hello\nWorld~Deleted~"
  */
-export function getNodetextWithNewline(node: Node) {
+export function getNodetextToSentence(node: Node): string {
     let result = '';
     for (const child of node.childNodes) {
         if (child.nodeType === Node.TEXT_NODE) {
@@ -544,10 +554,32 @@ export function getNodetextWithNewline(node: Node) {
         } else if (child.nodeType === Node.ELEMENT_NODE) {
             if (child.nodeName === 'BR') {
                 result += '\n';
+            } else if (child.nodeName === 'DEL') {
+                result += '~' + getNodetextToSentence(child) + '~';
             } else {
-                result += getNodetextWithNewline(child);
+                result += getNodetextToSentence(child);
             }
         }
     }
     return result;
+}
+
+export function applyMarkdownToNode(node: Node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent;
+        if (text) {
+            let markdown = mconverted.parseInline(text);
+            markdown = mconverted.parseInline(markdown)
+            if (markdown !== text) {
+                const span = document.createElement('span');
+                span.innerHTML = markdown;
+                (node as Element)?.replaceWith(span);
+                return
+            }
+        }
+    } else {
+        for (const child of node.childNodes) {
+            applyMarkdownToNode(child);
+        }
+    }
 }


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [x] Did you added a type def?

# Description
I knew there was a `ParseMarkdown` function, but I didn't think it fit the current situation, so I created a new `applyMarkdownToNode` function, 
but I didn't see much difference in the results, So if you think `ParseMarkdown` is better, you can change my code to use that. 
(To use `ParseMarkdown`, we need to create a parameter that allows us to use `mconverted.parseInline` instead of `mconverted.parse` to the ParseMarkdown function)
