### PR TITLE
Fixed example code error in plugin docs

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -118,7 +118,7 @@ Adds a risu script handler to the plugin.
 - `type: string` - The handler type. one of `display`, `output`, `input`, `process`
     - `display` - The handler will be called when the data is displayed.
     - `output` - The handler will be called when the data is outputted by the AI model.
-    - `input` - The handler will be called when the data is inputted to the user.
+    - `input` - The handler will be called when the data is inputted by the user.
     - `process` - The handler will be called when creating actual request data.
 - `func: (content:string) => string|null|undefined|Promise<string|null|undefined>` - The handler function.
     - `content: string` - The content to handle.

--- a/plugins.md
+++ b/plugins.md
@@ -9,7 +9,7 @@ A plugin is a js file with a header. for example:
 
 ```js
 //@name exampleplugin
-//display-name: Example Plugin
+//@display-name Example Plugin
 
 // Plugin code here
 ```


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

It's just a docs change.

# Description
Fixed example code in the plugin docs to match with Plugin Syntax.