### PR TITLE
Fix AWS Claude Support

### DIFF
--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -2059,12 +2059,12 @@ export async function requestChatDataMain(arg:requestDataArgument, model:'model'
                       "anthropic.claude-3-5-sonnet-20241022-v2:0"
                     ];
                     
-                    const awsModel = 
+                    const awsModel = "us." + (
                         raiModel.includes("3-5-sonnet-20241022") ? modelIDs[6] :
                         raiModel.includes("3-5-sonnet-20240620") ? modelIDs[5] :
                         raiModel.includes("3-opus") ? modelIDs[4] :
                         raiModel.includes("3-sonnet") ? modelIDs[3] : 
-                        modelIDs[2];
+                        modelIDs[2]);
                     const url = `https://${host}/model/${awsModel}/invoke${stream ? "-with-response-stream" : ""}`
 
                     const params = {


### PR DESCRIPTION
# PR Checklist
- [No] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
This only takes effect on AWS Claude models
- [Yes] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [No] Did you added a type def?

# Description
AWS Claude model calling no longer supports direct calling, but supports Cross-region inference instead. All Cross-region inference model profile IDs equal to original model name with "us." in the beginning. Reference: https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/inference-profiles