### PR TITLE
Fix build errors in Node version by updating scripts to use pnpm instead of npm

### DIFF
--- a/server.bat
+++ b/server.bat
@@ -1,3 +1,3 @@
-call npm install
-call npm run build
-call npm run runserver
+call pnpm install
+call pnpm run build
+call pnpm run runserver

--- a/server.sh
+++ b/server.sh
@@ -1,3 +1,3 @@
-npm install
-npm run build
-npm run runserver
+pnpm install
+pnpm run build
+pnpm run runserver


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
When running `npm install` followed by `npm run build` in the Node version, the build process fails with multiple errors indicating that various Svelte components and stores are not defined.

- Updated `server.bat` to use `pnpm install`, `pnpm run build`, and `pnpm run runserver`.
- Updated `server.sh` to use `pnpm install`, `pnpm run build`, and `pnpm run runserver`.

---

The errors encountered when using `npm install` in the Node version include:
- 'loadedStore' is not defined
- 'WelcomeRisu' is not defined
- 'settingsOpen' is not defined
- 'Settings' is not defined
- 'GridChars' is not defined
- 'DynamicGUI' is not defined
- 'Sidebar' is not defined
- 'sideBarStore' is not defined
- 'ChatScreen' is not defined
- 'alertStore' is not defined
- 'AlertComp' is not defined
- 'showRealmInfoStore' is not defined
- 'RealmPopUp' is not defined
- 'ShowRealmFrameStore' is not defined
- 'RealmFrame' is not defined

These errors are resolved by using `pnpm install` as the package manager.

