### PR TITLE
fix: prevent blocks lazy loading when no chat selected

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -51,6 +51,7 @@
     }
 
     $effect(() => {
+        if($selectedCharID < 0) return
         if(blocks.length-10 < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
             blocks = new Uint8Array(blocks.length + 500)
             for(let i=0;i<500;i++){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Prevented lazy loading of blocks when no chat is selected.