### PR TITLE
Feature: Preserve scroll position in menuMode 0 navigation (Trigger V2)

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -133,6 +133,8 @@
     let selectMode = $state(0) //0 = trigger 1 = effect
     let contextMenu = $state(false)
     let contextMenuLoc = $state({x: 0, y: 0})
+    let menu0Container = $state<HTMLDivElement>(null)
+    let menu0ScrollPosition = $state(0)
 
     type VirtualClipboard = {
         type: 'trigger',
@@ -147,6 +149,13 @@
     $effect(() => {
         if(menuMode === 0){
             addElse = false
+            setTimeout(() => {
+                menu0Container.scrollTop = menu0ScrollPosition
+            }, 10)
+        } else if(menuMode === 1 || menuMode === 2 || menuMode === 3) {
+            if(menu0Container) {
+                menu0ScrollPosition = menu0Container.scrollTop
+            }
         }
     })
 
@@ -1167,7 +1176,7 @@
                             </SelectInput>
                         </div>
                     </div>
-                    <div class="border border-darkborderc ml-2 rounded-md flex-1 mr-2 overflow-x-auto overflow-y-auto">
+                    <div class="border border-darkborderc ml-2 rounded-md flex-1 mr-2 overflow-x-auto overflow-y-auto" bind:this={menu0Container}>
                         {#each value[selectedIndex].effect as effect, i}
                             <button class="p-2 w-full text-start text-purple-500"
                                 class:hover:bg-selected={selectedEffectIndex !== i}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Implements scroll position preservation functionality for RisuAI's Trigger V2 menuMode 0. When users navigate away from menuMode 0 and then return, the scroll position is now automatically restored to where they left off.

Changes:
- Saves scroll position when leaving menuMode 0
- Restores saved scroll position when returning to menuMode 0
- Improves user experience by maintaining navigation context"

This enhancement provides a smoother user experience by eliminating the need to manually scroll back to previous positions after navigation.