### PR TITLE
fix: Chat trigger on start

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -1,5 +1,5 @@
 import { get, writable } from "svelte/store";
-import { type character, type MessageGenerationInfo, type Chat, changeToPreset } from "../storage/database.svelte";
+import { type character, type MessageGenerationInfo, type Chat, changeToPreset, setCurrentChat } from "../storage/database.svelte";
 import { DBState } from '../stores.svelte';
 import { CharEmotion, selectedCharID } from "../stores.svelte";
 import { ChatTokenizer, tokenize, tokenizeNum } from "../tokenizer";
@@ -694,6 +694,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     const triggerResult = await runTrigger(currentChar, 'start', {chat: currentChat})
     if(triggerResult){
         currentChat = triggerResult.chat
+        setCurrentChat(currentChat)
         ms = currentChat.message
         currentTokens += triggerResult.tokens
         if(triggerResult.stopSending){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR aims to fix the following issues:
1.  Fixed an issue where chat array changes caused by the 'start' mode trigger were not being applied correctly. (This problem occurs in both block type and Lua type.)
2.  Occasionally, there was a problem with scriptstate desync in Lua triggers, so I've changed to update method on every call.