### PR TITLE
fix: lua chat functions

### DIFF
--- a/src/ts/observer.svelte.ts
+++ b/src/ts/observer.svelte.ts
@@ -43,7 +43,12 @@ function nodeObserve(node:HTMLElement){
             if(currentChar.type === 'group'){
                 return;
             }
-            await runLuaButtonTrigger(currentChar, btnEvent);
+            const triggerResult = await runLuaButtonTrigger(currentChar, btnEvent);
+            
+            if(triggerResult){
+                setCurrentChat(triggerResult.chat);
+            }
+            
         }, {
             passive: true,
         });

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -1151,7 +1151,7 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
                     if(triggerCodeResult.stopSending){
                         stopSending = true
                     }
-                    chat = getCurrentChat()
+                    chat = triggerCodeResult.chat
                     break
                 }
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
The community have reported an issue where chat array-related effects malfunction when using modules using Lua alongside modules using blocks. It appears that my previous PR, #639, may be the cause of this problem. This PR included the following changes:

1.  Reverted a previous change to allow Lua triggers to cycle correctly within the trigger pipeline.
2.  After that, the issue that the previous PR attempted to fix has (understandably) resurfaced. To address this, I've taken a different approach: To prevent a situation where a created Lua mutex would eternally reference a single chat object if not initialized again, I've added a chat variable to the `luaEngineState` interface and updated it on every call.
3.  I noticed that the `removeChat` function was included twice in the Lua bindings. I've removed one. (Or was this intentional?)
4.  Modified the `getFullChat` function to also return the creation time of the chat.

Just in case, I've also attached a link to the bot card with Lua trigger I used for testing: https://files.catbox.moe/ujqt3o.jpeg

