### PR TITLE
chore: Specify pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "packageManager": "pnpm@9.10.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## PR Checklist

- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it doesn't, did you blocked it in those versions?

> [!NOTE]
> This checkbox is intentionally left unchecked due to an ongoing issue https://github.com/kwaroran/RisuAI/issues/641. If this issue is related to the pnpm version, this PR should not be merged.

## Description

This PR specifies the exact version of pnpm to be used for this project by adding the `packageManager` field to the `package.json` file.

## Changes

- Specified `"packageManager": "pnpm@9.10.0"` in `package.json`

## Motivation and Context

By explicitly declaring the pnpm version in `package.json`, we ensure consistent package management across different development environments. This addresses compatibility issues between the project's lockfile and pnpm versions, preventing potential problems that could arise from version mismatches.

## Note on Version Selection

The pnpm version 9.10.0 used in this PR is based on my current development environment. This version is flexible and can be adjusted if there's a specific version that should be used for this project. If you're aware of any version constraints or if there's a preferred pnpm version for this project, please let me know, and I'll update the PR accordingly.