### PR TITLE
fix: remove dupilacted nai settings input

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -123,7 +123,7 @@
     }
     // End HypaV3
 
-    let imageModel = '';
+    let imageModel = $state('');
 
     // add init NAI V4
     // if(DBState.db.NAIImgConfig.autoSmea === undefined) DBState.db.NAIImgConfig.autoSmea = false;
@@ -277,13 +277,6 @@
             <span class="text-textcolor">CFG rescale</span>
             <NumberInput size="sm" marginBottom min={0} max={1} bind:value={DBState.db.NAIImgConfig.cfg_rescale}/>
 
-            <span class="text-textcolor">Noise Schedule</span>
-            <SelectInput className="mt-2 mb-4" bind:value={DBState.db.NAIImgConfig.noise_schedule}>
-                <OptionInput value="karras">karras</OptionInput>
-                <OptionInput value="exponential">exponential</OptionInput>
-                <OptionInput value="polyexponential">polyexponential</OptionInput>
-            </SelectInput>
-
             {#if !DBState.db.NAII2I || DBState.db.NAIImgConfig.sampler !== 'ddim_v3'}
                 <Check bind:check={DBState.db.NAIImgConfig.sm} name="Use SMEA"/>
             {:else if DBState.db.NAIImgModel === 'nai-diffusion-4-full'
@@ -294,11 +287,6 @@
 
             {#if DBState.db.NAIImgModel === 'nai-diffusion-4-full'
             || DBState.db.NAIImgModel === 'nai-diffusion-4-curated-preview'}
-
-                <span class="text-textcolor">Prompt Guidance Rescale</span>
-                <SliderInput marginBottom min={0} max={1} step={0.02} fixed={2} bind:value={DBState.db.NAIImgConfig.cfg_rescale} />
-
-
                 <Check bind:check={DBState.db.NAIImgConfig.autoSmea} name='Auto Smea'/>
                 <Check bind:check={DBState.db.NAIImgConfig.use_coords} name='Use coords'/>
                 <Check bind:check={DBState.db.NAIImgConfig.legacy_uc} name='Use legacy uc'/>

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -310,9 +310,6 @@ export function setDatabase(data:Database){
             legacy_uc:false,
         };
     }
-    if(checkNullish(data.NAIImgConfig.cfg_rescale)){
-        data.NAIImgConfig.cfg_rescale = 0;
-    }
     if(checkNullish(data.customTextTheme)){
         data.customTextTheme = {
             FontColorStandard: "#f8f8f2",


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Removed duplicated nai settings inputs for `noise_schedule` and `cfg_rescale`.

### Before

![image](https://github.com/user-attachments/assets/3708be6a-8b04-41f4-9bf0-c2cb4af9e29c)

### After

![image](https://github.com/user-attachments/assets/df3fcf2b-b8e1-4594-ab7e-5f0d8cdcc88c)