### PR TITLE
fix: chat sync issue in lua engine

### DIFF
--- a/src/ts/process/lua.ts
+++ b/src/ts/process/lua.ts
@@ -104,6 +104,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 const message = chat.message?.at(index)
                 if(message){
                     message.data = value
@@ -114,6 +115,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 const message = chat.message?.at(index)
                 if(message){
                     message.role = value === 'user' ? 'user' : 'char'
@@ -124,6 +126,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 chat.message = chat.message.slice(start,end)
                 CurrentChat.set(chat)
             })
@@ -131,6 +134,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 chat.message.splice(index, 1)
                 CurrentChat.set(chat)
             })
@@ -138,6 +142,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 let roleData:'user'|'char' = role === 'user' ? 'user' : 'char'
                 chat.message.push({role: roleData, data: value})
                 CurrentChat.set(chat)
@@ -146,6 +151,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 let roleData:'user'|'char' = role === 'user' ? 'user' : 'char'
                 chat.message.splice(index, 0, {role: roleData, data: value})
                 CurrentChat.set(chat)
@@ -154,6 +160,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 chat.message.splice(index, 1)
                 CurrentChat.set(chat)
             })
@@ -161,9 +168,11 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 return chat.message.length
             })
             luaEngine.global.set('getFullChatMain', (id:string) => {
+                chat = get(CurrentChat)
                 const data = JSON.stringify(chat.message.map((v) => {
                     return {
                         role: v.role,
@@ -178,6 +187,7 @@ export async function runLua(code:string, arg:{
                 if(!LuaSafeIds.has(id)){
                     return
                 }
+                chat = get(CurrentChat)
                 chat.message = realValue.map((v) => {
                     return {
                         role: v.role,

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -517,7 +517,7 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
                     if(triggerCodeResult.stopSending){
                         stopSending = true
                     }
-                    chat = triggerCodeResult.chat
+                    chat = get(CurrentChat)
                     break
                 }
             }


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
This pull request resolves the issue where the chat object used in the Lua engine was fixed at the time of initialization. This also addresses issue #563.