### PR TITLE
add aws claude legacy

### DIFF
--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -739,6 +739,43 @@ export const LLMModels: LLMModel[] = [
         tokenizer: LLMTokenizer.Claude
     },
     {
+        name: 'Claude 3 Sonnet (20240229) v1',
+        id: 'anthropic.claude-3-sonnet-20240229-v1:0',
+        provider: LLMProvider.AWS,
+        format: LLMFormat.AWSBedrockClaude,
+        flags: [
+            LLMFlags.hasPrefill,
+            LLMFlags.hasImageInput,
+            LLMFlags.hasFirstSystemPrompt
+        ],
+        parameters: ClaudeParameters,
+        tokenizer: LLMTokenizer.Claude
+    },
+    {
+        name: 'Claude 2.1',
+        id: 'anthropic.claude-v2:1',
+        provider: LLMProvider.AWS,
+        format: LLMFormat.AWSBedrockClaude,
+        flags: [
+            LLMFlags.hasPrefill,
+            LLMFlags.hasFirstSystemPrompt
+        ],
+        parameters: ClaudeParameters,
+        tokenizer: LLMTokenizer.Claude
+    },
+    {
+        name: 'Claude 2',
+        id: 'anthropic.claude-v2',
+        provider: LLMProvider.AWS,
+        format: LLMFormat.AWSBedrockClaude,
+        flags: [
+            LLMFlags.hasPrefill,
+            LLMFlags.hasFirstSystemPrompt
+        ],
+        parameters: ClaudeParameters,
+        tokenizer: LLMTokenizer.Claude
+    },
+    {
         name: 'Ooba',
         id: 'ooba',
         provider: LLMProvider.AsIs,

--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -2572,7 +2572,7 @@ async function requestClaude(arg:RequestDataArgumentExtended):Promise<requestDat
         const host = AMZ_HOST.replace("%REGION%", region);
         const stream = false;   // todo?
         
-        const awsModel = "us." + arg.modelInfo.internalID;
+        const awsModel = !arg.modelInfo.internalID.includes("v2") ? "us." + arg.modelInfo.internalID : arg.modelInfo.internalID;
         const url = `https://${host}/model/${awsModel}/invoke${stream ? "-with-response-stream" : ""}`
 
         const params = {


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
I do aware these legacy models are currently deprecated and will be fully retired on July 21, 2025.
Just I need moment to farewell them.