### PR TITLE
fix: re‑implement prompt text storage without memo field

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -1205,7 +1205,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                         content: content
                     }
 
-                    if(DBState.db.promptInfoInsideChat && DBState.db.promptTextInfoInsideChat){
+                    if(DBState.db.promptInfoInsideChat && DBState.db.promptTextInfoInsideChat && card.type2 !== 'globalNote'){
                         pushPromptInfoBody(prompt.role, prompt.content, promptBodyformatedForChatStore)
                     }
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
## Related PRs

- This PR replaces the previous implementation in [#848](https://github.com/kwaroran/RisuAI/pull/848).

---

## Problem

- After [#848](https://github.com/kwaroran/RisuAI/pull/848), input token counts and `\n\n` spacing changed (e.g. custom API & OpenAI compatible models).  
- Before, I used the `memo` field in each message to help get **the final, parsed and pre-processed prompt template** from the `formated` array for storage.
- But the `memo` field is used in `pushPrompts()` to decide when to merge strings inside `formated`:

```js
// Existing code
if (chat.role === 'system') {
    const endf = formated.at(-1)
    if (endf && endf.role === 'system' && endf.memo === chat.memo && endf.name === chat.name) {
        formated[formated.length - 1].content += '\n\n' + chat.content
    }
}
```
- Therefore, relying on `memo` produced wrong results.


## Solution
- Rolled back all `memo` logic (For a clean diff, compare with 040652d, the last version before the memo logic was added).
- Added `pushPromptInfoBody()` (independent of global `formated`):

```js
function pushPromptInfoBody(role, fmt, promptBody) {
    if (!fmt.trim()) return;
    promptBody.push({
        role: role,
        content: risuChatParser(fmt),
    });
}
```
- Prompt text is now collected in a single switch(`card.type`) block, without needing to filter with `memo` or external fields.


## Result

Prompt text is still stored per message without side effects.


## Considerations (commit [8dc05cc](https://github.com/kwaroran/RisuAI/pull/860/commits/8dc05ccace4f07e8be150af65a4d3ae9a53b446e))

- Extracting only the original `globalNote` is hard unless parser order is changed.
    1. When `positionParser` is called first, sections marked as `position` are inserted early, making it impossible to extract only the prompt template afterward.
    2. If `risuChatParser` is called separately **just to save the prompt text**, the saved prompt may differ from the actual prompt sent, especially in cases involving `{{random}}` values.
- Reordering the function calls might help, but since it could change the prompt that is actually sent and cause differences from the previous output, it may be better to leave things as they are.
    - Personally, I tend to avoid using `position` in main system prompts; adding it often makes  the main prompt structure a bit messy (Using `position` is very useful for things that change frequently, such as bots or personas)
    - Global notes are typically used for individual bots, rather than as prompts shared globally, so skipping them here has no functional drawback, I think.
    - The **Custom Inner Format** fields such as authorNote, persona, description, and memory mainly serve as labels, so things like `{{random}}` are rarely used here. For this reason, I used **2(only `risuChatParser` is called just to save the prompt text)** in this context.

## Final Note

Sorry for any inconvenience! If you have questions or feedback, please let me know.


