### PR TITLE
Suggestion: disabling regex script

### DIFF
--- a/src/lib/SideBars/Scripts/RegexData.svelte
+++ b/src/lib/SideBars/Scripts/RegexData.svelte
@@ -121,6 +121,7 @@
                 <OptionInput value="editprocess">{language.editProcess}</OptionInput>
                 <OptionInput value="editdisplay">{language.editDisplay}</OptionInput>
                 <OptionInput value="edittrans">{language.editTranslationDisplay}</OptionInput>
+                <OptionInput value="disabled">{language.disabled}</OptionInput>
             </SelectInput>
             <span class="text-textcolor mt-6">IN:</span>
             <TextInput size="sm" bind:value={value.in} />


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description
![image](https://github.com/user-attachments/assets/efcd778e-82d3-4b23-9eba-3b2843709450)

I propose adding a feature to disable regex scripts instead of deleting them. In this PR, I opted for the approach that minimizes edits to the original source code, but I believe it’s worth considering alternatives, such as using a custom flag or a separate toggle. I’d like to gather your feedback on this approach and make further adjustments if necessary.