### PR TITLE
fix: conditionally initializing getCurrentWebviewWindow

### DIFF
--- a/src/ts/storage/globalApi.ts
+++ b/src/ts/storage/globalApi.ts
@@ -43,7 +43,6 @@ import { encodeCapKeySafe } from "./mobileStorage";
 import { updateLorebooks } from "../characters";
 import { initMobileGesture } from "../hotkey";
 import { fetch as TauriHTTPFetch } from '@tauri-apps/plugin-http';
-const appWindow = getCurrentWebviewWindow()
 
 //@ts-ignore
 export const isTauri = !!window.__TAURI_INTERNALS__
@@ -52,6 +51,8 @@ export const isNodeServer = !!globalThis.__NODE__
 export const forageStorage = new AutoStorage()
 export const googleBuild = false
 export const isMobile = navigator.userAgent.match(/(iPad)|(iPhone)|(iPod)|(android)|(webOS)/i)
+
+const appWindow = isTauri ? getCurrentWebviewWindow() : null
 
 interface fetchLog{
     body:string

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -8,7 +8,7 @@ import { basename } from "@tauri-apps/api/path"
 import { createBlankChar, getCharImage } from "./characters"
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { isTauri } from "./storage/globalApi"
-const appWindow = getCurrentWebviewWindow()
+const appWindow = isTauri ? getCurrentWebviewWindow() : null
 
 export const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1
 


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
This PR is not an ideal solution, but it provides a workaround for the issue where a specific built-in function of Tauri causes freezing in non-Tauri environments like Fixes #641.