### PR TITLE
Add time property to getFullChat

### DIFF
--- a/src/ts/process/lua.ts
+++ b/src/ts/process/lua.ts
@@ -148,7 +148,8 @@ export async function runLua(code:string, arg:{
             const data = JSON.stringify(chat.message.map((v) => {
                 return {
                     role: v.role,
-                    data: v.data
+                    data: v.data,
+                    time: v.time
                 }
             }))
             return data


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
I believe this change is the easiest path to calculating time idle duration inside the lua engine. I have decided to leave the handling of null or undefined time values open for now, as the appropriate default behavior requires further discussion and alignment with the project's overall handling of similar cases. I look forward to feedback and suggestions on this implementation.