### PR TITLE
Improve prompt comparison functionality with usability enhancements

### DIFF
--- a/src/lib/Setting/botpreset.svelte
+++ b/src/lib/Setting/botpreset.svelte
@@ -111,7 +111,7 @@
         return prompt
     }
 
-    async function checkDiff(prompt1: string, prompt2: string): Promise<string> {
+    async function checkDiff(prompt1: string, prompt2: string): Promise<void> {
         const { diffLines } = await import('diff')
         const lineDiffs = diffLines(prompt1, prompt2)
 
@@ -139,13 +139,17 @@
         }
 
         if(lineDiffs.length === 1 && !lineDiffs[0].added && !lineDiffs[0].removed) {
-            resultHtml = `<div style="background-color: #4caf50; color: white; padding: 10px 20px; border-radius: 5px; text-align: center;">No differences detected.</div>` + resultHtml
+            const userResponse = await alertConfirm('The two prompts are identical. Would you like to review the content?')
+
+            if(userResponse){
+                resultHtml = `<div style="background-color: #4caf50; color: white; padding: 10px 20px; border-radius: 5px; text-align: center;">No differences detected.</div>` + resultHtml
+                alertMd(resultHtml)
+            }
         }
         else{
             resultHtml = `<div style="background-color: #ff9800; color: white; padding: 10px 20px; border-radius: 5px; text-align: center;">Differences detected. Please review the changes.</div>` + resultHtml
+            alertMd(resultHtml)
         }
-
-        return resultHtml
     }
 
     async function highlightChanges(string1: string, string2: string) {
@@ -194,8 +198,8 @@
         }
         else{
             alertWait("Loading...")
-            const result = await checkDiff(selectedPrompts[0], prompt)
-            alertMd(result)
+            await checkDiff(selectedPrompts[0], prompt)
+
             selectedDiffPreset = -1
             selectedPrompts = []
         }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
This PR introduces a couple of usability improvements to the prompt comparison functionality.

1. If the two prompts are identical

Instead of showing the content right away, an alert is displayed saying the two prompts are the same. Only when the user clicks "Yes" the content will be shown. This avoids unnecessary confirmation of identical prompts.

<img width="519" alt="a" src="https://github.com/user-attachments/assets/bf48420e-bf69-4c8a-b700-754e1c38b6a6" />


2. If the two prompts are different

A summary of the number of modified, added, and removed lines is displayed.

<img width="598" alt="b" src="https://github.com/user-attachments/assets/c3269ee8-25e7-4ba9-957d-4e377d523795" />

When hovering over the summary, a quick overview of the changes appears. When only a single word or character is modified, it was previously hard to identify the line that was changed. Now, the overview improves clarity, making it easier to understand the changes.

<img width="595" alt="e" src="https://github.com/user-attachments/assets/1b55a3bc-70d2-43fa-ab4c-754e6fd4a85d" />

On mobile devices (tested on iOS 16.7), tapping on the 'Differences detected. Please review the changes.' section will display the changes.

---

As a future improvement, it might be useful to display line numbers or allow users to click and navigate to the specific parts of the differences.

I hope these changes make it easier to use, but feel free to reject this PR if you find it unnecessary or if the code feels too messy. I completely understand and appreciate your feedback.

Thank you for your time!
