### PR TITLE
feat: add local activation for lorebook

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1056,4 +1056,5 @@ export const languageEnglish = {
     copy: "Copy",
     paste: "Paste",
     depth: "Depth",
+    alwaysActiveInChat: "Always Active (Current Chat)",
 }

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1056,5 +1056,7 @@ export const languageEnglish = {
     copy: "Copy",
     paste: "Paste",
     depth: "Depth",
+    returnCSSError: "Return CSS Error",
     alwaysActiveInChat: "Always Active (Current Chat)",
+    childLoreDesc: "This is a copy of Character lore that remains 'Always Active' until removed or manually deactivated in the original.",
 }

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -979,4 +979,5 @@ export const languageKorean = {
     "paste": "붙여넣기",
     "depth": "깊이",
     "alwaysActiveInChat": "언제나 활성화 (현재 챗)",
+    "childLoreDesc": "이것은 캐릭터 로어의 복사본이며, 삭제하거나 원본 로어에서 직접 비활성화하기 전에는 '언제나 활성화' 상태로 유지됩니다."
 }

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -978,4 +978,5 @@ export const languageKorean = {
     "copy": "복사",
     "paste": "붙여넣기",
     "depth": "깊이",
+    "alwaysActiveInChat": "언제나 활성화 (현재 챗)",
 }

--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -218,6 +218,21 @@ export async function loadLoreBookV3Prompt(){
                 all?:boolean
             }[] = []
             let fullWordMatching = fullWordMatchingSetting
+            
+            if(fullLore[i].mode === 'child'){
+                activated = false
+                for(let j=0;j<i;j++){
+                    if(fullLore[j].id === fullLore[i].id){
+                        if(!activatedIndexes.includes(j)){
+                            fullLore[i].comment = fullLore[j].comment
+                            fullLore[i].content = fullLore[j].content
+                            fullLore[i].alwaysActive = true
+                            activated = true
+                        }
+                        break
+                    }
+                }
+            }
             const content = CCardLib.decorator.parse(fullLore[i].content, (name, arg) => {
                 switch(name){
                     case 'end':{
@@ -363,7 +378,7 @@ export async function loadLoreBookV3Prompt(){
                     }
                 }
             })
-            
+
 
             if(!activated || forceState !== 'none' || fullLore[i].alwaysActive){
                 //if the lore is not activated or force activated, skip the search

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -935,7 +935,7 @@ export interface loreBook{
     insertorder: number
     comment: string
     content: string
-    mode: 'multiple'|'constant'|'normal',
+    mode: 'multiple'|'constant'|'normal'|'child',
     alwaysActive: boolean
     selective:boolean
     extentions?:{
@@ -948,6 +948,7 @@ export interface loreBook{
     },
     useRegex?:boolean
     bookVersion?:number
+    id?:string
 }
 
 export interface character{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR adds a toggle to enable lore books specifically for the current chat session. This feature is expected to be particularly useful for simulator-style chatbots as it allows users to select and activate specific lore books for each chat from a pre-configured set. Please note that this is still an early implementation, and I'm open to any feedback or suggestions.

![image](https://github.com/user-attachments/assets/8b887b79-2bd0-40d5-914d-d3b901e4b71e)
