### PR TITLE
Fix cache handling for autoTranslateCachedOnly when translateBeforeHTMLFormatting is disabled

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -140,11 +140,12 @@
                 translateText = false
                 try {
                     if(DBState.db.autoTranslate){
-                        if(DBState.db.autoTranslateCachedOnly && DBState.db.translatorType === "llm"){
-                            const cache = await getLLMCache(data)
-                            if(cache !== null){
-                                translateText = true
-                            }
+                        if(DBState.db.autoTranslateCachedOnly && DBState.db.translatorType === 'llm'){
+                            const cache = DBState.db.translateBeforeHTMLFormatting
+                            ? await getLLMCache(data)
+                            : await getLLMCache(await ParseMarkdown(data, charArg, 'pretranslate', chatID, getCbsCondition()))
+                  
+                            translateText = cache !== null
                         }
                         else{
                             translateText = true


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
This PR introduces a fix for an issue where cache misses occur when translateBeforeHTMLFormatting is disabled. Previously, the 'Auto Translate Cached Only' feature only worked when translateBeforeHTMLFormatting was enabled. This update ensures that cached translations are used properly even when translateBeforeHTMLFormatting is disabled.

Thank you for taking the time. This is not an urgent matter, but I would appreciate it if you could incorporate this PR along with other changes in the next update.

