### PR TITLE
Add autoTranslateCachedOnly option for LLM-based Translation

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -170,6 +170,7 @@ export const languageEnglish = {
         summarizationPrompt: "The prompt that is used for summarization. if it is blank, it will use the default prompt. you can also use ChatML formating with {{slot}} for the chat data.",
         translatorPrompt: "The prompt that is used for translation. if it is blank, it will use the default prompt. you can also use ChatML formating with {{slot}} for the dest language, {{solt::content}} for the content, and {{slot::tnote}} for the translator note.",
         translateBeforeHTMLFormatting: "If enabled, it will translate the text before Regex scripts and HTML formatting. this could make the token lesser but could break the formatting.",
+        autoTranslateCachedOnly: "If enabled, it will automatically translate only the text that the user has translated previously.",
     },
     setup: {
         chooseProvider: "Choose AI Provider",
@@ -811,4 +812,5 @@ export const languageEnglish = {
     translateBeforeHTMLFormatting: "Translate Before HTML Formatting",
     retranslate: "Retranslate",
     loading: "Loading",
+    autoTranslateCachedOnly: "Auto Translate Cached Only",
 }

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -7,7 +7,7 @@
     import { type MessageGenerationInfo } from "../../ts/storage/database.svelte";
     import { alertStore, DBState } from 'src/ts/stores.svelte';
     import { HideIconStore, ReloadGUIPointer, selIdState } from "../../ts/stores.svelte";
-    import { translateHTML } from "../../ts/translator/translator";
+    import { translateHTML, getLLMCache } from "../../ts/translator/translator";
     import { risuChatParser } from "src/ts/process/scripts";
     import { type Unsubscriber } from "svelte/store";
     import { get, isEqual, startsWith } from "lodash";
@@ -140,7 +140,15 @@
                 translateText = false
                 try {
                     if(DBState.db.autoTranslate){
-                        translateText = true
+                        if(DBState.db.autoTranslateCachedOnly && DBState.db.translatorType === "llm"){
+                            const cache = await getLLMCache(data)
+                            if(cache !== null){
+                                translateText = true
+                            }
+                        }
+                        else{
+                            translateText = true
+                        }
                     }
 
                     setTimeout(() => {

--- a/src/lib/Setting/Pages/LanguageSettings.svelte
+++ b/src/lib/Setting/Pages/LanguageSettings.svelte
@@ -158,5 +158,11 @@
                 <Help key="translateBeforeHTMLFormatting"/>
             </Check>
         </div>
+
+        <div class="flex items-center mt-4">
+            <Check bind:check={DBState.db.autoTranslateCachedOnly} name={language.autoTranslateCachedOnly}>
+                    <Help key="autoTranslateCachedOnly"/>
+                </Check>
+        </div>        
     {/if}
 {/if}

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -846,6 +846,7 @@ export interface Database{
         otherAx: SeparateParameters
     }
     translateBeforeHTMLFormatting:boolean
+    autoTranslateCachedOnly:boolean
 }
 
 interface SeparateParameters{

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -508,3 +508,7 @@ async function translateLLM(text:string, arg:{to:string, regenerate?:boolean}):P
     await LLMCacheStorage.setItem(text, result)
     return result
 }
+
+export async function getLLMCache(text:string):Promise<string | null>{
+    return await LLMCacheStorage.getItem(text)
+}


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description

![preview](https://github.com/user-attachments/assets/10cbf5f0-ca19-4350-922e-77ecf775fc8e)

Please introduce an autoTranslateCachedOnly option that automatically translates only previously translated text when enabled.


# Why is this feature needed?
- LLM-based translations can be relatively costly, so end users may not want new/specific text to be automatically translated.
- End users may prefer not to manually click the translate button when viewing chat logs that have already been translated.
- By utilizing cached translations more effectively, we can enhance the overall user experience.

