### PR TITLE
Fix: translation request was made even though useAutoTranslateInput is turned off

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -317,6 +317,9 @@
     });
 
     async function updateInputTransateMessage(reverse: boolean) {
+        if(!DBState.db.useAutoTranslateInput){
+            return
+        }
         if(isExpTranslator()){
             if(!reverse){
                 messageInputTranslate = ''


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Because of this, even when useAutoTranslateInput is turned off, Google translation request runs every time a sentence is modified.

![image](https://github.com/user-attachments/assets/74133172-bbf0-439a-a715-cb253f94141e)
