### PR TITLE
feat: implement preset and parallel requests for HypaV3

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,7 @@
     import CustomGUISettingMenu from './lib/Setting/Pages/CustomGUISettingMenu.svelte';
     import { checkCharOrder } from './ts/globalApi.svelte';
     import { ArrowUpIcon, GlobeIcon, PlusIcon } from 'lucide-svelte';
+    import HypaV3Progress from './lib/Others/HypaV3Progress.svelte';
 
   
     let didFirstSetup: boolean  = $derived(DBState.db?.didFirstSetup)
@@ -168,4 +169,5 @@
         <ListedPersona close={() => {$openPersonaList = false}} />
     {/if}
     <SavePopupIconComp />
+    <HypaV3Progress />
 </main>

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -829,7 +829,7 @@
                     {/if}
 
                     {#if DBState.db.showMenuHypaMemoryModal}
-                        {#if DBState.db.supaModelType !== 'none' && (DBState.db.hypav2 || DBState.db.hypaV3)}
+                        {#if (DBState.db.supaModelType !== 'none' && DBState.db.hypav2) || DBState.db.hypaV3}
                             <div class="flex items-center cursor-pointer hover:text-green-500 transition-colors" onclick={() => {
                                 if (DBState.db.hypav2) {
                                     DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].hypaV2Data ??= {

--- a/src/lib/Others/HypaV3Modal.svelte
+++ b/src/lib/Others/HypaV3Modal.svelte
@@ -27,7 +27,10 @@
   } from "../../ts/stores.svelte";
   import { type OpenAIChat } from "../../ts/process/index.svelte";
   import { processScriptFull, risuChatParser } from "../../ts/process/scripts";
-  import { summarize } from "../../ts/process/memory/hypav3";
+  import {
+    summarize,
+    getCurrentHypaV3Preset,
+  } from "../../ts/process/memory/hypav3";
   import { type Message } from "../../ts/storage/database.svelte";
   import { translateHTML } from "../../ts/translator/translator";
   import { language } from "../../lang";
@@ -507,7 +510,7 @@
       return null;
     }
 
-    return DBState.db.hypaV3Settings.processRegexScript
+    return getCurrentHypaV3Preset().settings.processRegexScript
       ? await processRegexScript(unprocessed)
       : unprocessed;
   }
@@ -642,7 +645,7 @@
       return null;
     }
 
-    return DBState.db.hypaV3Settings.processRegexScript
+    return getCurrentHypaV3Preset().settings.processRegexScript
       ? await processRegexScript(unprocessed)
       : unprocessed;
   }

--- a/src/lib/Others/HypaV3Progress.svelte
+++ b/src/lib/Others/HypaV3Progress.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { hypaV3ProgressStore } from "src/ts/stores.svelte";
+
+  let isExpanded = $state(false);
+
+  const toggleExpand = () => {
+    isExpanded = !isExpanded;
+  };
+</script>
+
+{#if $hypaV3ProgressStore.open}
+  {#if isExpanded}
+    <div
+      class="absolute w-full h-full z-50 flex justify-center items-center pointer-events-none"
+    >
+      <button
+        class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl max-h-full overflow-y-auto transition-opacity duration-300 pointer-events-auto"
+        type="button"
+        onclick={toggleExpand}
+      >
+        <span class="mb-6 text-left text-gray-500 text-sm"
+          >{$hypaV3ProgressStore.msg || ""}</span
+        >
+        <div
+          class="w-full min-w-64 md:min-w-138 h-2 bg-darkbg border border-darkborderc rounded-md"
+        >
+          <div
+            class="h-full bg-gradient-to-r from-blue-500 to-purple-800 saving-animation transition-[width]"
+          ></div>
+        </div>
+        <span class="w-full mt-6 text-center text-gray-500 text-sm"
+          >{$hypaV3ProgressStore.subMsg || ""}</span
+        >
+      </button>
+    </div>
+  {:else}
+    <button
+      class="fixed top-4 right-4 z-50 bg-darkbg p-2 rounded-full shadow-lg transition-all duration-300 flex items-center justify-center"
+      type="button"
+      style="opacity: 0.8;"
+      onclick={toggleExpand}
+      onmouseenter={(e) => (e.currentTarget.style.opacity = "1")}
+      onmouseleave={(e) => (e.currentTarget.style.opacity = "0.8")}
+    >
+      <div class="w-8 h-8 relative">
+        <div
+          class="absolute inset-0 border-t-2 border-red-500 rounded-full animate-spin"
+        ></div>
+        <div
+          class="absolute inset-1 flex items-center justify-center text-xs text-gray-300"
+        >
+          {$hypaV3ProgressStore.miniMsg || ""}
+        </div>
+      </div>
+    </button>
+  {/if}
+{/if}

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -3,15 +3,13 @@
     import { language } from "src/lang";
     import Help from "src/lib/Others/Help.svelte";
     import { selectSingleFile } from "src/ts/util";
-    
-    import { DBState } from 'src/ts/stores.svelte';
-    import { isTauri, saveAsset } from "src/ts/globalApi.svelte";
+    import { DBState, selectedCharID } from 'src/ts/stores.svelte';
+    import { isTauri, saveAsset, downloadFile } from "src/ts/globalApi.svelte";
     import NumberInput from "src/lib/UI/GUI/NumberInput.svelte";
     import TextInput from "src/lib/UI/GUI/TextInput.svelte";
     import SelectInput from "src/lib/UI/GUI/SelectInput.svelte";
     import OptionInput from "src/lib/UI/GUI/OptionInput.svelte";
     import SliderInput from "src/lib/UI/GUI/SliderInput.svelte";
-    import Button from "src/lib/UI/GUI/Button.svelte";
     import { getCharImage } from "src/ts/characters";
     import Arcodion from "src/lib/UI/Arcodion.svelte";
     import CheckInput from "src/lib/UI/GUI/CheckInput.svelte";
@@ -19,7 +17,9 @@
     import { untrack } from "svelte";
     import { tokenizePreset } from "src/ts/process/prompt";
     import { getCharToken } from "src/ts/tokenizer";
-    import { selectedCharID } from "src/ts/stores.svelte";
+    import { PlusIcon, PencilIcon, TrashIcon, DownloadIcon, FolderUpIcon } from "lucide-svelte";
+    import { alertError, alertInput, alertConfirm, alertNormal } from "src/ts/alert";
+    import { createHypaV3Preset } from "src/ts/process/memory/hypav3";
 
     $effect.pre(() => {
         DBState.db.NAIImgConfig ??= {
@@ -67,25 +67,35 @@
 
     // HypaV3
     $effect(() => {
-        const newValue = Math.min(DBState.db.hypaV3Settings.recentMemoryRatio, 1);
+        const settings = DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.settings;
+        const currentValue = settings?.similarMemoryRatio;
+
+        if (!currentValue) return;
 
         untrack(() => {
-            DBState.db.hypaV3Settings.recentMemoryRatio = newValue;
-            
-            if (newValue + DBState.db.hypaV3Settings.similarMemoryRatio > 1) {
-                DBState.db.hypaV3Settings.similarMemoryRatio = 1 - newValue;
+            const newValue = Math.min(currentValue, 1);
+
+            settings.similarMemoryRatio = newValue;
+
+            if (newValue + settings.recentMemoryRatio > 1) {
+                settings.recentMemoryRatio = 1 - newValue;
             }
         })
     });
 
     $effect(() => {
-        const newValue = Math.min(DBState.db.hypaV3Settings.similarMemoryRatio, 1);
+        const settings = DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.settings;
+        const currentValue = settings?.recentMemoryRatio;
+
+        if (!currentValue) return;
 
         untrack(() => {
-            DBState.db.hypaV3Settings.similarMemoryRatio = newValue;
+            const newValue = Math.min(currentValue, 1);
 
-            if (newValue + DBState.db.hypaV3Settings.recentMemoryRatio > 1) {
-                DBState.db.hypaV3Settings.recentMemoryRatio = 1 - newValue;
+            settings.recentMemoryRatio = newValue;
+
+            if (newValue + settings.similarMemoryRatio > 1) {
+                settings.similarMemoryRatio = 1 - newValue;
             }
         })
     });
@@ -542,20 +552,11 @@
                 DBState.db.hanuraiEnable = false
                 DBState.db.hypaV3 = false
             } else if (value === 'hypaV3') {
-                DBState.db.supaModelType = 'subModel'
                 DBState.db.memoryAlgorithmType = 'hypaMemoryV3'
-                DBState.db.hypav2 = false
+                DBState.db.supaModelType = 'none'
                 DBState.db.hanuraiEnable = false
+                DBState.db.hypav2 = false
                 DBState.db.hypaV3 = true
-                DBState.db.hypaV3Settings.memoryTokensRatio = 0.2
-                DBState.db.hypaV3Settings.extraSummarizationRatio = 0
-                DBState.db.hypaV3Settings.maxChatsPerSummary = 4
-                DBState.db.hypaV3Settings.recentMemoryRatio = 0.4
-                DBState.db.hypaV3Settings.similarMemoryRatio = 0.4
-                DBState.db.hypaV3Settings.enableSimilarityCorrection = false
-                DBState.db.hypaV3Settings.preserveOrphanedMemory = false
-                DBState.db.hypaV3Settings.processRegexScript = false
-                DBState.db.hypaV3Settings.doNotSummarizeUserMessage = false
             } else {
                 DBState.db.supaModelType = 'none'
                 DBState.db.memoryAlgorithmType = 'none'
@@ -597,46 +598,171 @@
             <span class="text-textcolor">{language.hypaAllocatedTokens}</span>
             <NumberInput size="sm" marginBottom bind:value={DBState.db.hypaAllocatedTokens} min={100} />
         {:else if DBState.db.hypaV3}
-            <span class="mb-2 text-textcolor2 text-sm text-wrap break-words max-w-full">{language.hypaV3Settings.descriptionLabel}</span>
-            <span class="text-textcolor mt-4">{language.SuperMemory} {language.model}</span>
-            <SelectInput className="mt-2 mb-2" bind:value={DBState.db.supaModelType}>
-                <OptionInput value="distilbart">distilbart-cnn-6-6 (Free/Local)</OptionInput>
-                <OptionInput value="subModel">{language.submodel}</OptionInput>
-            </SelectInput>
-            <span class="text-textcolor">{language.summarizationPrompt} <Help key="summarizationPrompt"/></span>
-            <div class="mb-2">
-                <TextAreaInput size="sm" placeholder={language.hypaV3Settings.supaMemoryPromptPlaceHolder} bind:value={DBState.db.supaMemoryPrompt} />
+            <span class="max-w-full mb-6 text-sm text-wrap break-words text-textcolor2">{language.hypaV3Settings.descriptionLabel}</span>
+            <span class="text-textcolor">Preset</span>
+            <select class={"border border-darkborderc focus:border-borderc rounded-md shadow-sm text-textcolor bg-transparent focus:ring-borderc focus:ring-2 focus:outline-none transition-colors duration-200 text-md px-4 py-2 mb-1"}
+                bind:value={DBState.db.hypaV3PresetId}
+            >
+                {#each DBState.db.hypaV3Presets as preset, i}
+                    <option class="bg-darkbg appearance-none" value={i}>{preset.name}</option>
+                {/each}
+            </select>
+
+            <div class="flex items-center mb-8">
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={() => {
+                    const newPreset = createHypaV3Preset()
+                    const presets = DBState.db.hypaV3Presets
+
+                    presets.push(newPreset)
+                    DBState.db.hypaV3Presets = presets
+                    DBState.db.hypaV3PresetId = DBState.db.hypaV3Presets.length - 1
+                }}>
+                    <PlusIcon size={24}/>
+                </button>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async () => {
+                    const presets = DBState.db.hypaV3Presets
+
+                    if(presets.length === 0){
+                        alertError("There must be least one preset.")
+                        return
+                    }
+
+                    const id = DBState.db.hypaV3PresetId
+                    const preset = presets[id]
+                    const newName = await alertInput(`Enter new name for ${preset.name}`)
+
+                    if (!newName || newName.trim().length === 0) return
+
+                    preset.name = newName
+                    DBState.db.hypaV3Presets = presets
+                }}>
+                    <PencilIcon size={24}/>
+                </button>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async (e) => {
+                    const presets = DBState.db.hypaV3Presets
+
+                    if(presets.length <= 1){
+                        alertError("There must be least one preset.")
+                        return
+                    }
+
+                    const id = DBState.db.hypaV3PresetId
+                    const preset = presets[id]
+                    const confirmed = await alertConfirm(`${language.removeConfirm}${preset.name}`)
+
+                    if (!confirmed) return
+
+                    DBState.db.hypaV3PresetId = 0
+                    presets.splice(id, 1)
+                    DBState.db.hypaV3Presets = presets
+                }}>
+                    <TrashIcon size={24}/>
+                </button>
+
+                <div class="ml-2 mr-4 w-px h-full bg-darkborderc"></div>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async() => {
+                    try {
+                        const presets = DBState.db.hypaV3Presets
+                        
+                        if(presets.length === 0){
+                            alertError("There must be least one preset.")
+                            return
+                        }
+
+                        const id = DBState.db.hypaV3PresetId
+                        const preset = presets[id]
+                        const bytesExport = Buffer.from(JSON.stringify({
+                            type: 'risu',
+                            ver: 1,
+                            data: preset
+                        }), 'utf-8')
+                        
+                        await downloadFile(`hypaV3_export_${preset.name}.json`, bytesExport)
+                        alertNormal(language.successExport)
+                    } catch (error) {
+                        alertError(`${error}`)
+                    }
+                }}>
+                    <DownloadIcon size={24}/>
+                </button>
+
+                <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async() => {
+                    try {
+                        const bytesImport = (await selectSingleFile(['json'])).data
+
+                        if(!bytesImport) return
+
+                        const objImport = JSON.parse(Buffer.from(bytesImport).toString('utf-8'))
+
+                        if(objImport.type !== 'risu' || !objImport.data) return
+
+                        const newPreset = createHypaV3Preset(
+                            objImport.data.name || "Imported Preset",
+                            objImport.data.settings || {}
+                        );
+                        const presets = DBState.db.hypaV3Presets
+                        
+                        presets.push(newPreset)
+                        DBState.db.hypaV3Presets = presets
+                        DBState.db.hypaV3PresetId = DBState.db.hypaV3Presets.length - 1
+
+                        alertNormal(language.successImport)
+                    } catch (error) {
+                        alertError(`${error}`)
+                    }
+                }}>
+                    <FolderUpIcon size={24}/>
+                </button>
             </div>
-            {#await getMaxMemoryRatio() then maxMemoryRatio}
-            <span class="text-textcolor">{language.hypaV3Settings.maxMemoryTokensRatioLabel}</span>
-            <NumberInput marginBottom disabled size="sm" value={maxMemoryRatio} />
-            {:catch error}
-            <span class="text-red-400">{language.hypaV3Settings.maxMemoryTokensRatioError}</span>
-            {/await}
-            <span class="text-textcolor">{language.hypaV3Settings.memoryTokensRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.memoryTokensRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.extraSummarizationRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1 - DBState.db.hypaV3Settings.memoryTokensRatio} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.extraSummarizationRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.maxChatsPerSummaryLabel}</span>
-            <NumberInput marginBottom size="sm" min={1} bind:value={DBState.db.hypaV3Settings.maxChatsPerSummary} />
-            <span class="text-textcolor">{language.hypaV3Settings.recentMemoryRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.recentMemoryRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.similarMemoryRatioLabel}</span>
-            <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={DBState.db.hypaV3Settings.similarMemoryRatio} />
-            <span class="text-textcolor">{language.hypaV3Settings.randomMemoryRatioLabel}</span>
-            <NumberInput marginBottom disabled size="sm" value={parseFloat((1 - DBState.db.hypaV3Settings.recentMemoryRatio - DBState.db.hypaV3Settings.similarMemoryRatio).toFixed(2))} />
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.enableSimilarityCorrectionLabel} bind:check={DBState.db.hypaV3Settings.enableSimilarityCorrection} />
-            </div>
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.preserveOrphanedMemoryLabel} bind:check={DBState.db.hypaV3Settings.preserveOrphanedMemory} />
-            </div>
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.applyRegexScriptWhenRerollingLabel} bind:check={DBState.db.hypaV3Settings.processRegexScript} />
-            </div>
-            <div class="flex mb-2">
-                <Check name={language.hypaV3Settings.doNotSummarizeUserMessageLabel} bind:check={DBState.db.hypaV3Settings.doNotSummarizeUserMessage} />
-            </div>
+
+            {#if DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.settings}
+                {@const settings = DBState.db.hypaV3Presets[DBState.db.hypaV3PresetId].settings}
+
+                <span class="text-textcolor">{language.SuperMemory} {language.model}</span>
+                <SelectInput className="mb-4" bind:value={settings.summarizationModel}>
+                    <OptionInput value="distilbart">distilbart-cnn-6-6 (Free/Local)</OptionInput>
+                    <OptionInput value="subModel">{language.submodel}</OptionInput>
+                </SelectInput>
+                <span class="text-textcolor">{language.summarizationPrompt} <Help key="summarizationPrompt"/></span>
+                <div class="mb-4">
+                    <TextAreaInput size="sm" placeholder={language.hypaV3Settings.supaMemoryPromptPlaceHolder} bind:value={settings.summarizationPrompt} />
+                </div>
+                {#await getMaxMemoryRatio() then maxMemoryRatio}
+                <span class="text-textcolor">{language.hypaV3Settings.maxMemoryTokensRatioLabel}</span>
+                <NumberInput marginBottom disabled size="sm" value={maxMemoryRatio} />
+                {:catch error}
+                <span class="mb-4 text-red-400">{language.hypaV3Settings.maxMemoryTokensRatioError}</span>
+                {/await}
+                <span class="text-textcolor">{language.hypaV3Settings.memoryTokensRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={settings.memoryTokensRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.extraSummarizationRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1 - settings.memoryTokensRatio} step={0.01} fixed={2} bind:value={settings.extraSummarizationRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.maxChatsPerSummaryLabel}</span>
+                <NumberInput marginBottom size="sm" min={1} bind:value={settings.maxChatsPerSummary} />
+                <span class="text-textcolor">{language.hypaV3Settings.recentMemoryRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={settings.recentMemoryRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.similarMemoryRatioLabel}</span>
+                <SliderInput marginBottom min={0} max={1} step={0.01} fixed={2} bind:value={settings.similarMemoryRatio} />
+                <span class="text-textcolor">{language.hypaV3Settings.randomMemoryRatioLabel}</span>
+                <NumberInput marginBottom disabled size="sm" value={parseFloat((1 - settings.recentMemoryRatio - settings.similarMemoryRatio).toFixed(2))} />
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.enableSimilarityCorrectionLabel} bind:check={settings.enableSimilarityCorrection} />
+                </div>
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.preserveOrphanedMemoryLabel} bind:check={settings.preserveOrphanedMemory} />
+                </div>
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.applyRegexScriptWhenRerollingLabel} bind:check={settings.processRegexScript} />
+                </div>
+                <div class="mb-2">
+                    <Check name={language.hypaV3Settings.doNotSummarizeUserMessageLabel} bind:check={settings.doNotSummarizeUserMessage} />
+                </div>
+            {/if}
+
+            <div class="mb-4"></div>
         {:else if (DBState.db.supaModelType !== 'none' && DBState.db.hypav2 === false && DBState.db.hypaV3 === false)}
             <span class="mb-2 text-textcolor2 text-sm text-wrap break-words max-w-full">{language.supaDesc}</span>
             <span class="text-textcolor mt-4">{language.SuperMemory} {language.model}</span>
@@ -663,14 +789,17 @@
         <span class="text-textcolor">{language.embedding}</span>
         <SelectInput className="mt-2 mb-2" bind:value={DBState.db.hypaModel}>
             {#if 'gpu' in navigator}
+                <OptionInput value="MiniLMGPU">MiniLM L6 v2 (GPU)</OptionInput>
                 <OptionInput value="nomicGPU">Nomic Embed Text v1.5 (GPU)</OptionInput>
                 <OptionInput value="bgeSmallEnGPU">BGE Small English (GPU)</OptionInput>
                 <OptionInput value="bgem3GPU">BGE Medium 3 (GPU)</OptionInput>
+                <OptionInput value="multiMiniLMGPU">Multilingual MiniLM L12 v2 (GPU)</OptionInput>
             {/if}
             <OptionInput value="MiniLM">MiniLM L6 v2 (CPU)</OptionInput>
             <OptionInput value="nomic">Nomic Embed Text v1.5 (CPU)</OptionInput>
             <OptionInput value="bgeSmallEn">BGE Small English (CPU)</OptionInput>
             <OptionInput value="bgem3">BGE Medium 3 (CPU)</OptionInput>
+            <OptionInput value="multiMiniLM">Multilingual MiniLM L12 v2 (CPU)</OptionInput>
             <OptionInput value="openai3small">OpenAI text-embedding-3-small</OptionInput>
             <OptionInput value="openai3large">OpenAI text-embedding-3-large</OptionInput>
             <OptionInput value="ada">OpenAI Ada</OptionInput>

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -749,9 +749,6 @@
                 <span class="text-textcolor">{language.hypaV3Settings.randomMemoryRatioLabel}</span>
                 <NumberInput marginBottom disabled size="sm" value={parseFloat((1 - settings.recentMemoryRatio - settings.similarMemoryRatio).toFixed(2))} />
                 <div class="mb-2">
-                    <Check name={language.hypaV3Settings.enableSimilarityCorrectionLabel} bind:check={settings.enableSimilarityCorrection} />
-                </div>
-                <div class="mb-2">
                     <Check name={language.hypaV3Settings.preserveOrphanedMemoryLabel} bind:check={settings.preserveOrphanedMemory} />
                 </div>
                 <div class="mb-2">
@@ -760,9 +757,28 @@
                 <div class="mb-2">
                     <Check name={language.hypaV3Settings.doNotSummarizeUserMessageLabel} bind:check={settings.doNotSummarizeUserMessage} />
                 </div>
+                <Arcodion name="Advanced Settings" styled>
+                    <div class="mb-2">
+                        <Check name="Use Experimental Implementation" bind:check={settings.useExperimentalImpl} />
+                    </div>
+                    {#if settings.useExperimentalImpl}
+                        <span class="text-textcolor">Summarization Requests Per Minute</span>
+                        <NumberInput marginBottom size="sm" min={1} bind:value={settings.summarizationRequestsPerMinute} />
+                        <span class="text-textcolor">Summarization Max Concurrent</span>
+                        <NumberInput marginBottom size="sm" min={1} max={10} bind:value={settings.summarizationMaxConcurrent} />
+                        <span class="text-textcolor">Embedding Requests Per Minute</span>
+                        <NumberInput marginBottom size="sm" min={1} bind:value={settings.embeddingRequestsPerMinute} />
+                        <span class="text-textcolor">Embedding Max Concurrent</span>
+                        <NumberInput marginBottom size="sm" min={1} max={10} bind:value={settings.embeddingMaxConcurrent} />
+                    {:else}
+                        <div class="mb-2">
+                            <Check name={language.hypaV3Settings.enableSimilarityCorrectionLabel} bind:check={settings.enableSimilarityCorrection} />
+                        </div>
+                    {/if}
+                </Arcodion>
             {/if}
 
-            <div class="mb-4"></div>
+            <div class="mb-8"></div>
         {:else if (DBState.db.supaModelType !== 'none' && DBState.db.hypav2 === false && DBState.db.hypaV3 === false)}
             <span class="mb-2 text-textcolor2 text-sm text-wrap break-words max-w-full">{language.supaDesc}</span>
             <span class="text-textcolor mt-4">{language.SuperMemory} {language.model}</span>

--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -1103,7 +1103,7 @@
             >
                 {language.hypaMemoryV2Modal}
             </Button>
-        {:else if DBState.db.supaModelType !== 'none' && DBState.db.hypaV3}
+        {:else if DBState.db.hypaV3}
             <Button
                 onclick={() => {
                     showHypaV3Alert()

--- a/src/lib/SideBars/Toggles.svelte
+++ b/src/lib/SideBars/Toggles.svelte
@@ -53,9 +53,9 @@
             <CheckInput bind:check={DBState.db.jailbreakToggle} name={language.jailbreakToggle} reverse />
         </div>
         {@render toggles(true)}
-        {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable}
+        {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable || DBState.db.hypaV3}
             <div class="flex mt-2 items-center w-full" class:justify-end={$MobileGUI}>
-                <CheckInput bind:check={chara.supaMemory} reverse name={DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
+                <CheckInput bind:check={chara.supaMemory} reverse name={DBState.db.hypaV3 ? language.ToggleHypaMemory : DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
             </div>
         {/if}
     </div>
@@ -64,9 +64,9 @@
         <CheckInput bind:check={DBState.db.jailbreakToggle} name={language.jailbreakToggle}/>
     </div>
     {@render toggles()}
-    {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable}
+    {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable || DBState.db.hypaV3}
         <div class="flex mt-2 items-center">
-            <CheckInput bind:check={chara.supaMemory} name={DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
+            <CheckInput bind:check={chara.supaMemory} name={DBState.db.hypaV3 ? language.ToggleHypaMemory : DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
         </div>
     {/if}
 {/if}

--- a/src/ts/process/memory/hypamemoryv2.ts
+++ b/src/ts/process/memory/hypamemoryv2.ts
@@ -1,0 +1,416 @@
+import localforage from "localforage";
+import { type HypaModel, localModels } from "./hypamemory";
+import { TaskRateLimiter, TaskCanceledError } from "./taskRateLimiter";
+import { runEmbedding } from "../transformers";
+import { globalFetch } from "src/ts/globalApi.svelte";
+import { getDatabase } from "src/ts/storage/database.svelte";
+import { appendLastPath } from "src/ts/util";
+
+export interface HypaProcessorV2Options {
+  model?: HypaModel;
+  customEmbeddingUrl?: string;
+  oaiKey?: string;
+  rateLimiter?: TaskRateLimiter;
+  onProgress?: (queuedTaskCount: number) => void;
+}
+
+export interface EmbeddingText<TMetadata> {
+  content: string;
+  metadata?: TMetadata;
+}
+
+export interface EmbeddingResult<TMetadata> extends EmbeddingText<TMetadata> {
+  embedding: EmbeddingVector;
+}
+
+export type EmbeddingVector = number[] | Float32Array;
+
+export class HypaProcessorV2<TMetadata> {
+  private static readonly LOG_PREFIX = "[HypaProcessorV2]";
+  public readonly options: HypaProcessorV2Options;
+  private vectors: Map<string, EmbeddingResult<TMetadata>> = new Map();
+  private forage: LocalForage = localforage.createInstance({
+    name: "hypaVector",
+  });
+
+  public constructor(options?: HypaProcessorV2Options) {
+    const db = getDatabase();
+
+    this.options = {
+      model: db.hypaModel || "MiniLM",
+      customEmbeddingUrl: db.hypaCustomSettings?.url?.trim() || "",
+      oaiKey: db.supaMemoryKey?.trim() || "",
+      rateLimiter: new TaskRateLimiter(),
+      ...options,
+    };
+  }
+
+  public async addTexts(ebdTexts: EmbeddingText<TMetadata>[]): Promise<void> {
+    await this.getEmbeds(ebdTexts, true);
+  }
+
+  public async similaritySearchScored(
+    query: string
+  ): Promise<[EmbeddingResult<TMetadata>, number][]> {
+    const results = await this.similaritySearchScoredBatch([query]);
+    return results[0];
+  }
+
+  public async similaritySearchScoredBatch(
+    queries: string[]
+  ): Promise<[EmbeddingResult<TMetadata>, number][][]> {
+    if (queries.length === 0) {
+      return [];
+    }
+
+    // Remove duplicate queries
+    const uniqueQueries = [...new Set(queries)];
+
+    // Convert queries to EmbeddingText array
+    const ebdTexts: EmbeddingText<TMetadata>[] = uniqueQueries.map((query) => ({
+      content: query,
+    }));
+
+    // Get query embeddings (don't save to memory)
+    const ebdResults = await this.getEmbeds(ebdTexts, false);
+
+    const scoredResultsMap = new Map<
+      string,
+      [EmbeddingResult<TMetadata>, number][]
+    >();
+
+    // Calculate similarity for each unique query
+    for (let i = 0; i < uniqueQueries.length; i++) {
+      const ebdResult = ebdResults[i];
+
+      const scoredVectors = Array.from(this.vectors.values())
+        .map((vector): [EmbeddingResult<TMetadata>, number] => [
+          vector,
+          this.similarity(ebdResult.embedding, vector.embedding),
+        ])
+        .sort((a, b) => b[1] - a[1]);
+
+      scoredResultsMap.set(uniqueQueries[i], scoredVectors);
+    }
+
+    return queries.map((query) => scoredResultsMap.get(query));
+  }
+
+  private async getEmbeds(
+    ebdTexts: EmbeddingText<TMetadata>[],
+    saveToMemory: boolean = true
+  ): Promise<EmbeddingResult<TMetadata>[]> {
+    if (ebdTexts.length === 0) {
+      return [];
+    }
+
+    const resultMap: Map<string, EmbeddingResult<TMetadata>> = new Map();
+    const toEmbed: EmbeddingText<TMetadata>[] = [];
+
+    // Load cache
+    const loadPromises = ebdTexts.map(async (item, index) => {
+      const { content, metadata } = item;
+
+      // Use if already in memory
+      if (this.vectors.has(content)) {
+        resultMap.set(content, this.vectors.get(content));
+        return;
+      }
+
+      try {
+        const cached = await this.forage.getItem<EmbeddingResult<TMetadata>>(
+          this.getCacheKey(content)
+        );
+
+        if (cached) {
+          // Debug log for cache hit
+          console.debug(
+            HypaProcessorV2.LOG_PREFIX,
+            `Cache hit for getting embedding ${index} with model ${this.options.model}`
+          );
+
+          // Add metadata
+          cached.metadata = metadata;
+
+          // Save to memory
+          if (saveToMemory) {
+            this.vectors.set(content, cached);
+          }
+
+          resultMap.set(content, cached);
+        } else {
+          toEmbed.push(item);
+        }
+      } catch (error) {
+        toEmbed.push(item);
+      }
+    });
+
+    await Promise.all(loadPromises);
+
+    if (toEmbed.length === 0) {
+      return ebdTexts.map((item) => resultMap.get(item.content));
+    }
+
+    // Chunking array
+    const chunkSize = await this.getOptimalChunkSize();
+
+    // Debug log for optimal chunk size
+    console.debug(
+      HypaProcessorV2.LOG_PREFIX,
+      `Optimal chunk size for ${this.options.model}: ${chunkSize}`
+    );
+
+    const chunks = this.chunkArray(toEmbed, chunkSize);
+
+    if (this.isLocalModel()) {
+      // Local model: Sequential processing
+      for (let i = 0; i < chunks.length; i++) {
+        // Progress callback
+        this.options.onProgress?.(chunks.length - i - 1);
+
+        const chunk = chunks[i];
+        const embeddings = await this.getLocalEmbeds(
+          chunk.map((item) => item.content)
+        );
+
+        const savePromises = embeddings.map(async (embedding, j) => {
+          const { content, metadata } = chunk[j];
+
+          const ebdResult: EmbeddingResult<TMetadata> = {
+            content,
+            embedding,
+            metadata,
+          };
+
+          // Save to DB
+          await this.forage.setItem(this.getCacheKey(content), {
+            content,
+            embedding,
+          });
+
+          // Save to memory
+          if (saveToMemory) {
+            this.vectors.set(content, ebdResult);
+          }
+
+          resultMap.set(content, ebdResult);
+        });
+
+        await Promise.all(savePromises);
+      }
+    } else {
+      // API model: Parallel processing
+      const embeddingTasks = chunks.map((chunk) => {
+        const contents = chunk.map((item) => item.content);
+
+        return () => {
+          // Progress callback
+          this.options.onProgress?.(this.options.rateLimiter.queuedTaskCount);
+
+          return this.getAPIEmbeds(contents);
+        };
+      });
+
+      const batchResult = await this.options.rateLimiter.executeBatch<
+        EmbeddingVector[]
+      >(embeddingTasks);
+      const errors: Error[] = [];
+
+      const chunksSavePromises = batchResult.results.map(async (result, i) => {
+        if (!result.success) {
+          errors.push(result.error);
+          return;
+        }
+
+        if (!result.data) {
+          errors.push(new Error("No embeddings found in the response."));
+          return;
+        }
+
+        const chunk = chunks[i];
+        const savePromises = result.data.map(async (embedding, j) => {
+          const { content, metadata } = chunk[j];
+
+          const ebdResult: EmbeddingResult<TMetadata> = {
+            content,
+            embedding,
+            metadata,
+          };
+
+          // Save to DB
+          await this.forage.setItem(this.getCacheKey(content), {
+            content,
+            embedding,
+          });
+
+          // Save to memory
+          if (saveToMemory) {
+            this.vectors.set(content, ebdResult);
+          }
+
+          resultMap.set(content, ebdResult);
+        });
+
+        await Promise.all(savePromises);
+      });
+
+      await Promise.all(chunksSavePromises);
+
+      // Throw major error if there are errors
+      if (errors.length > 0) {
+        const majorError =
+          errors.find((error) => !(error instanceof TaskCanceledError)) ||
+          errors[0];
+
+        throw majorError;
+      }
+    }
+
+    return ebdTexts.map((item) => resultMap.get(item.content));
+  }
+
+  private similarity(a: EmbeddingVector, b: EmbeddingVector): number {
+    let dot = 0;
+    let magA = 0;
+    let magB = 0;
+
+    for (let i = 0; i < a.length; i++) {
+      dot += a[i] * b[i];
+      magA += a[i] * a[i];
+      magB += b[i] * b[i];
+    }
+
+    return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+  }
+
+  private getCacheKey(content: string): string {
+    const db = getDatabase();
+    const suffix =
+      this.options.model === "custom" && db.hypaCustomSettings?.model?.trim()
+        ? `-${db.hypaCustomSettings.model.trim()}`
+        : "";
+
+    return `${content}|${this.options.model}${suffix}`;
+  }
+
+  private async getOptimalChunkSize(): Promise<number> {
+    // API
+    if (!this.isLocalModel()) {
+      return 50;
+    }
+
+    const isMobile = /Android|iPhone|iPad|iPod|webOS/i.test(
+      navigator.userAgent
+    );
+
+    // WebGPU
+    if ("gpu" in navigator) {
+      return isMobile ? 5 : 10;
+    }
+
+    // WASM
+    const cpuCores = navigator.hardwareConcurrency || 4;
+    const baseChunkSize = isMobile ? Math.floor(cpuCores / 2) : cpuCores;
+
+    return Math.min(baseChunkSize, 10);
+  }
+
+  private isLocalModel(): boolean {
+    return Object.keys(localModels.models).includes(this.options.model);
+  }
+
+  private chunkArray<T>(array: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size));
+    }
+
+    return chunks;
+  }
+
+  private async getLocalEmbeds(contents: string[]): Promise<EmbeddingVector[]> {
+    const results: Float32Array[] = await runEmbedding(
+      contents,
+      localModels.models[this.options.model],
+      localModels.gpuModels.includes(this.options.model) ? "webgpu" : "wasm"
+    );
+
+    return results;
+  }
+
+  private async getAPIEmbeds(contents: string[]): Promise<EmbeddingVector[]> {
+    const db = getDatabase();
+    let response = null;
+
+    if (this.options.model === "custom") {
+      if (!this.options.customEmbeddingUrl) {
+        throw new Error("Custom model requires a Custom Server URL");
+      }
+
+      const replaceUrl = this.options.customEmbeddingUrl.endsWith("/embeddings")
+        ? this.options.customEmbeddingUrl
+        : appendLastPath(this.options.customEmbeddingUrl, "embeddings");
+
+      const fetchArgs = {
+        headers: {
+          ...(db.hypaCustomSettings?.key?.trim()
+            ? { Authorization: "Bearer " + db.hypaCustomSettings.key.trim() }
+            : {}),
+        },
+        body: {
+          input: contents,
+          ...(db.hypaCustomSettings?.model?.trim()
+            ? { model: db.hypaCustomSettings.model.trim() }
+            : {}),
+        },
+      };
+
+      response = await globalFetch(replaceUrl, fetchArgs);
+    } else if (
+      ["ada", "openai3small", "openai3large"].includes(this.options.model)
+    ) {
+      const models = {
+        ada: "text-embedding-ada-002",
+        openai3small: "text-embedding-3-small",
+        openai3large: "text-embedding-3-large",
+      };
+
+      const fetchArgs = {
+        headers: {
+          Authorization:
+            "Bearer " +
+            (this.options.oaiKey?.trim() || db.supaMemoryKey?.trim()),
+        },
+        body: {
+          input: contents,
+          model: models[this.options.model],
+        },
+      };
+
+      response = await globalFetch(
+        "https://api.openai.com/v1/embeddings",
+        fetchArgs
+      );
+    } else {
+      throw new Error(`Unsupported model: ${this.options.model}`);
+    }
+
+    if (!response.ok || !response.data.data) {
+      throw new Error(JSON.stringify(response.data));
+    }
+
+    const embeddings: EmbeddingVector[] = response.data.data.map(
+      (item: { embedding: EmbeddingVector }) => {
+        if (!item.embedding) {
+          throw new Error("No embeddings found in the response.");
+        }
+
+        return item.embedding;
+      }
+    );
+
+    return embeddings;
+  }
+}

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1,8 +1,4 @@
-import {
-  type VectorArray,
-  type memoryVector,
-  HypaProcesser,
-} from "./hypamemory";
+import { type memoryVector, HypaProcesser, similarity } from "./hypamemory";
 import {
   type Chat,
   type character,
@@ -12,14 +8,26 @@ import {
 import { type OpenAIChat } from "../index.svelte";
 import { requestChatData } from "../request";
 import { runSummarizer } from "../transformers";
-import { globalFetch } from "src/ts/globalApi.svelte";
 import { parseChatML } from "src/ts/parser.svelte";
 import { type ChatTokenizer } from "src/ts/tokenizer";
 
-interface Summary {
-  text: string;
-  chatMemos: Set<string>;
-  isImportant: boolean;
+export interface HypaV3Preset {
+  name: string;
+  settings: HypaV3Settings;
+}
+
+export interface HypaV3Settings {
+  summarizationModel: string;
+  summarizationPrompt: string;
+  memoryTokensRatio: number;
+  extraSummarizationRatio: number;
+  maxChatsPerSummary: number;
+  recentMemoryRatio: number;
+  similarMemoryRatio: number;
+  enableSimilarityCorrection: boolean;
+  preserveOrphanedMemory: boolean;
+  processRegexScript: boolean;
+  doNotSummarizeUserMessage: boolean;
 }
 
 interface HypaV3Data {
@@ -36,227 +44,28 @@ export interface SerializableHypaV3Data {
   lastSelectedSummaries?: number[];
 }
 
+interface Summary {
+  text: string;
+  chatMemos: Set<string>;
+  isImportant: boolean;
+}
+
 interface SummaryChunk {
   text: string;
   summary: Summary;
 }
 
+export interface HypaV3Result {
+  currentTokens: number;
+  chats: OpenAIChat[];
+  error?: string;
+  memory?: SerializableHypaV3Data;
+}
+
+const logPrefix = "[HypaV3]";
+const memoryPromptTag = "Past Events Summary";
 const minChatsForSimilarity = 3;
-const maxSummarizationFailures = 3;
 const summarySeparator = "\n\n";
-
-// Helper function to check if one Set is a subset of another
-function isSubset(subset: Set<string>, superset: Set<string>): boolean {
-  for (const elem of subset) {
-    if (!superset.has(elem)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function toSerializableHypaV3Data(data: HypaV3Data): SerializableHypaV3Data {
-  return {
-    ...data,
-    summaries: data.summaries.map((summary) => ({
-      ...summary,
-      chatMemos: [...summary.chatMemos],
-    })),
-  };
-}
-
-function toHypaV3Data(serialData: SerializableHypaV3Data): HypaV3Data {
-  return {
-    ...serialData,
-    summaries: serialData.summaries.map((summary) => ({
-      ...summary,
-      // Convert null back to undefined (JSON serialization converts undefined to null)
-      chatMemos: new Set(
-        summary.chatMemos.map((memo) => (memo === null ? undefined : memo))
-      ),
-    })),
-  };
-}
-
-function encapsulateMemoryPrompt(memoryPrompt: string): string {
-  return `<Past Events Summary>${memoryPrompt}</Past Events Summary>`;
-}
-
-function cleanOrphanedSummary(chats: OpenAIChat[], data: HypaV3Data): void {
-  // Collect all memos from current chats
-  const currentChatMemos = new Set(chats.map((chat) => chat.memo));
-  const originalLength = data.summaries.length;
-
-  // Filter summaries - keep only those whose chatMemos are subset of current chat memos
-  data.summaries = data.summaries.filter((summary) => {
-    return isSubset(summary.chatMemos, currentChatMemos);
-  });
-
-  const removedCount = originalLength - data.summaries.length;
-
-  if (removedCount > 0) {
-    console.log(`[HypaV3] Cleaned ${removedCount} orphaned summaries.`);
-  }
-}
-
-export async function summarize(
-  oaiChats: OpenAIChat[]
-): Promise<{ success: boolean; data: string }> {
-  const db = getDatabase();
-  const stringifiedChats = oaiChats
-    .map((chat) => `${chat.role}: ${chat.content}`)
-    .join("\n");
-
-  if (db.supaModelType === "distilbart") {
-    try {
-      const summaryText = (await runSummarizer(stringifiedChats)).trim();
-      return { success: true, data: summaryText };
-    } catch (error) {
-      return {
-        success: false,
-        data: error,
-      };
-    }
-  }
-
-  const summarizePrompt =
-    db.supaMemoryPrompt === ""
-      ? "[Summarize the ongoing role story, It must also remove redundancy and unnecessary text and content from the output.]"
-      : db.supaMemoryPrompt;
-
-  switch (db.supaModelType) {
-    case "instruct35": {
-      console.log(
-        "[HypaV3] Using openAI gpt-3.5-turbo-instruct for summarization."
-      );
-
-      const requestPrompt = `${stringifiedChats}\n\n${summarizePrompt}\n\nOutput:`;
-      const response = await globalFetch(
-        "https://api.openai.com/v1/completions",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: "Bearer " + db.supaMemoryKey,
-          },
-          body: {
-            model: "gpt-3.5-turbo-instruct",
-            prompt: requestPrompt,
-            max_tokens: db.maxResponse,
-            temperature: 0,
-          },
-        }
-      );
-
-      try {
-        if (!response.ok) {
-          return {
-            success: false,
-            data: JSON.stringify(response),
-          };
-        }
-
-        const summaryText =
-          response.data?.choices?.[0]?.message?.content?.trim();
-
-        if (!summaryText) {
-          return {
-            success: false,
-            data: JSON.stringify(response),
-          };
-        }
-
-        return { success: true, data: summaryText };
-      } catch (error) {
-        return {
-          success: false,
-          data: error,
-        };
-      }
-    }
-
-    case "subModel": {
-      console.log(`[HypaV3] Using ax model ${db.subModel} for summarization.`);
-
-      const requestMessages: OpenAIChat[] = parseChatML(
-        summarizePrompt.replaceAll("{{slot}}", stringifiedChats)
-      ) ?? [
-        {
-          role: "user",
-          content: stringifiedChats,
-        },
-        {
-          role: "system",
-          content: summarizePrompt,
-        },
-      ];
-
-      const response = await requestChatData(
-        {
-          formated: requestMessages,
-          bias: {},
-          useStreaming: false,
-          noMultiGen: true,
-        },
-        "memory"
-      );
-
-      if (response.type === "streaming" || response.type === "multiline") {
-        return {
-          success: false,
-          data: "unexpected response type",
-        };
-      }
-
-      if (response.type === "fail") {
-        return {
-          success: false,
-          data: response.result,
-        };
-      }
-
-      return { success: true, data: response.result.trim() };
-    }
-
-    default: {
-      return {
-        success: false,
-        data: `unsupported model ${db.supaModelType} for summarization`,
-      };
-    }
-  }
-}
-
-async function retryableSummarize(
-  oaiChats: OpenAIChat[]
-): Promise<{ success: boolean; data: string }> {
-  let summarizationFailures = 0;
-
-  while (summarizationFailures < maxSummarizationFailures) {
-    console.log(
-      "[HypaV3] Attempting summarization:",
-      "\nAttempt:",
-      summarizationFailures + 1,
-      "\nTarget:",
-      oaiChats
-    );
-
-    const summarizeResult = await summarize(oaiChats);
-
-    if (!summarizeResult.success) {
-      console.log("[HypaV3] Summarization failed:", summarizeResult.data);
-      summarizationFailures++;
-
-      if (summarizationFailures >= maxSummarizationFailures) {
-        return summarizeResult;
-      }
-
-      continue;
-    }
-
-    return summarizeResult;
-  }
-}
 
 export async function hypaMemoryV3(
   chats: OpenAIChat[],
@@ -265,24 +74,53 @@ export async function hypaMemoryV3(
   room: Chat,
   char: character | groupChat,
   tokenizer: ChatTokenizer
-): Promise<{
-  currentTokens: number;
-  chats: OpenAIChat[];
-  error?: string;
-  memory?: SerializableHypaV3Data;
-}> {
+): Promise<HypaV3Result> {
+  try {
+    return await hypaMemoryV3Main(
+      chats,
+      currentTokens,
+      maxContextTokens,
+      room,
+      char,
+      tokenizer
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      // Standard Error instance
+      error.message = `${logPrefix} ${error.message}`;
+      throw error;
+    }
+
+    // Fallback for non-Error object
+    let errorMessage: string;
+
+    try {
+      errorMessage = JSON.stringify(error);
+    } catch {
+      errorMessage = String(error);
+    }
+
+    throw new Error(`${logPrefix} ${errorMessage}`);
+  }
+}
+
+async function hypaMemoryV3Main(
+  chats: OpenAIChat[],
+  currentTokens: number,
+  maxContextTokens: number,
+  room: Chat,
+  char: character | groupChat,
+  tokenizer: ChatTokenizer
+): Promise<HypaV3Result> {
   const db = getDatabase();
+  const settings = getCurrentHypaV3Preset().settings;
 
   // Validate settings
-  if (
-    db.hypaV3Settings.recentMemoryRatio + db.hypaV3Settings.similarMemoryRatio >
-    1
-  ) {
+  if (settings.recentMemoryRatio + settings.similarMemoryRatio > 1) {
     return {
       currentTokens,
       chats,
-      error:
-        "[HypaV3] The sum of Recent Memory Ratio and Similar Memory Ratio is greater than 1.",
+      error: `${logPrefix} The sum of Recent Memory Ratio and Similar Memory Ratio is greater than 1.`,
     };
   }
 
@@ -300,7 +138,7 @@ export async function hypaMemoryV3(
   }
 
   // Clean orphaned summaries
-  if (!db.hypaV3Settings.preserveOrphanedMemory) {
+  if (!settings.preserveOrphanedMemory) {
     cleanOrphanedSummary(chats, data);
   }
 
@@ -324,13 +162,15 @@ export async function hypaMemoryV3(
     }
   }
 
+  console.log(logPrefix, "Starting index:", startIdx);
+
   // Reserve memory tokens
   const emptyMemoryTokens = await tokenizer.tokenizeChat({
     role: "system",
-    content: encapsulateMemoryPrompt(""),
+    content: wrapWithXml(memoryPromptTag, ""),
   });
   const memoryTokens = Math.floor(
-    maxContextTokens * db.hypaV3Settings.memoryTokensRatio
+    maxContextTokens * settings.memoryTokensRatio
   );
   const shouldReserveEmptyMemoryTokens =
     data.summaries.length === 0 &&
@@ -341,16 +181,16 @@ export async function hypaMemoryV3(
 
   if (shouldReserveEmptyMemoryTokens) {
     currentTokens += emptyMemoryTokens;
-    console.log("[HypaV3] Reserved empty memory tokens:", emptyMemoryTokens);
+    console.log(logPrefix, "Reserved empty memory tokens:", emptyMemoryTokens);
   } else {
     currentTokens += memoryTokens;
-    console.log("[HypaV3] Reserved max memory tokens:", memoryTokens);
+    console.log(logPrefix, "Reserved max memory tokens:", memoryTokens);
   }
 
   // If summarization is needed
-  let summarizationMode = currentTokens > maxContextTokens;
+  const summarizationMode = currentTokens > maxContextTokens;
   const targetTokens =
-    maxContextTokens * (1 - db.hypaV3Settings.extraSummarizationRatio);
+    maxContextTokens * (1 - settings.extraSummarizationRatio);
 
   while (summarizationMode) {
     if (currentTokens <= targetTokens) {
@@ -364,7 +204,7 @@ export async function hypaMemoryV3(
         return {
           currentTokens,
           chats,
-          error: `[HypaV3] Cannot summarize further: input token count (${currentTokens}) exceeds max context size (${maxContextTokens}), but minimum ${minChatsForSimilarity} messages required.`,
+          error: `${logPrefix} Cannot summarize further: input token count (${currentTokens}) exceeds max context size (${maxContextTokens}), but minimum ${minChatsForSimilarity} messages required.`,
           memory: toSerializableHypaV3Data(data),
         };
       }
@@ -372,13 +212,14 @@ export async function hypaMemoryV3(
 
     const toSummarize: OpenAIChat[] = [];
     const endIdx = Math.min(
-      startIdx + db.hypaV3Settings.maxChatsPerSummary,
+      startIdx + settings.maxChatsPerSummary,
       chats.length - minChatsForSimilarity
     );
     let toSummarizeTokens = 0;
 
     console.log(
-      "[HypaV3] Evaluating summarization batch:",
+      logPrefix,
+      "Evaluating summarization batch:",
       "\nCurrent Tokens:",
       currentTokens,
       "\nMax Context Tokens:",
@@ -390,7 +231,7 @@ export async function hypaMemoryV3(
       "\nChat Count:",
       endIdx - startIdx,
       "\nMax Chats Per Summary:",
-      db.hypaV3Settings.maxChatsPerSummary
+      settings.maxChatsPerSummary
     );
 
     for (let i = startIdx; i < endIdx; i++) {
@@ -398,7 +239,8 @@ export async function hypaMemoryV3(
       const chatTokens = await tokenizer.tokenizeChat(chat);
 
       console.log(
-        "[HypaV3] Evaluating chat:",
+        logPrefix,
+        "Evaluating chat:",
         "\nIndex:",
         i,
         "\nRole:",
@@ -411,19 +253,27 @@ export async function hypaMemoryV3(
 
       toSummarizeTokens += chatTokens;
 
-      if (i === 0 || !chat.content.trim()) {
-        console.log(
-          `[HypaV3] Skipping ${
-            i === 0 ? "[Start a new chat]" : "empty content"
-          } at index ${i}`
-        );
-
+      if (
+        chat.name === "example_user" ||
+        chat.name === "example_assistant" ||
+        chat.memo === "NewChatExample"
+      ) {
+        console.log(logPrefix, `Skipping example chat at index ${i}`);
         continue;
       }
 
-      if (db.hypaV3Settings.doNotSummarizeUserMessage && chat.role === "user") {
-        console.log(`[HypaV3] Skipping user role at index ${i}`);
+      if (chat.memo === "NewChat") {
+        console.log(logPrefix, `Skipping new chat at index ${i}`);
+        continue;
+      }
 
+      if (chat.content.trim().length === 0) {
+        console.log(logPrefix, `Skipping empty chat at index ${i}`);
+        continue;
+      }
+
+      if (settings.doNotSummarizeUserMessage && chat.role === "user") {
+        console.log(logPrefix, `Skipping user role at index ${i}`);
         continue;
       }
 
@@ -436,24 +286,35 @@ export async function hypaMemoryV3(
       currentTokens - toSummarizeTokens < targetTokens
     ) {
       console.log(
-        `[HypaV3] Stopping summarization: currentTokens(${currentTokens}) - toSummarizeTokens(${toSummarizeTokens}) < targetTokens(${targetTokens})`
+        logPrefix,
+        "Stopping summarization:",
+        `\ncurrentTokens(${currentTokens}) - toSummarizeTokens(${toSummarizeTokens}) < targetTokens(${targetTokens})`
       );
       break;
     }
 
     // Attempt summarization
     if (toSummarize.length > 0) {
-      const summarizeResult = await retryableSummarize(toSummarize);
+      console.log(
+        logPrefix,
+        "Attempting summarization:",
+        "\nTarget:",
+        toSummarize
+      );
 
-      if (
-        !summarizeResult.success ||
-        !summarizeResult.data ||
-        summarizeResult.data.trim().length === 0
-      ) {
+      const summarizeResult = await summarize(toSummarize);
+
+      if (!summarizeResult.success) {
+        console.log(
+          logPrefix,
+          "Summarization failed:",
+          `\n${summarizeResult.data}`
+        );
+
         return {
           currentTokens,
           chats,
-          error: `[HypaV3] Summarization failed after maximum retries: ${summarizeResult.data}`,
+          error: `${logPrefix} Summarization failed: ${summarizeResult.data}`,
           memory: toSerializableHypaV3Data(data),
         };
       }
@@ -470,9 +331,8 @@ export async function hypaMemoryV3(
   }
 
   console.log(
-    `[HypaV3] ${
-      summarizationMode ? "Completed" : "Skipped"
-    } summarization phase:`,
+    logPrefix,
+    `${summarizationMode ? "Completed" : "Skipped"} summarization phase:`,
     "\nCurrent Tokens:",
     currentTokens,
     "\nMax Context Tokens:",
@@ -484,7 +344,7 @@ export async function hypaMemoryV3(
   // Early return if no summaries
   if (data.summaries.length === 0) {
     // Generate final memory prompt
-    const memory = encapsulateMemoryPrompt("");
+    const memory = wrapWithXml(memoryPromptTag, "");
 
     const newChats: OpenAIChat[] = [
       {
@@ -496,7 +356,8 @@ export async function hypaMemoryV3(
     ];
 
     console.log(
-      "[HypaV3] Exiting function:",
+      logPrefix,
+      "Exiting function:",
       "\nCurrent Tokens:",
       currentTokens,
       "\nAll chats, including memory prompt:",
@@ -514,49 +375,50 @@ export async function hypaMemoryV3(
 
   const selectedSummaries: Summary[] = [];
   const randomMemoryRatio =
-    1 -
-    db.hypaV3Settings.recentMemoryRatio -
-    db.hypaV3Settings.similarMemoryRatio;
+    1 - settings.recentMemoryRatio - settings.similarMemoryRatio;
 
   // Select important summaries
-  const selectedImportantSummaries: Summary[] = [];
+  {
+    const selectedImportantSummaries: Summary[] = [];
 
-  for (const summary of data.summaries) {
-    if (summary.isImportant) {
-      const summaryTokens = await tokenizer.tokenizeChat({
-        role: "system",
-        content: summary.text + summarySeparator,
-      });
+    for (const summary of data.summaries) {
+      if (summary.isImportant) {
+        const summaryTokens = await tokenizer.tokenizeChat({
+          role: "system",
+          content: summary.text + summarySeparator,
+        });
 
-      if (summaryTokens > availableMemoryTokens) {
-        break;
+        if (summaryTokens > availableMemoryTokens) {
+          break;
+        }
+
+        selectedImportantSummaries.push(summary);
+
+        availableMemoryTokens -= summaryTokens;
       }
-
-      selectedImportantSummaries.push(summary);
-
-      availableMemoryTokens -= summaryTokens;
     }
+
+    selectedSummaries.push(...selectedImportantSummaries);
+
+    console.log(
+      logPrefix,
+      "After important memory selection:",
+      "\nSummary Count:",
+      selectedImportantSummaries.length,
+      "\nSummaries:",
+      selectedImportantSummaries,
+      "\nAvailable Memory Tokens:",
+      availableMemoryTokens
+    );
   }
-
-  selectedSummaries.push(...selectedImportantSummaries);
-
-  console.log(
-    "[HypaV3] After important memory selection:",
-    "\nSummary Count:",
-    selectedImportantSummaries.length,
-    "\nSummaries:",
-    selectedImportantSummaries,
-    "\nAvailable Memory Tokens:",
-    availableMemoryTokens
-  );
 
   // Select recent summaries
   const reservedRecentMemoryTokens = Math.floor(
-    availableMemoryTokens * db.hypaV3Settings.recentMemoryRatio
+    availableMemoryTokens * settings.recentMemoryRatio
   );
   let consumedRecentMemoryTokens = 0;
 
-  if (db.hypaV3Settings.recentMemoryRatio > 0) {
+  if (settings.recentMemoryRatio > 0) {
     const selectedRecentSummaries: Summary[] = [];
 
     // Target only summaries that haven't been selected yet
@@ -586,7 +448,8 @@ export async function hypaMemoryV3(
     selectedSummaries.push(...selectedRecentSummaries);
 
     console.log(
-      "[HypaV3] After recent memory selection:",
+      logPrefix,
+      "After recent memory selection:",
       "\nSummary Count:",
       selectedRecentSummaries.length,
       "\nSummaries:",
@@ -600,11 +463,11 @@ export async function hypaMemoryV3(
 
   // Select similar summaries
   let reservedSimilarMemoryTokens = Math.floor(
-    availableMemoryTokens * db.hypaV3Settings.similarMemoryRatio
+    availableMemoryTokens * settings.similarMemoryRatio
   );
   let consumedSimilarMemoryTokens = 0;
 
-  if (db.hypaV3Settings.similarMemoryRatio > 0) {
+  if (settings.similarMemoryRatio > 0) {
     const selectedSimilarSummaries: Summary[] = [];
 
     // Utilize unused token space from recent selection
@@ -614,7 +477,8 @@ export async function hypaMemoryV3(
 
       reservedSimilarMemoryTokens += unusedRecentTokens;
       console.log(
-        "[HypaV3] Additional available token space for similar memory:",
+        logPrefix,
+        "Additional available token space for similar memory:",
         "\nFrom recent:",
         unusedRecentTokens
       );
@@ -641,7 +505,7 @@ export async function hypaMemoryV3(
       );
     });
 
-    // Fetch memory from summaryChunks
+    // Initialize embedding processor
     const processor = new HypaProcesserEx(db.hypaModel);
     processor.oaikey = db.supaMemoryKey;
 
@@ -652,82 +516,99 @@ export async function hypaMemoryV3(
       return {
         currentTokens,
         chats,
-        error: `[HypaV3] Similarity search failed: ${error}`,
+        error: `${logPrefix} Similarity search failed: ${error}`,
         memory: toSerializableHypaV3Data(data),
       };
     }
 
     const scoredSummaries = new Map<Summary, number>();
+    const recentChats = chats
+      .slice(-minChatsForSimilarity)
+      .filter((chat) => chat.content.trim().length > 0);
 
-    // (1) Raw recent chat search
-    for (let i = 0; i < minChatsForSimilarity; i++) {
-      const pop = chats[chats.length - i - 1];
+    if (settings.enableSimilarityCorrection && recentChats.length > 1) {
+      // Raw + Summarized recent chat search
+      // Summarizing is meaningful when there are more than 2 recent chats
 
-      if (!pop) break;
-
-      try {
-        const searched = await processor.similaritySearchScoredEx(pop.content);
-
-        for (const [chunk, similarity] of searched) {
-          const summary = chunk.summary;
-
-          scoredSummaries.set(
-            summary,
-            (scoredSummaries.get(summary) || 0) + similarity
-          );
-        }
-      } catch (error) {
-        return {
-          currentTokens,
-          chats,
-          error: `[HypaV3] Similarity search failed: ${error}`,
-          memory: toSerializableHypaV3Data(data),
-        };
-      }
-    }
-
-    // (2) Summarized recent chat search
-    if (db.hypaV3Settings.enableSimilarityCorrection) {
       // Attempt summarization
-      const recentChats = chats.slice(-minChatsForSimilarity);
-      const summarizeResult = await retryableSummarize(recentChats);
+      console.log(
+        logPrefix,
+        "Attempting summarization for similarity search:",
+        "\nTarget:",
+        recentChats
+      );
 
-      if (
-        !summarizeResult.success ||
-        !summarizeResult.data ||
-        summarizeResult.data.trim().length === 0
-      ) {
-        return {
-          currentTokens,
-          chats,
-          error: `[HypaV3] Summarization failed after maximum retries: ${summarizeResult.data}`,
-          memory: toSerializableHypaV3Data(data),
-        };
-      }
+      const summarizeResult = await summarize(recentChats);
 
-      try {
-        const searched = await processor.similaritySearchScoredEx(
-          summarizeResult.data
+      if (!summarizeResult.success) {
+        console.log(
+          logPrefix,
+          "Summarization failed:",
+          `\n${summarizeResult.data}`
         );
 
-        for (const [chunk, similarity] of searched) {
-          const summary = chunk.summary;
-
-          scoredSummaries.set(
-            summary,
-            (scoredSummaries.get(summary) || 0) + similarity
-          );
-        }
-      } catch (error) {
         return {
           currentTokens,
           chats,
-          error: `[HypaV3] Similarity search failed: ${error}`,
+          error: `${logPrefix} Summarization failed: ${summarizeResult.data}`,
           memory: toSerializableHypaV3Data(data),
         };
       }
 
-      console.log("[HypaV3] Similarity corrected.");
+      const queries = [
+        ...recentChats.map((chat) => chat.content),
+        summarizeResult.data,
+      ];
+
+      for (const query of queries) {
+        try {
+          const scoredChunks = await processor.similaritySearchScoredEx(query);
+
+          for (const [chunk, similarity] of scoredChunks) {
+            const summary = chunk.summary;
+
+            scoredSummaries.set(
+              summary,
+              (scoredSummaries.get(summary) || 0) + similarity
+            );
+          }
+        } catch (error) {
+          return {
+            currentTokens,
+            chats,
+            error: `${logPrefix} Similarity search failed: ${error}`,
+            memory: toSerializableHypaV3Data(data),
+          };
+        }
+      }
+
+      console.log(logPrefix, "Similarity corrected.");
+    } else if (recentChats.length > 0) {
+      // Raw recent chat search
+
+      const queries = recentChats.map((chat) => chat.content);
+
+      for (const query of queries) {
+        try {
+          const scoredChunks = await processor.similaritySearchScoredEx(query);
+
+          for (const [chunk, similarity] of scoredChunks) {
+            const summary = chunk.summary;
+
+            scoredSummaries.set(
+              summary,
+              (scoredSummaries.get(summary) || 0) + similarity
+            );
+          }
+        } catch (error) {
+          return {
+            currentTokens,
+            chats,
+            error: `${logPrefix} Similarity search failed: ${error}`,
+            memory: toSerializableHypaV3Data(data),
+          };
+        }
+      }
     }
 
     // Sort in descending order
@@ -744,7 +625,8 @@ export async function hypaMemoryV3(
 
       /*
       console.log(
-        "[HypaV3] Trying to add similar summary:",
+        logPrefix,
+        "Trying to add similar summary:",
         "\nSummary Tokens:",
         summaryTokens,
         "\nConsumed Similar Memory Tokens:",
@@ -752,7 +634,8 @@ export async function hypaMemoryV3(
         "\nReserved Tokens:",
         reservedSimilarMemoryTokens,
         "\nWould exceed:",
-        summaryTokens + consumedSimilarMemoryTokens > reservedSimilarMemoryTokens
+        summaryTokens + consumedSimilarMemoryTokens >
+          reservedSimilarMemoryTokens
       );
       */
 
@@ -761,7 +644,9 @@ export async function hypaMemoryV3(
         reservedSimilarMemoryTokens
       ) {
         console.log(
-          `[HypaV3] Stopping similar memory selection: consumedSimilarMemoryTokens(${consumedSimilarMemoryTokens}) + summaryTokens(${summaryTokens}) > reservedSimilarMemoryTokens(${reservedSimilarMemoryTokens})`
+          logPrefix,
+          "Stopping similar memory selection:",
+          `\nconsumedSimilarMemoryTokens(${consumedSimilarMemoryTokens}) + summaryTokens(${summaryTokens}) > reservedSimilarMemoryTokens(${reservedSimilarMemoryTokens})`
         );
         break;
       }
@@ -773,7 +658,8 @@ export async function hypaMemoryV3(
     selectedSummaries.push(...selectedSimilarSummaries);
 
     console.log(
-      "[HypaV3] After similar memory selection:",
+      logPrefix,
+      "After similar memory selection:",
       "\nSummary Count:",
       selectedSimilarSummaries.length,
       "\nSummaries:",
@@ -802,7 +688,8 @@ export async function hypaMemoryV3(
 
     reservedRandomMemoryTokens += unusedRecentTokens + unusedSimilarTokens;
     console.log(
-      "[HypaV3] Additional available token space for random memory:",
+      logPrefix,
+      "Additional available token space for random memory:",
       "\nFrom recent:",
       unusedRecentTokens,
       "\nFrom similar:",
@@ -837,7 +724,8 @@ export async function hypaMemoryV3(
     selectedSummaries.push(...selectedRandomSummaries);
 
     console.log(
-      "[HypaV3] After random memory selection:",
+      logPrefix,
+      "After random memory selection:",
       "\nSummary Count:",
       selectedRandomSummaries.length,
       "\nSummaries:",
@@ -855,7 +743,8 @@ export async function hypaMemoryV3(
   );
 
   // Generate final memory prompt
-  const memory = encapsulateMemoryPrompt(
+  const memory = wrapWithXml(
+    memoryPromptTag,
     selectedSummaries.map((e) => e.text).join(summarySeparator)
   );
   const realMemoryTokens = await tokenizer.tokenizeChat({
@@ -873,7 +762,8 @@ export async function hypaMemoryV3(
   currentTokens += realMemoryTokens;
 
   console.log(
-    "[HypaV3] Final memory selection:",
+    logPrefix,
+    "Final memory selection:",
     "\nSummary Count:",
     selectedSummaries.length,
     "\nSummaries:",
@@ -886,7 +776,7 @@ export async function hypaMemoryV3(
 
   if (currentTokens > maxContextTokens) {
     throw new Error(
-      `[HypaV3] Unexpected error: input token count (${currentTokens}) exceeds max context size (${maxContextTokens})`
+      `Unexpected error: input token count (${currentTokens}) exceeds max context size (${maxContextTokens})`
     );
   }
 
@@ -905,7 +795,8 @@ export async function hypaMemoryV3(
   ];
 
   console.log(
-    "[HypaV3] Exiting function:",
+    logPrefix,
+    "Exiting function:",
     "\nCurrent Tokens:",
     currentTokens,
     "\nAll chats, including memory prompt:",
@@ -921,25 +812,206 @@ export async function hypaMemoryV3(
   };
 }
 
-type SummaryChunkVector = {
+function toHypaV3Data(serialData: SerializableHypaV3Data): HypaV3Data {
+  return {
+    ...serialData,
+    summaries: serialData.summaries.map((summary) => ({
+      ...summary,
+      // Convert null back to undefined (JSON serialization converts undefined to null)
+      chatMemos: new Set(
+        summary.chatMemos.map((memo) => (memo === null ? undefined : memo))
+      ),
+    })),
+  };
+}
+
+function toSerializableHypaV3Data(data: HypaV3Data): SerializableHypaV3Data {
+  return {
+    ...data,
+    summaries: data.summaries.map((summary) => ({
+      ...summary,
+      chatMemos: [...summary.chatMemos],
+    })),
+  };
+}
+
+function cleanOrphanedSummary(chats: OpenAIChat[], data: HypaV3Data): void {
+  // Collect all memos from current chats
+  const currentChatMemos = new Set(chats.map((chat) => chat.memo));
+  const originalLength = data.summaries.length;
+
+  // Filter summaries - keep only those whose chatMemos are subset of current chat memos
+  data.summaries = data.summaries.filter((summary) => {
+    return isSubset(summary.chatMemos, currentChatMemos);
+  });
+
+  const removedCount = originalLength - data.summaries.length;
+
+  if (removedCount > 0) {
+    console.log(logPrefix, `Cleaned ${removedCount} orphaned summaries.`);
+  }
+}
+
+function isSubset(subset: Set<string>, superset: Set<string>): boolean {
+  for (const elem of subset) {
+    if (!superset.has(elem)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function wrapWithXml(tag: string, content: string): string {
+  return `<${tag}>${content}</${tag}>`;
+}
+
+export async function summarize(
+  oaiMessages: OpenAIChat[]
+): Promise<{ success: boolean; data: string }> {
+  const db = getDatabase();
+  const settings = getCurrentHypaV3Preset().settings;
+
+  const strMessages = oaiMessages
+    .map((chat) => `${chat.role}: ${chat.content}`)
+    .join("\n");
+
+  if (settings.summarizationModel === "distilbart") {
+    try {
+      const content = await runSummarizer(strMessages);
+
+      if (!content || content.trim().length === 0) {
+        return {
+          success: false,
+          data: "Empty summary returned",
+        };
+      }
+
+      return { success: true, data: content.trim() };
+    } catch (error) {
+      return {
+        success: false,
+        data: error,
+      };
+    }
+  }
+
+  const summarizationPrompt =
+    settings.summarizationPrompt.trim() === ""
+      ? "[Summarize the ongoing role story, It must also remove redundancy and unnecessary text and content from the output.]"
+      : settings.summarizationPrompt;
+
+  if (settings.summarizationModel === "subModel") {
+    console.log(logPrefix, `Using ax model ${db.subModel} for summarization.`);
+
+    const formated: OpenAIChat[] = parseChatML(
+      summarizationPrompt.replaceAll("{{slot}}", strMessages)
+    ) ?? [
+      {
+        role: "user",
+        content: strMessages,
+      },
+      {
+        role: "system",
+        content: summarizationPrompt,
+      },
+    ];
+
+    const response = await requestChatData(
+      {
+        formated,
+        bias: {},
+        useStreaming: false,
+        noMultiGen: true,
+      },
+      "memory"
+    );
+
+    if (response.type === "streaming" || response.type === "multiline") {
+      return {
+        success: false,
+        data: "Unexpected response type",
+      };
+    }
+
+    if (response.type === "fail") {
+      return {
+        success: false,
+        data: response.result,
+      };
+    }
+
+    if (!response.result || response.result.trim().length === 0) {
+      return {
+        success: false,
+        data: "Empty summary returned",
+      };
+    }
+
+    return { success: true, data: response.result.trim() };
+  }
+
+  return {
+    success: false,
+    data: `Unsupported model ${settings.summarizationModel} for summarization`,
+  };
+}
+
+function getCurrentHypaV3Preset(): HypaV3Preset {
+  const db = getDatabase();
+  const preset = db.hypaV3Presets?.[db.hypaV3PresetId];
+
+  if (!preset) {
+    throw new Error("Preset not found. Please select a valid preset.");
+  }
+
+  return preset;
+}
+
+export function createHypaV3Preset(
+  name = "New Preset",
+  existingSettings = {}
+): HypaV3Preset {
+  const settings: HypaV3Settings = {
+    summarizationModel: "subModel",
+    summarizationPrompt: "",
+    memoryTokensRatio: 0.2,
+    extraSummarizationRatio: 0,
+    maxChatsPerSummary: 6,
+    recentMemoryRatio: 0.4,
+    similarMemoryRatio: 0.4,
+    enableSimilarityCorrection: false,
+    preserveOrphanedMemory: false,
+    processRegexScript: false,
+    doNotSummarizeUserMessage: false,
+  };
+
+  if (
+    existingSettings &&
+    typeof existingSettings === "object" &&
+    !Array.isArray(existingSettings)
+  ) {
+    for (const [key, value] of Object.entries(existingSettings)) {
+      if (key in settings && typeof value === typeof settings[key]) {
+        settings[key] = value;
+      }
+    }
+  }
+
+  return {
+    name,
+    settings,
+  };
+}
+
+interface SummaryChunkVector {
   chunk: SummaryChunk;
   vector: memoryVector;
-};
+}
 
 class HypaProcesserEx extends HypaProcesser {
   // Maintain references to SummaryChunks and their associated memoryVectors
   summaryChunkVectors: SummaryChunkVector[] = [];
-
-  // Calculate dot product similarity between two vectors
-  similarity(a: VectorArray, b: VectorArray): number {
-    let dot = 0;
-
-    for (let i = 0; i < a.length; i++) {
-      dot += a[i] * b[i];
-    }
-
-    return dot;
-  }
 
   async addSummaryChunks(chunks: SummaryChunk[]): Promise<void> {
     // Maintain the superclass's caching structure by adding texts
@@ -977,7 +1049,7 @@ class HypaProcesserEx extends HypaProcesser {
     return this.summaryChunkVectors
       .map((scv) => ({
         chunk: scv.chunk,
-        similarity: this.similarity(queryVector, scv.vector.embedding),
+        similarity: similarity(queryVector, scv.vector.embedding),
       }))
       .sort((a, b) => (a.similarity > b.similarity ? -1 : 0))
       .map((result) => [result.chunk, result.similarity]);

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1,4 +1,6 @@
 import { type memoryVector, HypaProcesser, similarity } from "./hypamemory";
+import { TaskRateLimiter } from "./taskRateLimiter";
+import { type EmbeddingText, HypaProcessorV2 } from "./hypamemoryv2";
 import {
   type Chat,
   type character,
@@ -9,6 +11,7 @@ import { type OpenAIChat } from "../index.svelte";
 import { requestChatData } from "../request";
 import { runSummarizer } from "../transformers";
 import { parseChatML } from "src/ts/parser.svelte";
+import { hypaV3ProgressStore } from "src/ts/stores.svelte";
 import { type ChatTokenizer } from "src/ts/tokenizer";
 
 export interface HypaV3Preset {
@@ -28,6 +31,12 @@ export interface HypaV3Settings {
   preserveOrphanedMemory: boolean;
   processRegexScript: boolean;
   doNotSummarizeUserMessage: boolean;
+  // Experimental
+  useExperimentalImpl: boolean;
+  summarizationRequestsPerMinute: number;
+  summarizationMaxConcurrent: number;
+  embeddingRequestsPerMinute: number;
+  embeddingMaxConcurrent: number;
 }
 
 interface HypaV3Data {
@@ -76,6 +85,21 @@ export async function hypaMemoryV3(
   tokenizer: ChatTokenizer
 ): Promise<HypaV3Result> {
   try {
+    const settings = getCurrentHypaV3Preset().settings;
+
+    if (settings.useExperimentalImpl) {
+      console.log(logPrefix, "Using experimental implementation.");
+
+      return await hypaMemoryV3MainExp(
+        chats,
+        currentTokens,
+        maxContextTokens,
+        room,
+        char,
+        tokenizer
+      );
+    }
+
     return await hypaMemoryV3Main(
       chats,
       currentTokens,
@@ -102,6 +126,787 @@ export async function hypaMemoryV3(
 
     throw new Error(`${logPrefix} ${errorMessage}`);
   }
+}
+
+async function hypaMemoryV3MainExp(
+  chats: OpenAIChat[],
+  currentTokens: number,
+  maxContextTokens: number,
+  room: Chat,
+  char: character | groupChat,
+  tokenizer: ChatTokenizer
+): Promise<HypaV3Result> {
+  const db = getDatabase();
+  const settings = getCurrentHypaV3Preset().settings;
+
+  // Validate settings
+  if (settings.recentMemoryRatio + settings.similarMemoryRatio > 1) {
+    return {
+      currentTokens,
+      chats,
+      error: `${logPrefix} The sum of Recent Memory Ratio and Similar Memory Ratio is greater than 1.`,
+    };
+  }
+
+  // Initial token correction
+  currentTokens -= db.maxResponse;
+
+  // Load existing hypa data if available
+  let data: HypaV3Data = {
+    summaries: [],
+    lastSelectedSummaries: [],
+  };
+
+  if (room.hypaV3Data) {
+    data = toHypaV3Data(room.hypaV3Data);
+  }
+
+  // Clean orphaned summaries
+  if (!settings.preserveOrphanedMemory) {
+    cleanOrphanedSummary(chats, data);
+  }
+
+  // Determine starting index
+  let startIdx = 0;
+
+  if (data.summaries.length > 0) {
+    const lastSummary = data.summaries.at(-1);
+    const lastChatIndex = chats.findIndex(
+      (chat) => chat.memo === [...lastSummary.chatMemos].at(-1)
+    );
+
+    if (lastChatIndex !== -1) {
+      startIdx = lastChatIndex + 1;
+
+      // Exclude tokens from summarized chats
+      const summarizedChats = chats.slice(0, lastChatIndex + 1);
+      for (const chat of summarizedChats) {
+        currentTokens -= await tokenizer.tokenizeChat(chat);
+      }
+    }
+  }
+
+  console.log(logPrefix, "Starting index:", startIdx);
+
+  // Reserve memory tokens
+  const emptyMemoryTokens = await tokenizer.tokenizeChat({
+    role: "system",
+    content: wrapWithXml(memoryPromptTag, ""),
+  });
+  const memoryTokens = Math.floor(
+    maxContextTokens * settings.memoryTokensRatio
+  );
+  const shouldReserveEmptyMemoryTokens =
+    data.summaries.length === 0 &&
+    currentTokens + emptyMemoryTokens <= maxContextTokens;
+  let availableMemoryTokens = shouldReserveEmptyMemoryTokens
+    ? 0
+    : memoryTokens - emptyMemoryTokens;
+
+  if (shouldReserveEmptyMemoryTokens) {
+    currentTokens += emptyMemoryTokens;
+    console.log(logPrefix, "Reserved empty memory tokens:", emptyMemoryTokens);
+  } else {
+    currentTokens += memoryTokens;
+    console.log(logPrefix, "Reserved max memory tokens:", memoryTokens);
+  }
+
+  // If summarization is needed
+  const summarizationMode = currentTokens > maxContextTokens;
+  const targetTokens =
+    maxContextTokens * (1 - settings.extraSummarizationRatio);
+  const toSummarizeArray: OpenAIChat[][] = [];
+
+  while (summarizationMode) {
+    if (currentTokens <= targetTokens) {
+      break;
+    }
+
+    if (chats.length - startIdx <= minChatsForSimilarity) {
+      if (currentTokens <= maxContextTokens) {
+        break;
+      } else {
+        return {
+          currentTokens,
+          chats,
+          error: `${logPrefix} Cannot summarize further: input token count (${currentTokens}) exceeds max context size (${maxContextTokens}), but minimum ${minChatsForSimilarity} messages required.`,
+          memory: toSerializableHypaV3Data(data),
+        };
+      }
+    }
+
+    const toSummarize: OpenAIChat[] = [];
+    let toSummarizeTokens = 0;
+    let currentIndex = startIdx;
+
+    console.log(
+      logPrefix,
+      "Evaluating summarization batch:",
+      "\nCurrent Tokens:",
+      currentTokens,
+      "\nMax Context Tokens:",
+      maxContextTokens,
+      "\nStart Index:",
+      startIdx,
+      "\nMax Chats Per Summary:",
+      settings.maxChatsPerSummary
+    );
+
+    while (
+      toSummarize.length < settings.maxChatsPerSummary &&
+      currentIndex < chats.length - minChatsForSimilarity
+    ) {
+      const chat = chats[currentIndex];
+      const chatTokens = await tokenizer.tokenizeChat(chat);
+
+      console.log(
+        logPrefix,
+        "Evaluating chat:",
+        "\nIndex:",
+        currentIndex,
+        "\nRole:",
+        chat.role,
+        "\nContent:",
+        "\n" + chat.content,
+        "\nTokens:",
+        chatTokens
+      );
+
+      toSummarizeTokens += chatTokens;
+
+      let shouldSummarize = true;
+
+      if (
+        chat.name === "example_user" ||
+        chat.name === "example_assistant" ||
+        chat.memo === "NewChatExample"
+      ) {
+        console.log(
+          logPrefix,
+          `Skipping example chat at index ${currentIndex}`
+        );
+        shouldSummarize = false;
+      }
+
+      if (chat.memo === "NewChat") {
+        console.log(logPrefix, `Skipping new chat at index ${currentIndex}`);
+        shouldSummarize = false;
+      }
+
+      if (chat.content.trim().length === 0) {
+        console.log(logPrefix, `Skipping empty chat at index ${currentIndex}`);
+        shouldSummarize = false;
+      }
+
+      if (settings.doNotSummarizeUserMessage && chat.role === "user") {
+        console.log(logPrefix, `Skipping user role at index ${currentIndex}`);
+        shouldSummarize = false;
+      }
+
+      if (shouldSummarize) {
+        toSummarize.push(chat);
+      }
+
+      currentIndex++;
+    }
+
+    // Stop summarization if further reduction would go below target tokens (unless we're over max tokens)
+    if (
+      currentTokens <= maxContextTokens &&
+      currentTokens - toSummarizeTokens < targetTokens
+    ) {
+      console.log(
+        logPrefix,
+        "Stopping summarization:",
+        `\ncurrentTokens(${currentTokens}) - toSummarizeTokens(${toSummarizeTokens}) < targetTokens(${targetTokens})`
+      );
+      break;
+    }
+
+    // Collect summarization batch
+    if (toSummarize.length > 0) {
+      console.log(
+        logPrefix,
+        "Collecting summarization batch:",
+        "\nTarget:",
+        toSummarize
+      );
+
+      toSummarizeArray.push([...toSummarize]);
+    }
+
+    currentTokens -= toSummarizeTokens;
+    startIdx = currentIndex;
+  }
+
+  // Process all collected summarization tasks
+  if (toSummarizeArray.length > 0) {
+    // Initialize rate limiter
+    const rateLimiter = new TaskRateLimiter({
+      tasksPerMinute: settings.summarizationRequestsPerMinute,
+      maxConcurrentTasks: settings.summarizationMaxConcurrent,
+    });
+
+    const summarizationTasks = toSummarizeArray.map((item) => () => {
+      hypaV3ProgressStore.set({
+        open: true,
+        miniMsg: `${rateLimiter.queuedTaskCount}`,
+        msg: `${logPrefix} Summarizing...`,
+        subMsg: `${rateLimiter.queuedTaskCount} queued`,
+      });
+
+      return summarize(item);
+    });
+
+    // Start of performance measurement: summarize
+    console.log(
+      logPrefix,
+      `Starting ${toSummarizeArray.length} summarization.`
+    );
+    const summarizeStartTime = performance.now();
+
+    const batchResult = await rateLimiter.executeBatch<{
+      success: boolean;
+      data: string;
+    }>(summarizationTasks);
+
+    const summarizeEndTime = performance.now();
+    console.debug(
+      `${logPrefix} summarization completed in ${
+        summarizeEndTime - summarizeStartTime
+      }ms`
+    );
+    // End of performance measurement: summarize
+
+    hypaV3ProgressStore.set({
+      open: false,
+      miniMsg: "",
+      msg: "",
+      subMsg: "",
+    });
+
+    // Note:
+    // We can't save some successful summaries to the DB temporarily
+    // because don't know the actual summarization model name.
+    // It is possible that the user can change the summarization model.
+    for (let i = 0; i < batchResult.results.length; i++) {
+      const result = batchResult.results[i];
+
+      // Push consecutive successes
+      if (!result.success || !result.data.success) {
+        console.log(
+          logPrefix,
+          "Summarization failed:",
+          `\n${!result.success ? result.error : result.data.data}`
+        );
+
+        return {
+          currentTokens,
+          chats,
+          error: `${logPrefix} Summarization failed: ${
+            !result.success ? result.error : result.data.data
+          }`,
+          memory: toSerializableHypaV3Data(data),
+        };
+      }
+
+      const summaryText = result.data.data;
+
+      data.summaries.push({
+        text: summaryText,
+        chatMemos: new Set(toSummarizeArray[i].map((chat) => chat.memo)),
+        isImportant: false,
+      });
+    }
+  }
+
+  console.log(
+    logPrefix,
+    `${summarizationMode ? "Completed" : "Skipped"} summarization phase:`,
+    "\nCurrent Tokens:",
+    currentTokens,
+    "\nMax Context Tokens:",
+    maxContextTokens,
+    "\nAvailable Memory Tokens:",
+    availableMemoryTokens
+  );
+
+  // Early return if no summaries
+  if (data.summaries.length === 0) {
+    // Generate final memory prompt
+    const memory = wrapWithXml(memoryPromptTag, "");
+
+    const newChats: OpenAIChat[] = [
+      {
+        role: "system",
+        content: memory,
+        memo: "supaMemory",
+      },
+      ...chats.slice(startIdx),
+    ];
+
+    console.log(
+      logPrefix,
+      "Exiting function:",
+      "\nCurrent Tokens:",
+      currentTokens,
+      "\nAll chats, including memory prompt:",
+      newChats,
+      "\nMemory Data:",
+      data
+    );
+
+    return {
+      currentTokens,
+      chats: newChats,
+      memory: toSerializableHypaV3Data(data),
+    };
+  }
+
+  const selectedSummaries: Summary[] = [];
+  const randomMemoryRatio =
+    1 - settings.recentMemoryRatio - settings.similarMemoryRatio;
+
+  // Select important summaries
+  {
+    const selectedImportantSummaries: Summary[] = [];
+
+    for (const summary of data.summaries) {
+      if (summary.isImportant) {
+        const summaryTokens = await tokenizer.tokenizeChat({
+          role: "system",
+          content: summary.text + summarySeparator,
+        });
+
+        if (summaryTokens > availableMemoryTokens) {
+          break;
+        }
+
+        selectedImportantSummaries.push(summary);
+
+        availableMemoryTokens -= summaryTokens;
+      }
+    }
+
+    selectedSummaries.push(...selectedImportantSummaries);
+
+    console.log(
+      logPrefix,
+      "After important memory selection:",
+      "\nSummary Count:",
+      selectedImportantSummaries.length,
+      "\nSummaries:",
+      selectedImportantSummaries,
+      "\nAvailable Memory Tokens:",
+      availableMemoryTokens
+    );
+  }
+
+  // Select recent summaries
+  const reservedRecentMemoryTokens = Math.floor(
+    availableMemoryTokens * settings.recentMemoryRatio
+  );
+  let consumedRecentMemoryTokens = 0;
+
+  if (settings.recentMemoryRatio > 0) {
+    const selectedRecentSummaries: Summary[] = [];
+
+    // Target only summaries that haven't been selected yet
+    const unusedSummaries = data.summaries.filter(
+      (e) => !selectedSummaries.includes(e)
+    );
+
+    // Add one by one from the end
+    for (let i = unusedSummaries.length - 1; i >= 0; i--) {
+      const summary = unusedSummaries[i];
+      const summaryTokens = await tokenizer.tokenizeChat({
+        role: "system",
+        content: summary.text + summarySeparator,
+      });
+
+      if (
+        summaryTokens + consumedRecentMemoryTokens >
+        reservedRecentMemoryTokens
+      ) {
+        break;
+      }
+
+      selectedRecentSummaries.push(summary);
+      consumedRecentMemoryTokens += summaryTokens;
+    }
+
+    selectedSummaries.push(...selectedRecentSummaries);
+
+    console.log(
+      logPrefix,
+      "After recent memory selection:",
+      "\nSummary Count:",
+      selectedRecentSummaries.length,
+      "\nSummaries:",
+      selectedRecentSummaries,
+      "\nReserved Tokens:",
+      reservedRecentMemoryTokens,
+      "\nConsumed Tokens:",
+      consumedRecentMemoryTokens
+    );
+  }
+
+  // Select similar summaries
+  let reservedSimilarMemoryTokens = Math.floor(
+    availableMemoryTokens * settings.similarMemoryRatio
+  );
+  let consumedSimilarMemoryTokens = 0;
+
+  if (settings.similarMemoryRatio > 0) {
+    const selectedSimilarSummaries: Summary[] = [];
+
+    // Utilize unused token space from recent selection
+    if (randomMemoryRatio <= 0) {
+      const unusedRecentTokens =
+        reservedRecentMemoryTokens - consumedRecentMemoryTokens;
+
+      reservedSimilarMemoryTokens += unusedRecentTokens;
+      console.log(
+        logPrefix,
+        "Additional available token space for similar memory:",
+        "\nFrom recent:",
+        unusedRecentTokens
+      );
+    }
+
+    // Target only summaries that haven't been selected yet
+    const unusedSummaries = data.summaries.filter(
+      (e) => !selectedSummaries.includes(e)
+    );
+
+    // Dynamically generate embedding texts
+    const ebdTexts: EmbeddingText<Summary>[] = unusedSummaries.flatMap(
+      (summary) => {
+        const splitted = summary.text
+          .split("\n\n")
+          .filter((e) => e.trim().length > 0);
+
+        return splitted.map((e) => ({
+          content: e.trim(),
+          metadata: summary,
+        }));
+      }
+    );
+
+    // Initialize embedding processor
+    const processor = new HypaProcessorV2<Summary>({
+      rateLimiter: new TaskRateLimiter({
+        tasksPerMinute: settings.embeddingRequestsPerMinute,
+        maxConcurrentTasks: settings.embeddingMaxConcurrent,
+      }),
+      onProgress: (queuedTaskCount) => {
+        hypaV3ProgressStore.set({
+          open: true,
+          miniMsg: `${queuedTaskCount}`,
+          msg: `${logPrefix} Similarity searching...`,
+          subMsg: `${queuedTaskCount} queued`,
+        });
+      },
+    });
+
+    try {
+      // Start of performance measurement: addTexts
+      console.log(
+        `${logPrefix} Starting addTexts with ${ebdTexts.length} chunks`
+      );
+      const addStartTime = performance.now();
+
+      // Add EmbeddingTexts to processor for similarity search
+      await processor.addTexts(ebdTexts);
+
+      const addEndTime = performance.now();
+      console.debug(
+        `${logPrefix} addTexts completed in ${addEndTime - addStartTime}ms`
+      );
+      // End of performance measurement: addTexts
+    } catch (error) {
+      return {
+        currentTokens,
+        chats,
+        error: `${logPrefix} Similarity search failed: ${error}`,
+        memory: toSerializableHypaV3Data(data),
+      };
+    } finally {
+      hypaV3ProgressStore.set({
+        open: false,
+        miniMsg: "",
+        msg: "",
+        subMsg: "",
+      });
+    }
+
+    const recentChats = chats
+      .slice(-minChatsForSimilarity)
+      .filter((chat) => chat.content.trim().length > 0);
+    const queries: string[] = recentChats.flatMap((chat) => {
+      return chat.content.split("\n\n").filter((e) => e.trim().length > 0);
+    });
+
+    if (queries.length > 0) {
+      const scoredSummaries = new Map<Summary, number>();
+
+      try {
+        // Start of performance measurement: similarity search
+        console.log(
+          `${logPrefix} Starting similarity search with ${recentChats.length} queries`
+        );
+        const searchStartTime = performance.now();
+
+        const batchScoredResults = await processor.similaritySearchScoredBatch(
+          queries
+        );
+
+        const searchEndTime = performance.now();
+        console.debug(
+          `${logPrefix} Similarity search completed in ${
+            searchEndTime - searchStartTime
+          }ms`
+        );
+        // End of performance measurement: similarity search
+
+        for (const scoredResults of batchScoredResults) {
+          for (const [ebdResult, similarity] of scoredResults) {
+            const summary = ebdResult.metadata;
+
+            scoredSummaries.set(
+              summary,
+              (scoredSummaries.get(summary) || 0) + similarity
+            );
+          }
+        }
+      } catch (error) {
+        return {
+          currentTokens,
+          chats,
+          error: `${logPrefix} Similarity search failed: ${error}`,
+          memory: toSerializableHypaV3Data(data),
+        };
+      } finally {
+        hypaV3ProgressStore.set({
+          open: false,
+          miniMsg: "",
+          msg: "",
+          subMsg: "",
+        });
+      }
+
+      // Normalize scores
+      if (scoredSummaries.size > 0) {
+        const maxScore = Math.max(...scoredSummaries.values());
+
+        for (const [summary, score] of scoredSummaries.entries()) {
+          scoredSummaries.set(summary, score / maxScore);
+        }
+      }
+
+      // Sort in descending order
+      const scoredArray = [...scoredSummaries.entries()].sort(
+        ([, scoreA], [, scoreB]) => scoreB - scoreA
+      );
+
+      // Debug log for scoredArray
+      console.debug("scoredArray:", scoredArray);
+
+      while (scoredArray.length > 0) {
+        const [summary] = scoredArray.shift();
+        const summaryTokens = await tokenizer.tokenizeChat({
+          role: "system",
+          content: summary.text + summarySeparator,
+        });
+
+        /*
+        console.log(
+          logPrefix,
+          "Trying to add similar summary:",
+          "\nSummary Tokens:",
+          summaryTokens,
+          "\nConsumed Similar Memory Tokens:",
+          consumedSimilarMemoryTokens,
+          "\nReserved Tokens:",
+          reservedSimilarMemoryTokens,
+          "\nWould exceed:",
+          summaryTokens + consumedSimilarMemoryTokens >
+            reservedSimilarMemoryTokens
+        );
+        */
+
+        if (
+          summaryTokens + consumedSimilarMemoryTokens >
+          reservedSimilarMemoryTokens
+        ) {
+          console.log(
+            logPrefix,
+            "Stopping similar memory selection:",
+            `\nconsumedSimilarMemoryTokens(${consumedSimilarMemoryTokens}) + summaryTokens(${summaryTokens}) > reservedSimilarMemoryTokens(${reservedSimilarMemoryTokens})`
+          );
+          break;
+        }
+
+        selectedSimilarSummaries.push(summary);
+        consumedSimilarMemoryTokens += summaryTokens;
+      }
+
+      selectedSummaries.push(...selectedSimilarSummaries);
+    }
+
+    console.log(
+      logPrefix,
+      "After similar memory selection:",
+      "\nSummary Count:",
+      selectedSimilarSummaries.length,
+      "\nSummaries:",
+      selectedSimilarSummaries,
+      "\nReserved Tokens:",
+      reservedSimilarMemoryTokens,
+      "\nConsumed Tokens:",
+      consumedSimilarMemoryTokens
+    );
+  }
+
+  // Select random summaries
+  let reservedRandomMemoryTokens = Math.floor(
+    availableMemoryTokens * randomMemoryRatio
+  );
+  let consumedRandomMemoryTokens = 0;
+
+  if (randomMemoryRatio > 0) {
+    const selectedRandomSummaries: Summary[] = [];
+
+    // Utilize unused token space from recent and similar selection
+    const unusedRecentTokens =
+      reservedRecentMemoryTokens - consumedRecentMemoryTokens;
+    const unusedSimilarTokens =
+      reservedSimilarMemoryTokens - consumedSimilarMemoryTokens;
+
+    reservedRandomMemoryTokens += unusedRecentTokens + unusedSimilarTokens;
+    console.log(
+      logPrefix,
+      "Additional available token space for random memory:",
+      "\nFrom recent:",
+      unusedRecentTokens,
+      "\nFrom similar:",
+      unusedSimilarTokens,
+      "\nTotal added:",
+      unusedRecentTokens + unusedSimilarTokens
+    );
+
+    // Target only summaries that haven't been selected yet
+    const unusedSummaries = data.summaries
+      .filter((e) => !selectedSummaries.includes(e))
+      .sort(() => Math.random() - 0.5); // Random shuffle
+
+    for (const summary of unusedSummaries) {
+      const summaryTokens = await tokenizer.tokenizeChat({
+        role: "system",
+        content: summary.text + summarySeparator,
+      });
+
+      if (
+        summaryTokens + consumedRandomMemoryTokens >
+        reservedRandomMemoryTokens
+      ) {
+        // Trying to select more random memory
+        continue;
+      }
+
+      selectedRandomSummaries.push(summary);
+      consumedRandomMemoryTokens += summaryTokens;
+    }
+
+    selectedSummaries.push(...selectedRandomSummaries);
+
+    console.log(
+      logPrefix,
+      "After random memory selection:",
+      "\nSummary Count:",
+      selectedRandomSummaries.length,
+      "\nSummaries:",
+      selectedRandomSummaries,
+      "\nReserved Tokens:",
+      reservedRandomMemoryTokens,
+      "\nConsumed Tokens:",
+      consumedRandomMemoryTokens
+    );
+  }
+
+  // Sort selected summaries chronologically (by index)
+  selectedSummaries.sort(
+    (a, b) => data.summaries.indexOf(a) - data.summaries.indexOf(b)
+  );
+
+  // Generate final memory prompt
+  const memory = wrapWithXml(
+    memoryPromptTag,
+    selectedSummaries.map((e) => e.text).join(summarySeparator)
+  );
+  const realMemoryTokens = await tokenizer.tokenizeChat({
+    role: "system",
+    content: memory,
+  });
+
+  // Release reserved memory tokens
+  if (shouldReserveEmptyMemoryTokens) {
+    currentTokens -= emptyMemoryTokens;
+  } else {
+    currentTokens -= memoryTokens;
+  }
+
+  currentTokens += realMemoryTokens;
+
+  console.log(
+    logPrefix,
+    "Final memory selection:",
+    "\nSummary Count:",
+    selectedSummaries.length,
+    "\nSummaries:",
+    selectedSummaries,
+    "\nReal Memory Tokens:",
+    realMemoryTokens,
+    "\nAvailable Memory Tokens:",
+    availableMemoryTokens
+  );
+
+  if (currentTokens > maxContextTokens) {
+    throw new Error(
+      `Unexpected error: input token count (${currentTokens}) exceeds max context size (${maxContextTokens})`
+    );
+  }
+
+  // Save last selected summaries
+  data.lastSelectedSummaries = selectedSummaries.map((selectedSummary) =>
+    data.summaries.findIndex((summary) => summary === selectedSummary)
+  );
+
+  const newChats: OpenAIChat[] = [
+    {
+      role: "system",
+      content: memory,
+      memo: "supaMemory",
+    },
+    ...chats.slice(startIdx),
+  ];
+
+  console.log(
+    logPrefix,
+    "Exiting function:",
+    "\nCurrent Tokens:",
+    currentTokens,
+    "\nAll chats, including memory prompt:",
+    newChats,
+    "\nMemory Data:",
+    data
+  );
+
+  return {
+    currentTokens,
+    chats: newChats,
+    memory: toSerializableHypaV3Data(data),
+  };
 }
 
 async function hypaMemoryV3Main(
@@ -957,7 +1762,7 @@ export async function summarize(
   };
 }
 
-function getCurrentHypaV3Preset(): HypaV3Preset {
+export function getCurrentHypaV3Preset(): HypaV3Preset {
   const db = getDatabase();
   const preset = db.hypaV3Presets?.[db.hypaV3PresetId];
 
@@ -984,6 +1789,12 @@ export function createHypaV3Preset(
     preserveOrphanedMemory: false,
     processRegexScript: false,
     doNotSummarizeUserMessage: false,
+    // Experimental
+    useExperimentalImpl: false,
+    summarizationRequestsPerMinute: 20,
+    summarizationMaxConcurrent: 1,
+    embeddingRequestsPerMinute: 100,
+    embeddingMaxConcurrent: 1,
   };
 
   if (

--- a/src/ts/process/memory/taskRateLimiter.ts
+++ b/src/ts/process/memory/taskRateLimiter.ts
@@ -1,0 +1,183 @@
+export interface TaskRateLimiterOptions {
+  tasksPerMinute?: number;
+  maxConcurrentTasks?: number;
+  failFast?: boolean;
+}
+
+export interface BatchResult<TData> {
+  results: TaskResult<TData>[];
+  successCount: number;
+  failureCount: number;
+  allSucceeded: boolean;
+}
+
+export interface TaskResult<TData> {
+  success: boolean;
+  data?: TData;
+  error?: Error;
+}
+
+export class TaskRateLimiter {
+  private static readonly LOG_PREFIX = "[TaskRateLimiter]";
+  public readonly options: TaskRateLimiterOptions;
+  private timestamps: number[] = [];
+  private active: number = 0;
+  private queue: Array<{
+    task: () => Promise<TaskResult<any>>;
+    resolve: (result: TaskResult<any>) => void;
+  }> = [];
+
+  public constructor(options?: TaskRateLimiterOptions) {
+    this.options = {
+      tasksPerMinute: 20,
+      maxConcurrentTasks: 5,
+      failFast: true,
+      ...options,
+    };
+
+    if (this.options.maxConcurrentTasks > this.options.tasksPerMinute) {
+      throw new Error("maxConcurrentTasks must be less than tasksPerMinute");
+    }
+  }
+
+  public async executeTask<TData>(
+    task: () => Promise<TData>
+  ): Promise<TaskResult<TData>> {
+    return new Promise<TaskResult<TData>>((resolve) => {
+      this.queue.push({
+        task: async () => {
+          try {
+            const data = await task();
+            return { success: true, data };
+          } catch (error) {
+            return { success: false, error };
+          }
+        },
+        resolve,
+      });
+
+      this.processNextFromQueue();
+    });
+  }
+
+  public async executeBatch<TData>(
+    tasks: Array<() => Promise<TData>>
+  ): Promise<BatchResult<TData>> {
+    const taskResults = await Promise.all(
+      tasks.map((task) => this.executeTask(task))
+    );
+    const successCount = taskResults.filter((r) => r.success).length;
+    const failureCount = taskResults.length - successCount;
+
+    return {
+      results: taskResults,
+      successCount,
+      failureCount,
+      allSucceeded: failureCount === 0,
+    };
+  }
+
+  public cancelPendingTasks(reason: string): void {
+    const error = new TaskCanceledError(reason);
+
+    while (this.queue.length > 0) {
+      const { resolve } = this.queue.shift();
+      resolve({ success: false, error });
+    }
+  }
+
+  public get queuedTaskCount(): number {
+    return this.queue.length;
+  }
+
+  private processNextFromQueue(): void {
+    if (this.queue.length === 0) return;
+
+    if (this.active >= this.options.maxConcurrentTasks) {
+      // Debug log for concurrency limit hit
+      console.debug(
+        TaskRateLimiter.LOG_PREFIX,
+        "Concurrency limit hit:",
+        "\nTasks in last minute:",
+        this.timestamps.length + "/" + this.options.tasksPerMinute,
+        "\nActive tasks:",
+        this.active + "/" + this.options.maxConcurrentTasks,
+        "\nWaiting tasks in queue:",
+        this.queue.length
+      );
+
+      return;
+    }
+
+    this.timestamps = this.timestamps.filter(
+      (ts) => Date.now() - ts <= 60 * 1000
+    );
+
+    if (this.timestamps.length >= this.options.tasksPerMinute) {
+      const oldestTimestamp = Math.min(...this.timestamps);
+      const timeUntilExpiry = Math.max(
+        100,
+        60 * 1000 - (Date.now() - oldestTimestamp)
+      );
+
+      // Debug log for rate limit hit
+      console.debug(
+        TaskRateLimiter.LOG_PREFIX,
+        "Rate limit hit:",
+        "\nTasks in last minute:",
+        this.timestamps.length + "/" + this.options.tasksPerMinute,
+        "\nActive tasks:",
+        this.active + "/" + this.options.maxConcurrentTasks,
+        "\nWaiting tasks in queue:",
+        this.queue.length,
+        "\nWill retry in:",
+        timeUntilExpiry + "ms"
+      );
+
+      // Wait until rate limit window advances before retrying
+      setTimeout(() => this.processNextFromQueue(), timeUntilExpiry);
+      return;
+    }
+
+    const { task, resolve } = this.queue.shift();
+
+    this.active++;
+    this.timestamps.push(Date.now());
+
+    // Debug log for task start
+    console.debug(
+      TaskRateLimiter.LOG_PREFIX,
+      "Task started:",
+      "\nTasks in last minute:",
+      this.timestamps.length + "/" + this.options.tasksPerMinute,
+      "\nActive tasks:",
+      this.active + "/" + this.options.maxConcurrentTasks,
+      "\nWaiting tasks in queue:",
+      this.queue.length
+    );
+
+    task()
+      .then((result) => {
+        resolve(result);
+
+        if (!result.success && this.options.failFast) {
+          this.cancelPendingTasks("Task canceled due to previous failure");
+        }
+      })
+      .finally(() => {
+        this.active--;
+
+        // Prevents call stack overflow while maintaining concurrency limits
+        queueMicrotask(() => this.processNextFromQueue());
+      });
+  }
+}
+
+export class TaskCanceledError extends Error {
+  public readonly name: string;
+
+  public constructor(message: string) {
+    super(message);
+    this.name = "TaskCanceledError";
+  }
+}

--- a/src/ts/process/transformers.ts
+++ b/src/ts/process/transformers.ts
@@ -60,12 +60,19 @@ export const runEmbedding = async (texts: string[], model:EmbeddingModel = 'Xeno
     console.log('running embedding')
     let embeddingModelQuery = model + device
     if(!extractor || embeddingModelQuery !== lastEmbeddingModelQuery){
+        // Dispose old extractor
+        if(extractor) {
+            await extractor.dispose()
+        }
         extractor = await pipeline('feature-extraction', model, {
+            // Default dtype for webgpu is fp32, so we can use q8, which is the default dtype in wasm.
+            ...(device === 'webgpu' ? { dtype: "q8" } : {}),
             device: device,
             progress_callback: (progress) => {
                 console.log(progress)
             }
         });
+        lastEmbeddingModelQuery = embeddingModelQuery
         console.log('extractor loaded')
     }
     let result = await extractor(texts, { pooling: 'mean', normalize: true });

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -11,6 +11,7 @@ import { prebuiltNAIpresets, prebuiltPresets } from '../process/templates/templa
 import { defaultColorScheme, type ColorScheme } from '../gui/colorscheme';
 import type { PromptItem, PromptSettings } from '../process/prompt';
 import type { OobaChatCompletionRequestParams } from '../model/ooba';
+import { type HypaV3Settings, type HypaV3Preset, createHypaV3Preset } from '../process/memory/hypav3'
 
 export let appVer = "159.0.0"
 export let webAppSubVer = ''
@@ -515,17 +516,21 @@ export function setDatabase(data:Database){
     data.checkCorruption ??= true
     data.OaiCompAPIKeys ??= {}
     data.reasoningEffort ??= 0
-    data.hypaV3Settings = {
-        memoryTokensRatio: data.hypaV3Settings?.memoryTokensRatio ?? 0.2,
-        extraSummarizationRatio: data.hypaV3Settings?.extraSummarizationRatio ?? 0,
-        maxChatsPerSummary: data.hypaV3Settings?.maxChatsPerSummary ?? 4,
-        recentMemoryRatio: data.hypaV3Settings?.recentMemoryRatio ?? 0.4,
-        similarMemoryRatio: data.hypaV3Settings?.similarMemoryRatio ?? 0.4,
-        enableSimilarityCorrection: data.hypaV3Settings?.enableSimilarityCorrection ?? false,
-        preserveOrphanedMemory: data.hypaV3Settings?.preserveOrphanedMemory ?? false,
-        processRegexScript: data.hypaV3Settings?.processRegexScript ?? false,
-        doNotSummarizeUserMessage: data.hypaV3Settings?.doNotSummarizeUserMessage ?? false
+    data.hypaV3Presets ??= [
+        createHypaV3Preset("Default", {
+            summarizationPrompt: data.supaMemoryPrompt ? data.supaMemoryPrompt : "",
+            ...data.hypaV3Settings
+        })
+    ]
+    if (data.hypaV3Presets.length > 0) {
+        data.hypaV3Presets = data.hypaV3Presets.map((preset, i) =>
+            createHypaV3Preset(
+                preset.name || `Preset ${i + 1}`,
+                preset.settings || {}
+            )
+        )
     }
+    data.hypaV3PresetId ??= 0
     data.returnCSSError ??= true
     data.useExperimentalGoogleTranslator ??= false
     if(data.antiClaudeOverload){ //migration
@@ -535,7 +540,7 @@ export function setDatabase(data:Database){
     data.hypaCustomSettings = {
         url: data.hypaCustomSettings?.url ?? "",
         key: data.hypaCustomSettings?.key ?? "",
-        model: data.hypaCustomSettings?.model ?? "",       
+        model: data.hypaCustomSettings?.model ?? ""     
     }
     data.doNotChangeSeperateModels ??= false
     data.modelTools ??= []
@@ -960,17 +965,10 @@ export interface Database{
     showPromptComparison:boolean
     checkCorruption:boolean
     hypaV3:boolean
-    hypaV3Settings: {
-        memoryTokensRatio: number
-        extraSummarizationRatio: number
-        maxChatsPerSummary: number
-        recentMemoryRatio: number
-        similarMemoryRatio: number
-        enableSimilarityCorrection: boolean
-        preserveOrphanedMemory: boolean
-        processRegexScript: boolean
-        doNotSummarizeUserMessage: boolean
-    }
+    hypaV3Settings: HypaV3Settings // legacy
+    hypaV3Presets: HypaV3Preset[]
+    hypaV3PresetId: number
+    showMenuHypaMemoryModal:boolean
     OaiCompAPIKeys: {[key:string]:string}
     inlayErrorResponse:boolean
     reasoningEffort:number
@@ -1025,7 +1023,6 @@ export interface Database{
     }[]
     igpPrompt:string
     useTokenizerCaching:boolean
-    showMenuHypaMemoryModal:boolean
 }
 
 interface SeparateParameters{

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -50,6 +50,12 @@ export const alertStore = writable({
     type: 'none',
     msg: 'n',
 } as alertData)
+export const hypaV3ProgressStore = writable({
+    open: false,
+    miniMsg: '',
+    msg: '',
+    subMsg: '',
+})
 export const selIdState = $state({
     selId: -1
 })


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Preview
![preview](https://github.com/user-attachments/assets/603c249d-6a97-44ee-a0d4-767c0a0cfcca)

# Description
This PR adds preset support for the HypaV3 memory system.
Users can now create different presets as needed and switch between presets.
It also supports parallel requests in an experimental implementation.
As it's still in the experimental stage, feedback is requested.