### PR TITLE
fix: force refresh modules after closing menu

### DIFF
--- a/src/lib/Setting/Pages/Module/ModuleSettings.svelte
+++ b/src/lib/Setting/Pages/Module/ModuleSettings.svelte
@@ -33,9 +33,7 @@
     }
 
     onDestroy(() => {
-        if(DBState.db.moduleIntergration){
-            refreshModules()
-        }
+        refreshModules()
     })
 </script>
 {#if mode === 0}

--- a/src/ts/process/modules.ts
+++ b/src/ts/process/modules.ts
@@ -268,9 +268,7 @@ function getModuleByIds(ids:string[]){
             modules.push(module)
         }
     }
-    if(db.moduleIntergration){
-        modules = deduplicateModuleById(modules)
-    }
+    modules = deduplicateModuleById(modules)
     return modules
 }
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
It seems modifying an already activated module is causing a synchronization issue with the current chats. Correcting this should fix it.