### PR TITLE
Fix Docker image build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20
 WORKDIR /app
 COPY . .
+RUN npm install -g corepack@latest
 RUN corepack enable && \
     corepack install --global pnpm@latest
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

This PR fixes #749.
The npm registry key rotation caused the issue. Bumping Corepack to >= 0.31.0 fixes it. 
