### PR TITLE
Fix lua lowlevel access key not added

### DIFF
--- a/src/ts/process/lua.ts
+++ b/src/ts/process/lua.ts
@@ -389,7 +389,7 @@ export async function runLua(code:string, arg:{
     else{
         LuaSafeIds.add(accessKey)
         if(lowLevelAccess){
-            LuaLowLevelIds.add(v4())
+            LuaLowLevelIds.add(accessKey)
         }
     }
     let res:any


### PR DESCRIPTION
Seems like a coding mistake here. Even if low level access is turned on, another random access key was added making low level access feature not working.