### PR TITLE
Fix: variable name color inconsistency

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -1013,6 +1013,12 @@
             if(effect[p1 + 'Type'] === 'value'){
                 return `<span class="text-green-500">"${d}"</span>`
             }
+            if(effect.type === 'v2If' && p1 === 'source'){
+                return `<span class="text-yellow-500">${d || 'null'}</span>`
+            }
+            if(effect.type === 'v2SetVar' && p1 === 'var'){
+                return `<span class="text-yellow-500">${d || 'null'}</span>`
+            }
             return `<span class="text-blue-500">${d || 'null'}</span>`
         })
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Standardize variable name display color to yellow