### PR TITLE
Fix thoughts extraction regex for multiline content handling

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -755,7 +755,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             }
         }
         let thoughts:string[] = []
-        formatedChat = formatedChat.replace(/<Thoughts>(.+?)<\/Thoughts>/gm, (match, p1) => {
+        formatedChat = formatedChat.replace(/<Thoughts>([\s\S]+?)<\/Thoughts>/g, (match, p1) => {
             thoughts.push(p1)
             return ''
         })


### PR DESCRIPTION
# PR Checklist
- [x] Did you check if it works normally in all models? *ignore this when it dosen't uses models*
- [x] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
- [ ] Did you added a type def?

# Description

This PR updates the regex used for extracting <Thoughts> content to handle multiline cases reliably. The previous regex (.+?) had limitations when processing text spanning multiple lines, as it could not match content with line breaks.