### PR TITLE
feat: apply positionParser to alternate global note

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -551,7 +551,10 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     let content = positionParser(card.text)
 
                     if(card.type2 === 'globalNote'){
-                        content = (risuChatParser(currentChar.replaceGlobalNote?.replaceAll('{{original}}', content) || content, {chara: currentChar, role: card.role}))
+                        if(currentChar.replaceGlobalNote){
+                            content = positionParser(currentChar.replaceGlobalNote).replaceAll('{{original}}', content)
+                        }
+                        content = (risuChatParser(content, {chara: currentChar, role: card.role}))
                     }
                     else if(card.type2 === 'main'){
                         content = (risuChatParser(content, {chara: currentChar, role: card.role}))
@@ -1050,7 +1053,10 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     let content = positionParser(card.text)
 
                     if(card.type2 === 'globalNote'){
-                        content = (risuChatParser(currentChar.replaceGlobalNote?.replaceAll('{{original}}', content) || content, {chara:currentChar, role: card.role}))
+                        if(currentChar.replaceGlobalNote){
+                            content = positionParser(currentChar.replaceGlobalNote).replaceAll('{{original}}', content)
+                        }
+                        content = (risuChatParser(content, {chara: currentChar, role: card.role}))
                     }
                     else if(card.type2 === 'main'){
                         content = (risuChatParser(content, {chara: currentChar, role: card.role}))


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR ensures that the 'position' lorebook decorator is correctly applied to alternate (replaced) GlobalNotes.
Thank you for your time and consideration.