### PR TITLE
Fix: Variable name highlighting inconsistency in v2setvar and v2If

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -189,6 +189,7 @@
                     condition: '=',
                     targetType: 'value',
                     target: '',
+                    sourceType: 'var',
                     source: ''
                 }
                 break;

--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -177,6 +177,7 @@
                     type: 'v2SetVar',
                     operator: '=',
                     var: '',
+                    varType: 'var',
                     value: '',
                     valueType: 'value',
                     indent: 0

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -177,8 +177,8 @@ export type triggerV2IfVar = {
     condition: '='|'!='|'>'|'<'|'>='|'<=',
     targetType: 'var'|'value',
     target: string,
+    sourceType: 'var'|'value',
     source: string,
-    sourceType: 'var',
     indent: number
 }
 

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -197,6 +197,7 @@ export type triggerV2SetVar = {
     type: 'v2SetVar',
     operator: '='|'+='|'-='|'*='|'/='|'%=',
     var: string,
+    varType: 'var'|'value',
     valueType: 'var'|'value',
     value: string,
     indent: number

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -178,6 +178,7 @@ export type triggerV2IfVar = {
     targetType: 'var'|'value',
     target: string,
     source: string,
+    sourceType: 'var',
     indent: number
 }
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Fixed inconsistent variable name styling in v2setvar and v2If. All variable names now display consistently in yellow.