### PR TITLE
Fix: Avoid flatMap crash when output.images is undefined

### DIFF
--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -435,7 +435,7 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                 }
                 await new Promise(r => setTimeout(r, 1000))
             } // Check history until the generation is complete.
-            const genImgInfo = Object.values(item.outputs).flatMap((output: any) => output.images)[0];
+            const genImgInfo = Object.values(item.outputs).flatMap((output: any) => output.images || [])[0];
 
             const imgResponse = await fetchNative(createUrl('/view', {
                 filename: genImgInfo.filename,


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
In some ComfyUI workflows, output.images is often undefined when intermediate outputs from text-based nodes are included and cannot be suppressed in the response.