### PR TITLE
fix: disable module before remove

### DIFF
--- a/src/lib/Setting/Pages/Module/ModuleSettings.svelte
+++ b/src/lib/Setting/Pages/Module/ModuleSettings.svelte
@@ -82,6 +82,10 @@
                             e.stopPropagation()
                             const d = await alertConfirm(`${language.removeConfirm}` + rmodule.name)
                             if(d){
+                                if(DBState.db.enabledModules.includes(rmodule.id)){
+                                    DBState.db.enabledModules.splice(DBState.db.enabledModules.indexOf(rmodule.id), 1)
+                                    DBState.db.enabledModules = DBState.db.enabledModules
+                                }
                                 const index = DBState.db.modules.findIndex((v) => v.id === rmodule.id)
                                 DBState.db.modules.splice(index, 1)
                                 DBState.db.modules = DBState.db.modules


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR fixes an issue where a removed module remains active until the app is restarted if it was enabled at the time of deletion.