### PR TITLE
Fix macOS Asset Visibility Issue in Local Version of RisuAI

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -74,6 +74,11 @@ DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
     }
 })
 
+DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+    if (['IMG', 'SOURCE', 'STYLE'].includes(node.nodeName) && data.attrName === 'src' && data.attrValue.startsWith('asset://localhost/')) {
+        data.forceKeepAttr = true;
+    }
+});
 
 function renderMarkdown(md:markdownit, data:string){
     let quotes = ['“', '”', '‘', '’']


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
## Problem
This PR resolves an issue where assets were not visible on macOS when using `asset://localhost/` URLs.

The problem occurred because **DOMPurify** was removing the `src` attribute when its value started with `asset://localhost/`. This behavior affected the visibility of assets on macOS for the Local version of RisuAI.


## Solution
To address this, I chose to use `DOMPurify.addHook` to allow `src` attributes starting with `asset://localhost/` for certain tags.

I also thought about another solution: passing `ALLOWED_URI_REGEXP` to `DOMPurify.sanitize`. However, I decided not to use it because it would require using regular expressions to check strings every time the method is called, which might be less efficient in my opinion.


## Considerations
While this issue is specific to macOS and the Local version of RisuAI, I opted not to include additional conditions for the following reasons:
1. The code change is simple and lightweight.
2. It doesn’t cause conflicts on other OSes or RisuAI versions.
3. Avoiding conditions improves readability and maintainability.

---

If you have any suggestions for a better approach, I’d be happy to hear them!

---

## Linked Issue
This PR addresses and fixes #656 

