### PR TITLE
fix: add missing definitions of plugin APIs

### DIFF
--- a/src/ts/plugins/plugins.ts
+++ b/src/ts/plugins/plugins.ts
@@ -245,6 +245,8 @@ export async function loadV2Plugin(plugins:RisuPlugin[]){
             const setChar = globalThis.__pluginApis__.setChar
             const addProvider = globalThis.__pluginApis__.addProvider
             const addRisuEventHandler = globalThis.__pluginApis__.addRisuEventHandler
+            const addRisuReplacer = globalThis.__pluginApis__.addRisuReplacer
+            const removeRisuReplacer = globalThis.__pluginApis__.removeRisuReplacer
             const onUnload = globalThis.__pluginApis__.onUnload
 
             ${data}


### PR DESCRIPTION
# PR Checklist
- [ ] Did you check if it works normally in all models? *ignore this when it doesn't use models*
  - It doesn't use models.
- [ ] Did you check if it works normally in all of web, local and node hosted versions? if it dosen't, did you blocked it in those versions?
  - Only checked on the browser
- [ ] Did you add a type def?
  - It does nothing with types
# Description
In plugins.ts methods `addRisuReplacer` and `removeRisuReplacer` are implemented but not defined (exported).
I thought that the definitions were simply missing. So I added only two lines.