### PR TITLE
fix: resolve state_unsafe_mutation in getChatVar()

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -2172,7 +2172,7 @@ export function getChatVar(key:string){
         return 'null'
     }
     const chat = char.chats[char.chatPage]
-    chat.scriptstate = chat.scriptstate ?? {}
+    chat.scriptstate ??= {}
     const state = (chat.scriptstate['$' + key])
     if(state === undefined || state === null){
         const defaultVariables = parseKeyValue(char.defaultVariables).concat(parseKeyValue(DBState.db.templateDefaultVariables))


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
While investigating an issue where variable calls were not possible in background embedding, I encountered a state_unsafe_mutation error. It appears that modifying the null check operator on the relevant line can resolve this issue. Thank for your time.