### PR TITLE
Add text node rendering to custom HTML

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -507,8 +507,12 @@
 {/snippet}
 
 {#snippet renderChilds(dom:HTMLElement)}
-    {#each dom.children as node}
-        {@render renderGuiHtmlPart((node as HTMLElement))}
+    {#each dom.childNodes as node}
+        {#if node.nodeType === Node.TEXT_NODE}
+            {node.textContent}
+        {:else if node.nodeType === Node.ELEMENT_NODE}
+            {@render renderGuiHtmlPart((node as HTMLElement))}
+        {/if}
     {/each}
 {/snippet}
 


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
## Summary

This PR updates the `renderChilds` function to properly handle `TextNode` rendering. Previously, `renderChilds` only iterated over `children`, which excluded `TextNode`s and rendered only `HTMLElement`s. Now, the function iterates over `childNodes`, ensuring that:

1. **TextNodes**: Are rendered by displaying their `textContent`.
2. **ElementNodes**: Are rendered as before, using `renderGuiHtmlPart`.


## Context

Initially, I wondered whether the absence of `TextNode` rendering might have been due to security considerations. However, since elements like headings (`h1`), lists (`ul`, `li`), and strong text (`strong`) were already being rendered, it seems likely that the exclusion of `TextNode` rendering was an oversight rather than an intentional decision.

I believe that these elements are meaningful only when they include text. For example, elements like `h1`, `h2`, `h3`, `p`, `li`, `strong`, `em`, and `code` rely on text content to fulfill their intended purpose.


## Notes

If there was a specific reason for excluding `TextNode`s in the original implementation (e.g., for security, intentional design choices, or other constraints), please feel free to reject this PR. I completely understand if this change conflicts with any design decisions or requirements of the project.

Thank you for your time and consideration!

