### PR TITLE
Fix: now simpleLLM requires low level access

### DIFF
--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -766,6 +766,9 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
                         })
 
                         luaEngine.global.set('simpleLLM', async (id:string, prompt:string) => {
+                            if(!LuaLowLevelIds.has(id)){
+                                return
+                            }
                             const result = await requestChatData({
                                 formated: [{
                                     role: 'user',


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
