### PR TITLE
Fix: Replace /sw/check to /sw/img in service worker checkCache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -87,8 +87,19 @@ self.addEventListener('fetch', (event) => {
 async function checkCache(url){
     const cache = await caches.open('risuCache')
 
+    const origURL = url.pathname;
+
+    if(url.pathname.startsWith("/sw/check")) {
+        url.pathname = "/sw/img" + url.pathname.slice(9);
+        return new Response(JSON.stringify({
+            "able": !!(await cache.match(url)),
+            "origURL": origURL,
+        }))
+    }
+
     return new Response(JSON.stringify({
-        "able": !!(await cache.match(url))
+        "able": !!(await cache.match(url)),
+        "origURL": origURL,
     }))
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -87,19 +87,15 @@ self.addEventListener('fetch', (event) => {
 async function checkCache(url){
     const cache = await caches.open('risuCache')
 
-    const origURL = url.pathname;
-
     if(url.pathname.startsWith("/sw/check")) {
         url.pathname = "/sw/img" + url.pathname.slice(9);
         return new Response(JSON.stringify({
-            "able": !!(await cache.match(url)),
-            "origURL": origURL,
+            "able": !!(await cache.match(url))
         }))
     }
 
     return new Response(JSON.stringify({
-        "able": !!(await cache.match(url)),
-        "origURL": origURL,
+        "able": !!(await cache.match(url))
     }))
 }
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Currently, a specific endpoint that calls /sw/check in the service worker checks whether '/sw/check' is cached.
Since the service worker does not have any logic to cache /sw/check itself, the service worker will always respond that there is no cached data.
This forces all data to be re-registered when getFileSrc is called from globalApi.svelte.ts, and bots with a lot of assets will re-register all data, which slows down bot changes.
Since I am not familiar with the internal structure of RisuAI, I have temporarily modified the code to check /sw/img when the service worker checks /sw/check.