### PR TITLE
fix: Divider toggles should reference within group

### DIFF
--- a/src/lib/SideBars/Toggles.svelte
+++ b/src/lib/SideBars/Toggles.svelte
@@ -61,14 +61,13 @@
                 <TextInput className="w-32" bind:value={DBState.db.globalChatVariables[`toggle_${toggle.key}`]} />
             </div>
         {:else if toggle.type === 'divider'}
-            {@const prevToggle = groupedToggles[index - 1]}
             <!-- Prevent multiple dividers appearing in a row -->
-            {#if index === 0 || prevToggle.type !== 'divider' || prevToggle.value !== toggle.value}
+            {#if index === 0 || items[index - 1]?.type !== 'divider' || items[index - 1]?.value !== toggle.value}
                 <div class="w-full min-h-5 flex gap-2 mt-2 items-center" class:justify-end={!reverse}>
                     {#if toggle.value}
-                        <span>{toggle.value}</span>
+                        <span class="shrink-0">{toggle.value}</span>
                     {/if}
-                    <hr class="border-t border-darkborderc m-0 min-w-32 flex-grow" />
+                    <hr class="border-t border-darkborderc m-0 flex-grow" />
                 </div>
             {/if}
         {:else}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

When dividers within a group becomes many, it would throw.

Found out that the divider was referencing the whole list of toggles (root level), not `items` (items of a group it belongs), as divider development happened before the group. It caused out of index array access and `prevToggle.type` would throw because `prevToggle` can be `undefined`.