### PR TITLE
fix: error alert not showing when parameter is error type

### DIFF
--- a/src/ts/alert.ts
+++ b/src/ts/alert.ts
@@ -26,14 +26,18 @@ export const alertStore = {
     }
 }
 
-export function alertError(msg:string){
+export function alertError(msg: string | Error) {
     console.error(msg)
     const db = getDatabase()
 
-    if(typeof(msg) !== 'string'){
+    if (typeof(msg) !== 'string') {
         try{
-            msg = JSON.stringify(msg)
-        }catch(e){
+            if (msg instanceof Error) {
+                msg = msg.message
+            } else {
+                msg = JSON.stringify(msg)
+            }
+        } catch {
             msg = `${msg}`
         }
     }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

It fixes a bug identified during the testing of ComfyUI image generation in Playground. Specifically, the error alert, which is supposed to display error messages, was not appearing when a parameter was of an error type. This fix ensures that error alerts are now correctly displayed under such conditions.