### PR TITLE
feat: Add first_msg_index curly syntax

### DIFF
--- a/src/ts/parser.ts
+++ b/src/ts/parser.ts
@@ -535,6 +535,13 @@ const matcher = (p1:string,matcherArg:matcherArg) => {
             case 'chat_index':{
                 return chatID.toString() 
             }
+            case 'first_msg_index':{
+                if(chatID !== -1){
+                    const selchar = db.characters[get(selectedCharID)]
+                    return selchar.firstMsgIndex
+                }
+                return null;
+            }
             case 'blank':
             case 'none':{
                 return ''


### PR DESCRIPTION
# PR Checklist
- [v] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [v] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [v] Did you added a type def?

# Description

Add a curly syntax for retrieving the index for the selected alternate first message. {{first_msg_index}} replaced with -1 if the default first message is being used, otherwise it's replace with the selected index of alternate first message.