### PR TITLE
Fix {{role}} CBS support to custom HTML

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -206,7 +206,7 @@
     function RenderGUIHtml(html:string){
         try {
             const parser = new DOMParser()
-            const doc = parser.parseFromString(risuChatParser(html ?? ''), 'text/html')
+            const doc = parser.parseFromString(risuChatParser(html ?? '', {cbsConditions: getCbsCondition()}), 'text/html')
             console.log(doc.body)
             return doc.body   
         } catch (error) {


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [v] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [v] Did you added a type def?

# Description
This pull request adds `{{role}}` support to the recently introduced Custom HTML feature. Although documentation indicated that CBS was supported in Custom HTML, the `{{role}}` CBS was returning `null` instead of rendering the intended values.

## Changes
By passing `getCbsCondition()` as the second argument to `risuChatParser`, `{{role}}` now renders as expected in Custom HTML, allowing users to apply conditional logic based on roles.

If there is an alternative way to enable `{{role}}` support in Custom HTML without this modification, feel free to close this PR. Thanks for checking it out!
