### PR TITLE
Add getDescription function to LUA script (was missing)

### DIFF
--- a/src/ts/process/lua.ts
+++ b/src/ts/process/lua.ts
@@ -418,6 +418,19 @@ export async function runLua(code:string, arg:{
                 setDatabase(db)
             })
 
+            luaEngine.global.set('getDescription', async (id:string) => {
+                if(!LuaSafeIds.has(id)){
+                    return
+                }
+                const db = getDatabase()
+                const selectedChar = get(selectedCharID)
+                const char = db.characters[selectedChar]
+                if(char.type === 'group'){
+                    throw('Character is a group')
+                }
+                return char.desc
+            })
+            
             luaEngine.global.set('setDescription', async (id:string, desc:string) => {
                 if(!LuaSafeIds.has(id)){
                     return


### PR DESCRIPTION
The `getDescription(triggerId)` function, documented at: https://kwaroran.github.io/docs/srp/lua/#getdescriptiontriggerid was missing from the codebase and has now been added.

# PR Checklist
- [  ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ o] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [  ] Have you added type definitions?

# Description
