### PR TITLE
Fix translation issue in input auto-translation field for LLM-based Translation

### DIFF
--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -111,7 +111,7 @@ export async function runTranslator(text:string, reverse:boolean, from:string,ta
 async function translateMain(text:string, arg:{from:string, to:string, host:string}){
     let db = getDatabase()
     if(db.translatorType === 'llm'){
-        const tr = db.translator || 'en'
+        const tr = arg.to || 'en'
         return translateLLM(text, {to: tr})
     }
     if(db.translatorType === 'deepl'){


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
This PR introduces a fix for the issue where the input auto-translation field ("Enter Message for Translate to English" text displayed when nothing is entered) was not correctly translating the original text into English in the LLM-based translation.

Additionally, this update ensures that "Curly Braced Syntaxes {{slot}}" are translated into the user's native language when the translation button is pressed, and into English during the input translation, facilitating more effective translation.