### PR TITLE
fix: add missing api definition

### DIFF
--- a/src/ts/plugins/plugins.ts
+++ b/src/ts/plugins/plugins.ts
@@ -244,7 +244,8 @@ export async function loadV2Plugin(plugins:RisuPlugin[]){
             const getChar = globalThis.__pluginApis__.getChar
             const setChar = globalThis.__pluginApis__.setChar
             const addProvider = globalThis.__pluginApis__.addProvider
-            const addRisuEventHandler = globalThis.__pluginApis__.addRisuEventHandler
+            const addRisuScriptHandler = globalThis.__pluginApis__.addRisuScriptHandler
+            const removeRisuScriptHandler = globalThis.__pluginApis__.removeRisuScriptHandler
             const addRisuReplacer = globalThis.__pluginApis__.addRisuReplacer
             const removeRisuReplacer = globalThis.__pluginApis__.removeRisuReplacer
             const onUnload = globalThis.__pluginApis__.onUnload


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
In plugins.ts methods `addRisuScriptHandler` and `removeRisuScriptHandler` are implemented but not defined (exported).
Thanks for your time.