### PR TITLE
Add GPT-4o in Custom (OpenAI-compatible)

### DIFF
--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -172,6 +172,7 @@
         <OptionInput value="gpt35">GPT 3.5</OptionInput>
         <OptionInput value="gpt35_16k">GPT 3.5 16k</OptionInput>
         <OptionInput value="gpt4">GPT-4</OptionInput>
+        <OptionInput value="gpt4o">GPT-4o</OptionInput>
         <OptionInput value="gpt4_32k">GPT-4 32k</OptionInput>
         <OptionInput value="gpt4_1106">GPT-4 Turbo 1106</OptionInput>
         <OptionInput value="gptvi4_1106">GPT-4 Turbo 1106 Vision</OptionInput>


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
Apart from pr, I wish reverse proxy had showUnrec too like the official openai setting