### PR TITLE
Enhance Node Version RisuAI Backend Server File I/O Performance

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -201,9 +201,12 @@ app.get('/api/list', async (req, res, next) => {
         return
     }
     try {
+        const data = (await fs.readdir(path.join(savePath))).map((v) => {
+            return Buffer.from(v, 'hex').toString('utf-8')
+        })
         res.send({
             success: true,
-            content: await fs.readdir(path.join(savePath))
+            content: data
         });
     } catch (error) {
         next(error);

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -7,7 +7,8 @@ const bodyParser = require('body-parser');
 const fs = require('fs/promises')
 const crypto = require('crypto')
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false}));
-app.use(bodyParser.json({ limit: 100000000 }));
+app.use(bodyParser.raw({ limit: 100000000 }));
+app.use(bodyParser.json())
 const {pipeline} = require('stream/promises')
 
 let password = ''
@@ -148,17 +149,11 @@ app.get('/api/read', async (req, res, next) => {
     }
     try {
         if(!existsSync(path.join(savePath, filePath))){
-            res.send({
-                success: true,
-                content: null
-            });
+            res.send();
         }
         else{
-            const data = await fs.readFile(path.join(savePath, filePath));
-            res.send({
-                success: true,
-                content: data.toString('base64')
-            });
+            res.setHeader('Content-Type','application/octet-stream');
+            res.sendFile(path.join(savePath, filePath));
         }
     } catch (error) {
         next(error);
@@ -206,12 +201,9 @@ app.get('/api/list', async (req, res, next) => {
         return
     }
     try {
-        const data = (await fs.readdir(path.join(savePath))).map((v) => {
-            return Buffer.from(v, 'hex').toString('utf-8')
-        })
         res.send({
             success: true,
-            content: data
+            content: await fs.readdir(path.join(savePath))
         });
     } catch (error) {
         next(error);
@@ -227,7 +219,7 @@ app.post('/api/write', async (req, res, next) => {
         return
     }
     const filePath = req.headers['file-path'];
-    const fileContent = Buffer.from(req.body.content, 'base64');
+    const fileContent = req.body
     if (!filePath || !fileContent) {
         res.status(400).send({
             error:'File path required'

--- a/src/ts/storage/nodeStorage.ts
+++ b/src/ts/storage/nodeStorage.ts
@@ -9,11 +9,9 @@ export class NodeStorage{
         await this.checkAuth()
         const da = await fetch('/api/write', {
             method: "POST",
-            body: JSON.stringify({
-                content: Buffer.from(value).toString('base64')
-            }),
+            body: value,
             headers: {
-                'content-type': 'application/json',
+                'content-type': 'application/octet-stream',
                 'file-path': Buffer.from(key, 'utf-8').toString('hex'),
                 'risu-auth': auth
             }
@@ -35,17 +33,15 @@ export class NodeStorage{
                 'risu-auth': auth
             }
         })
-        const data = await da.json()
         if(da.status < 200 || da.status >= 300){
             throw "getItem Error"
         }
-        if(data.error){
-            throw data.error
-        }
-        if(data.content === null){
+
+        const data = Buffer.from(await da.arrayBuffer())
+        if (data.length == 0){
             return null
         }
-        return Buffer.from(data.content, 'base64')
+        return data
     }
     async keys():Promise<string[]>{
         await this.checkAuth()


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
노드리스의 /api/write와 /api/read에서 base64를 제거해 파일 용량 과 I/O에 필요한 연산량을 줄였습니다.
Removed base64 from /api/write and /api/read on node version rise to reduce file size and the amount of computation required for I/O.