### PR TITLE
fix: prevent missing data field for recursive lorebook

### DIFF
--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -448,6 +448,7 @@ export async function loadLoreBookV3Prompt(){
                     matching = true
                     recursivePrompt.push({
                         prompt: content,
+                        data: content,
                         source: fullLore[i].comment || `lorebook ${i}`
                     })
                 }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Filled data field when creating a recursive lorebook.