### PR TITLE
feat: implement preset for HypaV3

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -828,7 +828,7 @@
                     {/if}
 
                     {#if DBState.db.showMenuHypaMemoryModal}
-                        {#if DBState.db.supaModelType !== 'none' && (DBState.db.hypav2 || DBState.db.hypaV3)}
+                        {#if (DBState.db.supaModelType !== 'none' && DBState.db.hypav2) || DBState.db.hypaV3}
                             <div class="flex items-center cursor-pointer hover:text-green-500 transition-colors" onclick={() => {
                                 if (DBState.db.hypav2) {
                                     DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].hypaV2Data ??= {

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -5,13 +5,12 @@
     import { selectSingleFile } from "src/ts/util";
     
     import { DBState } from 'src/ts/stores.svelte';
-    import { isTauri, saveAsset } from "src/ts/globalApi.svelte";
+    import { isTauri, saveAsset, downloadFile } from "src/ts/globalApi.svelte";
     import NumberInput from "src/lib/UI/GUI/NumberInput.svelte";
     import TextInput from "src/lib/UI/GUI/TextInput.svelte";
     import SelectInput from "src/lib/UI/GUI/SelectInput.svelte";
     import OptionInput from "src/lib/UI/GUI/OptionInput.svelte";
     import SliderInput from "src/lib/UI/GUI/SliderInput.svelte";
-    import Button from "src/lib/UI/GUI/Button.svelte";
     import { getCharImage } from "src/ts/characters";
     import Arcodion from "src/lib/UI/Arcodion.svelte";
     import CheckInput from "src/lib/UI/GUI/CheckInput.svelte";
@@ -20,6 +19,9 @@
     import { tokenizePreset } from "src/ts/process/prompt";
     import { getCharToken } from "src/ts/tokenizer";
     import { selectedCharID } from "src/ts/stores.svelte";
+    import { PlusIcon, PencilIcon, TrashIcon, DownloadIcon, FolderUpIcon } from "lucide-svelte";
+    import { alertError, alertInput, alertConfirm, alertNormal } from "src/ts/alert";
+    import { createNewHypaV3Preset } from "src/ts/process/memory/hypav3";
 
     $effect.pre(() => {
         DBState.db.NAIImgConfig ??= {
@@ -67,25 +69,35 @@
 
     // HypaV3
     $effect(() => {
-        const newValue = Math.min(DBState.db.hypaV3Settings.recentMemoryRatio, 1);
+        const settings = DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.settings;
+        const currentValue = settings?.similarMemoryRatio;
+
+        if (!currentValue) return;
 
         untrack(() => {
-            DBState.db.hypaV3Settings.recentMemoryRatio = newValue;
-            
-            if (newValue + DBState.db.hypaV3Settings.similarMemoryRatio > 1) {
-                DBState.db.hypaV3Settings.similarMemoryRatio = 1 - newValue;
+            const newValue = Math.min(currentValue, 1);
+
+            settings.similarMemoryRatio = newValue;
+
+            if (newValue + settings.recentMemoryRatio > 1) {
+                settings.recentMemoryRatio = 1 - newValue;
             }
         })
     });
 
     $effect(() => {
-        const newValue = Math.min(DBState.db.hypaV3Settings.similarMemoryRatio, 1);
+        const settings = DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.settings;
+        const currentValue = settings?.recentMemoryRatio;
+
+        if (!currentValue) return;
 
         untrack(() => {
-            DBState.db.hypaV3Settings.similarMemoryRatio = newValue;
+            const newValue = Math.min(currentValue, 1);
 
-            if (newValue + DBState.db.hypaV3Settings.recentMemoryRatio > 1) {
-                DBState.db.hypaV3Settings.recentMemoryRatio = 1 - newValue;
+            settings.recentMemoryRatio = newValue;
+
+            if (newValue + settings.similarMemoryRatio > 1) {
+                settings.similarMemoryRatio = 1 - newValue;
             }
         })
     });
@@ -542,20 +554,11 @@
                 DBState.db.hanuraiEnable = false
                 DBState.db.hypaV3 = false
             } else if (value === 'hypaV3') {
-                DBState.db.supaModelType = 'subModel'
                 DBState.db.memoryAlgorithmType = 'hypaMemoryV3'
-                DBState.db.hypav2 = false
+                DBState.db.supaModelType = 'none'
                 DBState.db.hanuraiEnable = false
+                DBState.db.hypav2 = false
                 DBState.db.hypaV3 = true
-                DBState.db.hypaV3Settings.memoryTokensRatio = 0.2
-                DBState.db.hypaV3Settings.extraSummarizationRatio = 0
-                DBState.db.hypaV3Settings.maxChatsPerSummary = 4
-                DBState.db.hypaV3Settings.recentMemoryRatio = 0.4
-                DBState.db.hypaV3Settings.similarMemoryRatio = 0.4
-                DBState.db.hypaV3Settings.enableSimilarityCorrection = false
-                DBState.db.hypaV3Settings.preserveOrphanedMemory = false
-                DBState.db.hypaV3Settings.processRegexScript = false
-                DBState.db.hypaV3Settings.doNotSummarizeUserMessage = false
             } else {
                 DBState.db.supaModelType = 'none'
                 DBState.db.memoryAlgorithmType = 'none'
@@ -597,46 +600,168 @@
             <span class="text-textcolor">{language.hypaAllocatedTokens}</span>
             <NumberInput size="sm" marginBottom bind:value={DBState.db.hypaAllocatedTokens} min={100} />
         {:else if DBState.db.hypaV3}
-            <span class="mb-2 text-textcolor2 text-sm text-wrap break-words max-w-full">{language.hypaV3Settings.descriptionLabel}</span>
-            <span class="text-textcolor mt-4">{language.SuperMemory} {language.model}</span>
-            <SelectInput className="mt-2 mb-2" bind:value={DBState.db.supaModelType}>
-                <OptionInput value="distilbart">distilbart-cnn-6-6 (Free/Local)</OptionInput>
-                <OptionInput value="subModel">{language.submodel}</OptionInput>
-            </SelectInput>
-            <span class="text-textcolor">{language.summarizationPrompt} <Help key="summarizationPrompt"/></span>
-            <div class="mb-2">
-                <TextAreaInput size="sm" placeholder={language.hypaV3Settings.supaMemoryPromptPlaceHolder} bind:value={DBState.db.supaMemoryPrompt} />
+            <span class="max-w-full mb-6 text-sm text-wrap break-words text-textcolor2">{language.hypaV3Settings.descriptionLabel}</span>
+            <span class="text-textcolor">Preset</span>
+            <select class={"border border-darkborderc focus:border-borderc rounded-md shadow-sm text-textcolor bg-transparent focus:ring-borderc focus:ring-2 focus:outline-none transition-colors duration-200 text-md px-4 py-2 mb-1"}
+                bind:value={DBState.db.hypaV3PresetId}
+            >
+                {#each DBState.db.hypaV3Presets as preset, i}
+                    <option class="bg-darkbg appearance-none" value={i}>{preset.name}</option>
+                {/each}
+            </select>
+
+            <div class="flex items-center mb-8">
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={() => {
+                    const newPreset = createNewHypaV3Preset()
+                    const presets = DBState.db.hypaV3Presets
+
+                    presets.push(newPreset)
+                    DBState.db.hypaV3Presets = presets
+                    DBState.db.hypaV3PresetId = DBState.db.hypaV3Presets.length - 1
+                }}>
+                    <PlusIcon size={24}/>
+                </button>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async () => {
+                    const presets = DBState.db.hypaV3Presets
+
+                    if(presets.length === 0){
+                        alertError("There must be least one preset.")
+                        return
+                    }
+
+                    const id = DBState.db.hypaV3PresetId
+                    const newName = await alertInput(`Enter new name for ${presets[id].name}`)
+
+                    if (!newName || newName.trim().length === 0) return
+
+                    presets[id].name = newName
+                    DBState.db.hypaV3Presets = presets
+                }}>
+                    <PencilIcon size={24}/>
+                </button>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async (e) => {
+                    const presets = DBState.db.hypaV3Presets
+
+                    if(presets.length <= 1){
+                        alertError("There must be least one preset.")
+                        return
+                    }
+
+                    const id = DBState.db.hypaV3PresetId
+                    const confirmed = await alertConfirm(`${language.removeConfirm}${presets[id].name}`)
+
+                    if (!confirmed) return
+
+                    DBState.db.hypaV3PresetId = 0
+                    presets.splice(id, 1)
+                    DBState.db.hypaV3Presets = presets
+                }}>
+                    <TrashIcon size={24}/>
+                </button>
+
+                <div class="ml-2 mr-4 w-px h-full bg-darkborderc"></div>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async() => {
+                    try {
+                        const presets = DBState.db.hypaV3Presets
+                        
+                        if(presets.length === 0){
+                            alertError("There must be least one preset.")
+                            return
+                        }
+
+                        const id = DBState.db.hypaV3PresetId
+                        const jsonExport = Buffer.from(JSON.stringify({
+                            type: 'risu',
+                            ver: 1,
+                            data: presets[id]
+                        }), 'utf-8')
+                        
+                        await downloadFile(`hypaV3_export.json`, jsonExport)
+                        alertNormal(language.successExport)
+                    } catch (error) {
+                        alertError(`${error}`)
+                    }
+                }}>
+                    <DownloadIcon size={24}/>
+                </button>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async() => {
+                    try {
+                        const bytesExport = (await selectSingleFile(['json'])).data
+
+                        if(!bytesExport) return
+
+                        const objExport = JSON.parse(Buffer.from(bytesExport).toString('utf-8'))
+
+                        if(objExport.type !== 'risu' || !objExport.data) return
+
+                        const newPreset = createNewHypaV3Preset(
+                            objExport.data.name || "Imported Preset",
+                            objExport.data.settings || {}
+                        );
+                        const presets = DBState.db.hypaV3Presets
+                        
+                        presets.push(newPreset)
+                        DBState.db.hypaV3Presets = presets
+                        DBState.db.hypaV3PresetId = DBState.db.hypaV3Presets.length - 1
+
+                        alertNormal(language.successImport)
+                    } catch (error) {
+                        alertError(`${error}`)
+                    }
+                }}>
+                    <FolderUpIcon size={24}/>
+                </button>
             </div>
-            {#await getMaxMemoryRatio() then maxMemoryRatio}
-            <span class="text-textcolor">{language.hypaV3Settings.maxMemoryTokensRatioLabel}</span>
-            <NumberInput marginBottom disabled size="sm" value={maxMemoryRatio} />
-            {:catch error}
-            <span class="text-red-400">{language.hypaV3Settings.maxMemoryTokensRatioError}</span>
-            {/await}
-            <span class="text-textcolor">{language.hypaV3Settings.memoryTokensRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.memoryTokensRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.extraSummarizationRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1 - DBState.db.hypaV3Settings.memoryTokensRatio} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.extraSummarizationRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.maxChatsPerSummaryLabel}</span>
-            <NumberInput marginBottom size="sm" min={1} bind:value={DBState.db.hypaV3Settings.maxChatsPerSummary} />
-            <span class="text-textcolor">{language.hypaV3Settings.recentMemoryRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.recentMemoryRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.similarMemoryRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.similarMemoryRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.randomMemoryRatioLabel}</span>
-            <NumberInput marginBottom disabled size="sm" value={parseFloat((1 - DBState.db.hypaV3Settings.recentMemoryRatio - DBState.db.hypaV3Settings.similarMemoryRatio).toFixed(2))} />
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.enableSimilarityCorrectionLabel} bind:check={DBState.db.hypaV3Settings.enableSimilarityCorrection} />
-            </div>
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.preserveOrphanedMemoryLabel} bind:check={DBState.db.hypaV3Settings.preserveOrphanedMemory} />
-            </div>
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.applyRegexScriptWhenRerollingLabel} bind:check={DBState.db.hypaV3Settings.processRegexScript} />
-            </div>
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.doNotSummarizeUserMessageLabel} bind:check={DBState.db.hypaV3Settings.doNotSummarizeUserMessage} />
-            </div>
+
+            {#if DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.settings}
+                {@const settings = DBState.db.hypaV3Presets[DBState.db.hypaV3PresetId].settings}
+
+                <span class="text-textcolor">{language.SuperMemory} {language.model}</span>
+                <SelectInput className="mb-4" bind:value={settings.summarizationModel}>
+                    <OptionInput value="distilbart">distilbart-cnn-6-6 (Free/Local)</OptionInput>
+                    <OptionInput value="subModel">{language.submodel}</OptionInput>
+                </SelectInput>
+                <span class="text-textcolor">{language.summarizationPrompt} <Help key="summarizationPrompt"/></span>
+                <div class="mb-4">
+                    <TextAreaInput size="sm" placeholder={language.hypaV3Settings.supaMemoryPromptPlaceHolder} bind:value={settings.summarizationPrompt} />
+                </div>
+                {#await getMaxMemoryRatio() then maxMemoryRatio}
+                <span class="text-textcolor">{language.hypaV3Settings.maxMemoryTokensRatioLabel}</span>
+                <NumberInput marginBottom disabled size="sm" value={maxMemoryRatio} />
+                {:catch error}
+                <span class="mb-4 text-red-400">{language.hypaV3Settings.maxMemoryTokensRatioError}</span>
+                {/await}
+                <span class="text-textcolor">{language.hypaV3Settings.memoryTokensRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={settings.memoryTokensRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.extraSummarizationRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1 - settings.memoryTokensRatio} step={0.01} fixed={2} bind:value={settings.extraSummarizationRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.maxChatsPerSummaryLabel}</span>
+                <NumberInput marginBottom size="sm" min={1} bind:value={settings.maxChatsPerSummary} />
+                <span class="text-textcolor">{language.hypaV3Settings.recentMemoryRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={settings.recentMemoryRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.similarMemoryRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={settings.similarMemoryRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.randomMemoryRatioLabel}</span>
+                <NumberInput marginBottom disabled size="sm" value={parseFloat((1 - settings.recentMemoryRatio - settings.similarMemoryRatio).toFixed(2))} />
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.enableSimilarityCorrectionLabel} bind:check={settings.enableSimilarityCorrection} />
+                </div>
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.preserveOrphanedMemoryLabel} bind:check={settings.preserveOrphanedMemory} />
+                </div>
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.applyRegexScriptWhenRerollingLabel} bind:check={settings.processRegexScript} />
+                </div>
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.doNotSummarizeUserMessageLabel} bind:check={settings.doNotSummarizeUserMessage} />
+                </div>
+            {/if}
+
+            <div class="mb-4"></div>
         {:else if (DBState.db.supaModelType !== 'none' && DBState.db.hypav2 === false && DBState.db.hypaV3 === false)}
             <span class="mb-2 text-textcolor2 text-sm text-wrap break-words max-w-full">{language.supaDesc}</span>
             <span class="text-textcolor mt-4">{language.SuperMemory} {language.model}</span>

--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -1103,7 +1103,7 @@
             >
                 {language.hypaMemoryV2Modal}
             </Button>
-        {:else if DBState.db.supaModelType !== 'none' && DBState.db.hypaV3}
+        {:else if DBState.db.hypaV3}
             <Button
                 onclick={() => {
                     showHypaV3Alert()

--- a/src/lib/SideBars/Toggles.svelte
+++ b/src/lib/SideBars/Toggles.svelte
@@ -53,9 +53,9 @@
             <CheckInput bind:check={DBState.db.jailbreakToggle} name={language.jailbreakToggle} reverse />
         </div>
         {@render toggles(true)}
-        {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable}
+        {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable || DBState.db.hypaV3}
             <div class="flex mt-2 items-center w-full" class:justify-end={$MobileGUI}>
-                <CheckInput bind:check={chara.supaMemory} reverse name={DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
+                <CheckInput bind:check={chara.supaMemory} reverse name={DBState.db.hypaV3 ? language.ToggleHypaMemory : DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
             </div>
         {/if}
     </div>
@@ -64,9 +64,9 @@
         <CheckInput bind:check={DBState.db.jailbreakToggle} name={language.jailbreakToggle}/>
     </div>
     {@render toggles()}
-    {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable}
+    {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable || DBState.db.hypaV3}
         <div class="flex mt-2 items-center">
-            <CheckInput bind:check={chara.supaMemory} name={DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
+            <CheckInput bind:check={chara.supaMemory} name={DBState.db.hypaV3 ? language.ToggleHypaMemory : DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
         </div>
     {/if}
 {/if}

--- a/src/ts/process/memory/hypamemory.ts
+++ b/src/ts/process/memory/hypamemory.ts
@@ -44,7 +44,7 @@ export class HypaProcesser{
         else{
             this.model = model
         }
-        this.customEmbeddingUrl = customEmbeddingUrl || db.hypaCustomSettings.url
+        this.customEmbeddingUrl = customEmbeddingUrl?.trim() || db.hypaCustomSettings?.url?.trim() || ""
     }
 
     async embedDocuments(texts: string[]): Promise<VectorArray[]> {
@@ -80,10 +80,12 @@ export class HypaProcesser{
 
             const db = getDatabase()
             const fetchArgs = {
-                ...(db.hypaCustomSettings.key ? {headers: {"Authorization": "Bearer " + db.hypaCustomSettings.key}} : {}),
+                headers: {
+                    ...(db.hypaCustomSettings?.key?.trim() ? {"Authorization": "Bearer " + db.hypaCustomSettings.key.trim()} : {})
+                },
                 body: {
                     "input": input,
-                    ...(db.hypaCustomSettings.model ? {"model": db.hypaCustomSettings.model} : {})
+                    ...(db.hypaCustomSettings?.model?.trim() ? {"model": db.hypaCustomSettings.model.trim()} : {})
                 }
             };
  
@@ -99,7 +101,7 @@ export class HypaProcesser{
 
             gf = await globalFetch("https://api.openai.com/v1/embeddings", {
                 headers: {
-                    "Authorization": "Bearer " + db.supaMemoryKey || this.oaikey
+                    "Authorization": "Bearer " + (this.oaikey?.trim() || db.supaMemoryKey?.trim())
                 },
                 body: {
                     "input": input,
@@ -134,7 +136,7 @@ export class HypaProcesser{
     
     async addText(texts:string[]) {
         const db = getDatabase()
-        const suffix = (this.model === 'custom' && db.hypaCustomSettings.model) ? `-${db.hypaCustomSettings.model}` : ""
+        const suffix = (this.model === 'custom' && db.hypaCustomSettings?.model?.trim()) ? `-${db.hypaCustomSettings.model.trim()}` : ""
 
         for(let i=0;i<texts.length;i++){
             const itm:memoryVector = await this.forage.getItem(texts[i] + '|' + this.model + suffix)
@@ -205,7 +207,8 @@ export class HypaProcesser{
         return similarity(query1, query2)
     }
 }
-function similarity(a:VectorArray, b:VectorArray) {    
+
+export function similarity(a:VectorArray, b:VectorArray) {    
     let dot = 0;
     for(let i=0;i<a.length;i++){
         dot += a[i] * b[i]

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -11,6 +11,7 @@ import { prebuiltNAIpresets, prebuiltPresets } from '../process/templates/templa
 import { defaultColorScheme, type ColorScheme } from '../gui/colorscheme';
 import type { PromptItem, PromptSettings } from '../process/prompt';
 import type { OobaChatCompletionRequestParams } from '../model/ooba';
+import { type HypaV3Settings, type HypaV3Preset, createNewHypaV3Preset } from '../process/memory/hypav3'
 
 export let appVer = "159.0.0"
 export let webAppSubVer = ''
@@ -515,17 +516,21 @@ export function setDatabase(data:Database){
     data.checkCorruption ??= true
     data.OaiCompAPIKeys ??= {}
     data.reasoningEffort ??= 0
-    data.hypaV3Settings = {
-        memoryTokensRatio: data.hypaV3Settings?.memoryTokensRatio ?? 0.2,
-        extraSummarizationRatio: data.hypaV3Settings?.extraSummarizationRatio ?? 0,
-        maxChatsPerSummary: data.hypaV3Settings?.maxChatsPerSummary ?? 4,
-        recentMemoryRatio: data.hypaV3Settings?.recentMemoryRatio ?? 0.4,
-        similarMemoryRatio: data.hypaV3Settings?.similarMemoryRatio ?? 0.4,
-        enableSimilarityCorrection: data.hypaV3Settings?.enableSimilarityCorrection ?? false,
-        preserveOrphanedMemory: data.hypaV3Settings?.preserveOrphanedMemory ?? false,
-        processRegexScript: data.hypaV3Settings?.processRegexScript ?? false,
-        doNotSummarizeUserMessage: data.hypaV3Settings?.doNotSummarizeUserMessage ?? false
+    data.hypaV3Presets ??= [
+        createNewHypaV3Preset("Default", {
+            summarizationPrompt: data.supaMemoryPrompt ? data.supaMemoryPrompt : "",
+            ...data.hypaV3Settings
+        })
+    ]
+    if (data.hypaV3Presets.length > 0) {
+        data.hypaV3Presets = data.hypaV3Presets.map((preset, i) =>
+            createNewHypaV3Preset(
+                preset.name || `Preset ${i + 1}`,
+                preset.settings || {}
+            )
+        )
     }
+    data.hypaV3PresetId ??= 0
     data.returnCSSError ??= true
     data.useExperimentalGoogleTranslator ??= false
     if(data.antiClaudeOverload){ //migration
@@ -535,7 +540,7 @@ export function setDatabase(data:Database){
     data.hypaCustomSettings = {
         url: data.hypaCustomSettings?.url ?? "",
         key: data.hypaCustomSettings?.key ?? "",
-        model: data.hypaCustomSettings?.model ?? "",       
+        model: data.hypaCustomSettings?.model ?? ""   
     }
     data.doNotChangeSeperateModels ??= false
     data.modelTools ??= []
@@ -960,17 +965,9 @@ export interface Database{
     showPromptComparison:boolean
     checkCorruption:boolean
     hypaV3:boolean
-    hypaV3Settings: {
-        memoryTokensRatio: number
-        extraSummarizationRatio: number
-        maxChatsPerSummary: number
-        recentMemoryRatio: number
-        similarMemoryRatio: number
-        enableSimilarityCorrection: boolean
-        preserveOrphanedMemory: boolean
-        processRegexScript: boolean
-        doNotSummarizeUserMessage: boolean
-    }
+    hypaV3Settings: HypaV3Settings // legacy
+    hypaV3Presets: HypaV3Preset[]
+    hypaV3PresetId: number
     OaiCompAPIKeys: {[key:string]:string}
     inlayErrorResponse:boolean
     reasoningEffort:number


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Preview
![preview](https://github.com/user-attachments/assets/1ff10034-dd8d-4f95-bf0f-d5767550c291)

# Description
This PR adds support for HypaV3 memory presets. Users can now create and switch between different memory settings depending on their needs.

## Changes
- feat: add getCurrentHypaV3Preset and createNewHypaV3Preset to support preset
- fix: prevent similarity search on empty messages in HypaV3
- fix: skip example chat when summarizing
- fix: update HypaV3 modal menu button to support preset
- fix: remove deprecated summarization model from HypaV3
- fix: prevent Content-Type error when using custom embedding without key
- refactor: improve error handling in HypaV3