### PR TITLE
fix: add missing check for regex order flag

### DIFF
--- a/src/ts/process/scripts.ts
+++ b/src/ts/process/scripts.ts
@@ -277,6 +277,7 @@ export async function processScriptFull(char:character|groupChat|simpleCharacter
                 for(const m of meta){
                     if(m.startsWith('order ')){
                         order = parseInt(m.substring(6))
+                        orderChanged = true
                     }
                     else{
                         actions.push(m)


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
In the current build, it seems that the order flag in the regex script is not functioning as intended. This PR is expected to fix the issue and ensure it works as originally intended.