### PR TITLE
Fix issue with autoTranslateCachedOnly option being ignored when sending messages

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -57,7 +57,7 @@
     }: Props = $props();
 
     let msgDisplay = $state('')
-    let translated = $state(DBState.db.autoTranslate)
+    let translated = $state(false)
     let role = $derived(DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx]?.role)
     async function rm(e:MouseEvent, rec?:boolean){
         if(e.shiftKey){


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
There was an issue where the autoTranslateCachedOnly option was being ignored when sending messages. This occurred due to the way the translated variable was initialized with let translated = $state(DBState.db.autoTranslate).