### PR TITLE
fix: issue with asset names case-insensitive

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -303,11 +303,11 @@ async function replaceAsync(string, regexp, replacerFunction) {
 }
 
 async function getAssetSrc(assetArr: string[][], name: string, assetPaths: {[key: string]:{path: string, ext?: string}}) {
-    name = name.toLocaleLowerCase()
+    const lowerName = name.toLocaleLowerCase()
     for (const asset of assetArr) {
-        if (trimmer(asset[0].toLocaleLowerCase()) !== trimmer(name)) continue
+        if (trimmer(asset[0].toLocaleLowerCase()) !== trimmer(lowerName)) continue
         const assetPath = await getFileSrc(asset[1])
-        assetPaths[asset[0].toLocaleLowerCase()] = {
+        assetPaths[name] = {
             path: assetPath,
             ext: asset[2]
         }

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -303,11 +303,10 @@ async function replaceAsync(string, regexp, replacerFunction) {
 }
 
 async function getAssetSrc(assetArr: string[][], name: string, assetPaths: {[key: string]:{path: string, ext?: string}}) {
-    const lowerName = name.toLocaleLowerCase()
     for (const asset of assetArr) {
-        if (trimmer(asset[0].toLocaleLowerCase()) !== trimmer(lowerName)) continue
+        if (trimmer(asset[0].toLocaleLowerCase()) !== trimmer(name)) continue
         const assetPath = await getFileSrc(asset[1])
-        assetPaths[name] = {
+        assetPaths[asset[0].toLocaleLowerCase()] = {
             path: assetPath,
             ext: asset[2]
         }
@@ -341,6 +340,7 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
     let needsSourceAccess = false
 
     data = await replaceAsync(data, assetRegex, async (full:string, type:string, name:string) => {
+        name = name.toLocaleLowerCase()
         const moduleAssets = getModuleAssets()
         if (char.additionalAssets) {
             await getAssetSrc(char.additionalAssets, name, assetPaths)

--- a/src/ts/process/modules.ts
+++ b/src/ts/process/modules.ts
@@ -268,7 +268,10 @@ function getModuleByIds(ids:string[]){
             modules.push(module)
         }
     }
-    return deduplicateModuleById(modules)
+    if(db.moduleIntergration){
+        modules = deduplicateModuleById(modules)
+    }
+    return modules
 }
 
 function deduplicateModuleById(modules:RisuModule[]){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR addresses the issue where asset names were only recognized when entered in lowercase, even if they were originally uppercase. It ensures that asset names are now case-insensitive, aligning with the intended behavior.