### PR TITLE
add sonnet 3.5 for aws and custom

### DIFF
--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -174,6 +174,7 @@
         <OptionInput value="gpt4">GPT-4</OptionInput>
         <OptionInput value="gpt4o">GPT-4o</OptionInput>
         <OptionInput value="gpt4_32k">GPT-4 32k</OptionInput>
+        <OptionInput value="gpt4_turbo">GPT-4 Turbo</OptionInput>
         <OptionInput value="gpt4_1106">GPT-4 Turbo 1106</OptionInput>
         <OptionInput value="gptvi4_1106">GPT-4 Turbo 1106 Vision</OptionInput>
         <OptionInput value="gpt35_0301">GPT-3.5 0301</OptionInput>
@@ -190,6 +191,7 @@
         <OptionInput value="claude-instant-v1.1-100k">claude-instant-v1.1-100k</OptionInput>
         <OptionInput value="claude-3-opus-20240229">claude-3-opus-20240229</OptionInput>
         <OptionInput value="claude-3-sonnet-20240229">claude-3-sonnet-20240229</OptionInput>
+        <OptionInput value="claude-3-5-sonnet-20240620">claude-3-5-sonnet-20240620</OptionInput>
         <OptionInput value="custom">Custom</OptionInput>
     </SelectInput>
     {#if $DataBase.proxyRequestModel === 'custom'}

--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -1818,10 +1818,15 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
                       "anthropic.claude-v2:1",
                       "anthropic.claude-3-haiku-20240307-v1:0",
                       "anthropic.claude-3-sonnet-20240229-v1:0",
+                      "anthropic.claude-3-5-sonnet-20240620-v1:0",
                       "anthropic.claude-3-opus-20240229-v1:0"
                     ];
                     
-                    const awsModel = raiModel.includes("opus") ? modelIDs[4] : raiModel.includes("sonnet") ? modelIDs[3] : modelIDs[2];
+                    const awsModel = 
+                        raiModel.includes("3-opus") ? modelIDs[5] :
+                        raiModel.includes("3-5-sonnet") ? modelIDs[4] :
+                        raiModel.includes("3-sonnet") ? modelIDs[3] : 
+                        modelIDs[2];
                     const url = `https://${host}/model/${awsModel}/invoke${stream ? "-with-response-stream" : ""}`
 
                     const params = {


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
aws += sonnet-3-5
custom += sonnet-3-5, gpt-4-turbo