### PR TITLE
fix: prevent missing data field for recursive lorebook, prevent blocks lazy loading when no chat selected

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -51,6 +51,7 @@
     }
 
     $effect(() => {
+        if($selectedCharID < 0) return
         if(blocks.length-10 < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
             blocks = new Uint8Array(blocks.length + 500)
             for(let i=0;i<500;i++){

--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -448,6 +448,7 @@ export async function loadLoreBookV3Prompt(){
                     matching = true
                     recursivePrompt.push({
                         prompt: content,
+                        data: content,
                         source: fullLore[i].comment || `lorebook ${i}`
                     })
                 }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
1. Filled `data` field when creating a recursive lorebook.
2. Prevented lazy loading of blocks when no chat is selected.