### PR TITLE
feat: add option to show translation loading and optimize auto translation

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -888,4 +888,5 @@ export const languageEnglish = {
         nextSummarizationLoadingError: "Error loading next summarization target: {0}",
         emptySelectedFirstMessageLabel: "WARN: Selected first message is empty",
     },
+    showTranslationLoading: "Show Translation Loading",
 }

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -815,4 +815,5 @@ export const languageKorean = {
         "nextSummarizationLoadingError": "다음 요약 대상을 불러오는 동안 오류 발생: {0}",
         "emptySelectedFirstMessageLabel": "경고: 선택된 첫 메시지가 비어있습니다"
     },
+    "showTranslationLoading": "번역 로딩 보이기",
 }

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -154,14 +154,26 @@
                         }
                     }
 
+                    const lastTranslated = translated
+
                     setTimeout(() => {
                             translated = translateText
                     }, 10)
+
+                    // State change of `translated` triggers markParsing again,
+                    // causing redundant translation attempts
+                    if (lastTranslated !== translateText) {
+                        return;
+                    }
                 } catch (error) {
                     console.error(error)
                 }
             }
             if(translateText){
+                if (!retranslate && DBState.db.showTranslationLoading) {
+                    lastParsed = `<div class="flex justify-center items-center"><div class="animate-spin rounded-full h-8 w-8 border-b-2 border-textcolor"></div></div>`
+                }
+
                 let doRetranslate = retranslate
                 retranslate = false
                 if(DBState.db.translatorType === 'llm' && DBState.db.translateBeforeHTMLFormatting){

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -28,7 +28,6 @@
     import { getInlayAsset } from 'src/ts/process/files/inlays';
     import PlaygroundMenu from '../Playground/PlaygroundMenu.svelte';
     import { ConnectionOpenStore } from 'src/ts/sync/multiuser';
-  import { preventDefault } from 'svelte/legacy';
 
     let messageInput:string = $state('')
     let messageInputTranslate:string = $state('')

--- a/src/lib/Setting/Pages/AccessibilitySettings.svelte
+++ b/src/lib/Setting/Pages/AccessibilitySettings.svelte
@@ -55,3 +55,7 @@
 <div class="flex items-center mt-2">
     <Check bind:check={DBState.db.inlayErrorResponse} name={language.inlayErrorResponse}/>
 </div>
+
+<div class="flex items-center mt-2">
+    <Check bind:check={DBState.db.showTranslationLoading} name={language.showTranslationLoading}/>
+</div>

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -900,6 +900,7 @@ export interface Database{
     OaiCompAPIKeys: {[key:string]:string}
     inlayErrorResponse:boolean
     reasoningEffort:number
+    showTranslationLoading: boolean
 }
 
 interface SeparateParameters{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Preview
![preview](https://github.com/user-attachments/assets/e1c206d0-2ba0-432e-97ad-07b77ef43821)

# Description
This PR introduces following:
- New accessibility option for translation loading
- Prevent redundant translation attempts when auto translating