### PR TITLE
fix: update plugin docs with abortSignal support

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -75,6 +75,15 @@ Gets the argument value by name.
 
 - `string|number` - The argument value.
 
+### `setArg(name: string, value: string|number): void`
+
+Sets the argument value by name.
+
+#### Arguments
+
+- `name: string` - The argument name. must be format of `<plugin_name>::<arg_name>` like `exampleplugin::arg1`.
+- `value: string|number` - The argument value.
+
 ### `getChar(): character`
 
 Gets the current character.
@@ -83,14 +92,14 @@ Gets the current character.
 
 Sets the current character.
 
-### `addProvider(type: string, func: (arg:PluginV2ProviderArgument, options?:PluginV2ProviderOptions) => Promise<{success:boolean,content:string}>): void`
+### `addProvider(type: string, func: (arg:PluginV2ProviderArgument, abortSignal?: AbortSignal) => Promise<{success:boolean,content:string|ReadableStream<string>}>, options?:PluginV2ProviderOptions): void`
 
 Adds a provider to the plugin.
 
 #### Arguments
 
 - `type: string` - The provider name.
-- `func: (arg:PluginV2ProviderArgument) => Promise<{success:boolean,content:string}>` - The provider function.
+- `func: (arg:PluginV2ProviderArgument, abortSignal?: AbortSignal) => Promise<{success:boolean,content:string}>` - The provider function.
     - `arg: PluginV2ProviderArgument` - The provider argument.
         - `prompt_chat: Chat[]` - The chat prompt.
         - `frequency_penalty?: number` - The frequency penalty.
@@ -102,6 +111,7 @@ Adds a provider to the plugin.
         - `temperature?: number` - The temperature value.
         - `max_tokens?: number` - The max tokens value.
         - `mode: string` - The mode. one of `model`, `submodel`, `memory`, `emotion`, `otherAx`, `translate`
+    - `abortSignal?: AbortSignal` - The signal to use for aborting the request.
     - `Promise<{success:boolean,content:string|ReadableStream<string>}>` - The provider result.
         - `success: boolean` - If the provider was successful.
         - `content: string|ReadableStream<string>` - The provider content. if it's a ReadableStream, it will be streamed to the chat.

--- a/src/ts/plugins/plugins.ts
+++ b/src/ts/plugins/plugins.ts
@@ -120,7 +120,7 @@ export async function loadPlugins() {
 }
 
 type PluginV2ProviderArgument = {
-    prompt_chat: OpenAIChat[],
+    prompt_chat: OpenAIChat[]
     frequency_penalty: number
     min_p: number
     presence_penalty: number
@@ -129,6 +129,7 @@ type PluginV2ProviderArgument = {
     top_p: number
     temperature: number
     mode: string
+    max_tokens: number
 }
 
 type PluginV2ProviderOptions = {
@@ -140,7 +141,7 @@ type EditFunction = (content:string) => string|null|undefined|Promise<string|nul
 type ReplacerFunction = (content:OpenAIChat[], type:string) => OpenAIChat[]|Promise<OpenAIChat[]>
 
 export const pluginV2 = {
-    providers: new Map<string, (arg:PluginV2ProviderArgument) => Promise<{success:boolean,content:string|ReadableStream<string>}> >(),
+    providers: new Map<string, (arg:PluginV2ProviderArgument, abortSignal?: AbortSignal) => Promise<{success:boolean,content:string|ReadableStream<string>}> >(),
     providerOptions: new Map<string, PluginV2ProviderOptions>(),
     editdisplay: new Set<EditFunction>(),
     editoutput: new Set<EditFunction>(),
@@ -189,7 +190,7 @@ export async function loadV2Plugin(plugins:RisuPlugin[]){
             db.characters[charid] = char
             setDatabaseLite(db)
         },
-        addProvider: (name:string, func:(arg:PluginV2ProviderArgument) => Promise<{success:boolean,content:string}>, options?:PluginV2ProviderOptions) => {
+        addProvider: (name:string, func:(arg:PluginV2ProviderArgument, abortSignal?:AbortSignal) => Promise<{success:boolean,content:string}>, options?:PluginV2ProviderOptions) => {
             let provs = get(customProviderStore)
             provs.push(name)
             pluginV2.providers.set(name, func)

--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -1606,7 +1606,7 @@ async function requestPlugin(arg:RequestDataArgumentExtended):Promise<requestDat
             max_tokens: maxTokens,
         }, [
             'frequency_penalty','min_p','presence_penalty','repetition_penalty','top_k','top_p','temperature'
-        ], {}, arg.mode) as any)) : await pluginProcess({
+        ], {}, arg.mode) as any, arg.abortSignal)) : await pluginProcess({
             bias: bias,
             prompt_chat: formated,
             temperature: (db.temperature / 100),


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR introduces following:
- Add setArg function to plugin docs
- Add abortSignal parameter to addProvider function