### PR TITLE
Increase max token of LLM translate.

### DIFF
--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -464,7 +464,7 @@ async function translateLLM(text:string, arg:{to:string}){
         bias: {},
         useStreaming: false,
         noMultiGen: true,
-        maxTokens: 1000,
+        maxTokens: 2000,
     }, 'submodel')
 
     if(rq.type === 'fail' || rq.type === 'streaming' || rq.type === 'multiline'){


### PR DESCRIPTION
1000 -> 2000

# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
Previously, max token of LLM translate (Ax. model) is hardcoded with 1000
It makes translation truncated if the content is too long.

This PR makes it double, from 1000 to 2000.