### PR TITLE
Fix: handling more markdown in getNodetextToSentence

### DIFF
--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -554,9 +554,25 @@ export function getNodetextToSentence(node: Node): string {
         } else if (child.nodeType === Node.ELEMENT_NODE) {
             if (child.nodeName === 'BR') {
                 result += '\n';
-            } else if (child.nodeName === 'DEL') {
+                continue;
+            }
+            
+            // If a child has a style it's not for a markdown formatting
+            const childStyle = (child as HTMLElement)?.style;
+            if (childStyle?.cssText!== '') {
+                result += getNodetextToSentence(child);
+                continue;
+            }
+            
+            // convert HTML elements to markdown format
+            if (child.nodeName === 'DEL') {
                 result += '~' + getNodetextToSentence(child) + '~';
-            } else {
+            } else if (child.nodeName === 'STRONG' || child.nodeName === 'B') {
+                result += '**' + getNodetextToSentence(child) + '**';
+            } else if (child.nodeName === 'EM' || child.nodeName === 'I') {
+                result += '*' + getNodetextToSentence(child) + '*';
+            } 
+            else {
                 result += getNodetextToSentence(child);
             }
         }


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
Sorry but there were some markdown tags that I missed, But I think It's not an urgent patch like last time.
So If there are any tags I missed, I will continue commit to this pr until the next update.