### PR TITLE
Fix TTS TypeError issue when using gptsovits TTS by adding missing break statement

### DIFF
--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -309,6 +309,7 @@ export async function sayTTS(character:character,text:string) {
                     const text = Buffer.from(textBuffer).toString('utf-8')
                     throw new Error(text);
                 }
+                break;
             }
             case 'fishspeech':{
                 if (character.fishSpeechConfig.model._id === ''){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This pull request resolves a `TypeError` that occurred specifically when executing TTS with the `gptsovits` model.

In Edge browsers, this manifested as:

`TTS Error: TypeError: Cannot read properties of undefined (reading 'model')`

While the TTS functionality itself was working, a missing `break` statement in the `gptsovits` case of the `sayTTS` function caused this error during runtime. This PR adds the necessary `break` statement to prevent this `TypeError`.