### PR TITLE
suggestion: apply 'processScriptFull()' to 'editprocess' mode regex script

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -669,9 +669,9 @@ export async function sendChat(chatProcessIndex = -1,arg:{
 
     let index = 0
     for(const msg of ms){
-        let formatedChat = await processScript(nowChatroom,risuChatParser(msg.data, {chara: currentChar, role: msg.role}), 'editprocess', {
+        let formatedChat = (await processScriptFull(nowChatroom,risuChatParser(msg.data, {chara: currentChar, role: msg.role}), 'editprocess', index, {
             chatRole: msg.role,
-        })
+        })).data
         let name = ''
         if(msg.role === 'char'){
             if(msg.saying){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR addresses an issue where the `{{chat_index}}` cbs does not work correctly in regex scripts of the 'Modify Request Data' (editprocess) type. To work around this issue, I propose changing the function used in this section to `processScriptFull()`.

If you have any other suggestions, such as modifying the arguments instead, please feel free to let me know.

Thanks for your time and consideration.