### PR TITLE
feat: add global toggle buttons for lorebook always-active state

### DIFF
--- a/src/lib/SideBars/LoreBook/LoreBookSetting.svelte
+++ b/src/lib/SideBars/LoreBook/LoreBookSetting.svelte
@@ -141,7 +141,7 @@
         {:else}
             <LinkIcon />
         {/if}
-        <span class="text-xs">Char</span>
+        <span class="text-xs">CHAR</span>
     </button>
     <button onclick={() => {
         toggleChatLoreAlwaysActive()
@@ -151,7 +151,7 @@
         {:else}
             <LinkIcon />
         {/if}
-        <span class="text-xs">Chat</span>
+        <span class="text-xs">CHAT</span>
     </button>
 </div>
 {/if}

--- a/src/lib/SideBars/LoreBook/LoreBookSetting.svelte
+++ b/src/lib/SideBars/LoreBook/LoreBookSetting.svelte
@@ -2,13 +2,13 @@
     
     import { DBState } from 'src/ts/stores.svelte';
     import { language } from "../../../lang";
-    import { DownloadIcon, FolderUpIcon, ImportIcon, PlusIcon } from "lucide-svelte";
+    import { DownloadIcon, FolderUpIcon, ImportIcon, PlusIcon, SunIcon, LinkIcon } from "lucide-svelte";
     import { addLorebook, exportLoreBook, importLoreBook } from "../../../ts/process/lorebook.svelte";
     import Check from "../../UI/GUI/CheckInput.svelte";
     import NumberInput from "../../UI/GUI/NumberInput.svelte";
     import LoreBookList from "./LoreBookList.svelte";
     import Help from "src/lib/Others/Help.svelte";
-  import { selectedCharID } from "src/ts/stores.svelte";
+    import { selectedCharID } from "src/ts/stores.svelte";
 
     let submenu = $state(0)
     interface Props {
@@ -16,6 +16,40 @@
     }
 
     let { globalMode = $bindable(false) }: Props = $props();
+
+    function isAllCharacterLoreAlwaysActive() {
+        const globalLore = DBState.db.characters[$selectedCharID].globalLore;
+        return globalLore && globalLore.every((book) => book.alwaysActive);
+    }
+
+    function isAllChatLoreAlwaysActive() {
+        const localLore = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].localLore;
+        return localLore && localLore.every((book) => book.alwaysActive);
+    }
+
+    function toggleCharacterLoreAlwaysActive() {
+        const globalLore = DBState.db.characters[$selectedCharID].globalLore;
+
+        if (!globalLore) return;
+        
+        const allActive = globalLore.every((book) => book.alwaysActive);
+        
+        globalLore.forEach((book) => {
+            book.alwaysActive = !allActive;
+        });
+    }
+
+    function toggleChatLoreAlwaysActive() {
+        const localLore = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].localLore;
+
+        if (!localLore) return;
+
+        const allActive = localLore.every((book) => book.alwaysActive);
+
+        localLore.forEach((book) => {
+            book.alwaysActive = !allActive;
+        });
+    }
 </script>
 
 {#if !globalMode}
@@ -98,6 +132,26 @@
         importLoreBook(globalMode ? 'sglobal' : submenu === 0 ? 'global' : 'local')
     }} class="hover:text-textcolor ml-2  cursor-pointer">
         <FolderUpIcon />
+    </button>
+    <button onclick={() => {
+        toggleCharacterLoreAlwaysActive()
+    }} class="hover:text-textcolor ml-2 cursor-pointer flex items-center gap-1">
+        {#if isAllCharacterLoreAlwaysActive()}
+            <SunIcon />
+        {:else}
+            <LinkIcon />
+        {/if}
+        <span class="text-xs">Char</span>
+    </button>
+    <button onclick={() => {
+        toggleChatLoreAlwaysActive()
+    }} class="hover:text-textcolor ml-2 cursor-pointer flex items-center gap-1">
+        {#if isAllChatLoreAlwaysActive()}
+            <SunIcon />
+        {:else}
+            <LinkIcon />
+        {/if}
+        <span class="text-xs">Chat</span>
     </button>
 </div>
 {/if}


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Preview
![off](https://github.com/user-attachments/assets/0b062220-a101-4c77-ac58-9e87d7e8985c)

![on](https://github.com/user-attachments/assets/1441ad33-6608-4df4-8d8d-4de9c927d180)

# Description
This PR introduces following:
- Add buttons to toggle all character/chat lorebooks' always-active state at once
- Show SunIcon when all lorebooks are active, LinkIcon otherwise
