### PR TITLE
fix: stringify object in HypaProcesser to display actual error content instead of [object Object]

### DIFF
--- a/src/ts/process/memory/hypamemory.ts
+++ b/src/ts/process/memory/hypamemory.ts
@@ -106,7 +106,7 @@ export class HypaProcesser{
     
     
         if(!gf.ok){
-            throw gf.data
+            throw JSON.stringify(gf.data)
         }
     
         const result:number[][] = []


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
![1](https://github.com/user-attachments/assets/04012607-375c-4128-abf0-50ef6daae3b6)

The error messages were not properly displayed, showing [object Object] instead of the actual content.
<br>

![2](https://github.com/user-attachments/assets/5ff217ab-cb50-41e1-b2eb-a9ba8eeef094)

This PR improves error handling to display actual error content.