### PR TITLE
Fix missing aws key slot

### DIFF
--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -114,7 +114,8 @@
         <span class="text-textcolor">Mancer {language.apiKey}</span>
         <TextInput hideText={DBState.db.hideApiKey} marginBottom={true} size={"sm"} placeholder="..." bind:value={DBState.db.mancerHeader}/>
     {/if}
-    {#if modelInfo.provider === LLMProvider.Anthropic || subModelInfo.provider === LLMProvider.Anthropic}
+    {#if modelInfo.provider === LLMProvider.Anthropic || subModelInfo.provider === LLMProvider.Anthropic
+            || modelInfo.provider === LLMProvider.AWS || subModelInfo.provider === LLMProvider.AWS }
         <span class="text-textcolor">Claude {language.apiKey}</span>
         <TextInput hideText={DBState.db.hideApiKey} marginBottom={true} size={"sm"} placeholder="..." bind:value={DBState.db.claudeAPIKey}/>
     {/if}


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
![image](https://github.com/user-attachments/assets/3d9414d8-d0df-4b3a-afb8-faaab36e94ee)

Current build doesn't have aws key slot.
Thank for your time.