### PR TITLE
fix: prevent `Buffer.from(undefined)` error in native fetch for GET/DELETE requests

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -1974,7 +1974,7 @@ export async function fetchNative(url:string, arg:{
                 id: fetchId,
                 url: url,
                 headers: JSON.stringify(headers),
-                body: Buffer.from(realBody).toString('base64'),
+                body: realBody ? Buffer.from(realBody).toString('base64') : '',
                 method: arg.method
             }).then((res) => {
                 try {
@@ -1994,7 +1994,7 @@ export async function fetchNative(url:string, arg:{
                 id: fetchId,
                 url: url,
                 headers: headers,
-                body: Buffer.from(realBody).toString('base64'),
+                body: realBody ? Buffer.from(realBody).toString('base64') : '',
             }).then((res) => {
                 if(!res.success){
                     error = res.error


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

While tracking down the error "The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type undefined" that occurs during ComfyUI image generation, I found an issue in the `fetchNative` function.

## Issue

When sending GET or DELETE requests, the `realBody` variable is set to `undefined`, but it's directly passed to `Buffer.from()` without null checking, causing the error.

## Fix

Added a simple null check to prevent the error:

```typescript
// Before
body: Buffer.from(realBody).toString('base64'),

// After
body: realBody ? Buffer.from(realBody).toString('base64') : '',