### PR TITLE
Add support for remote asset server

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -177,6 +177,7 @@ export const languageEnglish = {
         automaticCachePoint: "Automatically creates cache point after the chat ends, if the caching point doesn't exist.",
         experimentalChatCompressionDesc: "Compresses the unused chat data and saves in seperate file. this greatly reduces the size of the chat data, and greatly improves the performance, however its experimental and can be unstable, causing issues in backup feature and more.",
         promptInfoInsideChatDesc: "When enabled, this stores prompt preset information in the chat metadata. The stored data includes the preset name, active toggles, and the prompt text. This may slightly increase processing time and storage usage.",
+        assetServerURL: "If this option is set, assets are loaded from the specified remote server instead of from the local environment. If left blank, assets will be loaded from the local environment.",
     },
     setup: {
         chooseProvider: "Choose AI Provider",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -126,6 +126,7 @@ export const languageKorean = {
         "chatHTML": "A HTML that would be inserted as each chat.\n\nYou can use CBS and special tags.\n- `<risutextbox>`: a textbox that would be used to render text\n- `<risuicon>`: an icon for user or assistant\n- `<risubuttons>`: icon buttons for chat edit, translations and etc.\n- `<risugeninfo>`: generation information button.",
         "autoTranslateCachedOnly": "자동 번역 옵션이 켜진 상태에서 활성화하면, 사용자가 이전에 번역한 메시지만 자동으로 번역됩니다.",
         "promptInfoInsideChatDesc": "활성화되면 채팅 메타데이터에 프롬프트 프리셋 정보를 저장합니다. 저장되는 정보는 프롬프트 프리셋 이름과 활성화된 토글, 그리고 프롬프트 텍스트입니다. 약간의 처리 시간과 용량을 차지할 수 있습니다.",
+        "assetServerURL": "이 옵션을 설정하면 로컬이 아닌 설정한 리모트 서버에서 에셋을 불러옵니다. 비워두면 로컬에서 에셋을 불러옵니다.",
     },
     "setup": {
         "chooseProvider": "AI 제공자를 선택해 주세요",

--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -86,6 +86,9 @@
 <span class="text-textcolor">Kei Server URL</span>
 <TextInput marginBottom={true} size={"sm"} bind:value={DBState.db.keiServerURL} placeholder="Leave it blank to use default"/>
 
+<span class="text-textcolor">Asset Server URL <Help key="assetServerURL"/></span>
+<TextInput marginBottom={true} size={"sm"} bind:value={DBState.db.assetServerURL} placeholder="Leave it blank to not use"/>
+
 <span class="text-textcolor">{language.presetChain} <Help key="presetChain"/></span>
 <TextInput marginBottom={true} size={"sm"} bind:value={DBState.db.presetChain} placeholder="Leave it blank to not use">
 </TextInput>

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -352,8 +352,8 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
     const videoExtention = ['mp4', 'webm', 'avi', 'm4p', 'm4v']
     let needsSourceAccess = false
 
-    data = await replaceAsync(data, assetRegex, async (full:string, type:string, name:string) => {
-        name = name.toLocaleLowerCase()
+    data = await replaceAsync(data, assetRegex, async (full:string, type:string, rawName:string) => {
+        const name = rawName.toLocaleLowerCase()
         const moduleAssets = getModuleAssets()
         if (char.additionalAssets) {
             await getAssetSrc(char.additionalAssets, name, assetPaths)
@@ -401,6 +401,12 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
         if(path.path.length > 1){
             p = path.path[Math.floor(arg.ch % p.length)]
         }
+
+        if(DBState.db.assetServerURL){
+            const trimedUrl = encodeURI(DBState.db.assetServerURL.replace(/\/+$/, ''))
+            p = `${trimedUrl}/${rawName}${path.ext ? `.${path.ext}` : ''}`
+        }
+
         switch(type){
             case 'raw':
             case 'path':

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -427,6 +427,7 @@ export function setDatabase(data:Database){
         maxThoughtTagDepth: -1
     }
     data.keiServerURL ??= ''
+    data.assetServerURL ??= ''
     data.top_k ??= 0
     data.promptSettings.maxThoughtTagDepth ??= -1
     data.openrouterFallback ??= true
@@ -1028,6 +1029,7 @@ export interface Database{
     showMenuHypaMemoryModal:boolean
     promptInfoInsideChat:boolean
     promptTextInfoInsideChat:boolean
+    assetServerURL:string
 }
 
 interface SeparateParameters{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions? - I've checked web version only.
- [x] Have you added type definitions?

# Description

This setting allows assets to be loaded from a remote server rather than from local cache. If no setting is provided, assets will continue to be loaded from the local environment as before.

It is designed to enable functionalities such as asset replacement, random usage of multiple assets under a single asset name, and dynamic asset generation via an external server — without the need to upload assets locally or modify prompts.

# Example

## Advanced Settings

![image](https://github.com/user-attachments/assets/83297000-07d6-4d35-a4f4-47a952ab8f5c)

## Chat

`{{raw:asset_name}}`

![image](https://github.com/user-attachments/assets/d8ba667f-0429-4244-b23f-53ca76ab992c)

`{{image:asset_name}}`

![image](https://github.com/user-attachments/assets/54c0d97a-76f5-44a0-813d-1136202a63ea)

`{{video:asset_name}}`

![image](https://github.com/user-attachments/assets/1e2875ca-bee7-4819-a7de-5ab7619f664e)
