### PR TITLE
feat: Substitute first_msg_index even if context is not chat

### DIFF
--- a/src/ts/parser.ts
+++ b/src/ts/parser.ts
@@ -536,11 +536,8 @@ const matcher = (p1:string,matcherArg:matcherArg) => {
                 return chatID.toString() 
             }
             case 'first_msg_index':{
-                if(chatID !== -1){
-                    const selchar = db.characters[get(selectedCharID)]
-                    return selchar.firstMsgIndex
-                }
-                return null;
+                const selchar = db.characters[get(selectedCharID)]
+                return selchar.firstMsgIndex
             }
             case 'blank':
             case 'none':{


### PR DESCRIPTION
# PR Checklist
- [v] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [v] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [v] Did you added a type def?

# Description

Remove unnecessary check when substituting first_msg_index that is preventing it to be used within non-chat context (e.g. lorebook)