### PR TITLE
Fix: v2EndIndent positioning in nested if/else statements in Trigger v2

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -1992,6 +1992,12 @@
                         else if(menuMode === 2){
                             editTrigger.indent = (value[selectedIndex].effect[selectedEffectIndex] as triggerEffectV2).indent
                             if(editTrigger.type === 'v2If' || editTrigger.type === 'v2IfAdvanced' || editTrigger.type === 'v2Loop' || editTrigger.type === 'v2LoopNTimes' || editTrigger.type === 'v2Else'){
+                                value[selectedIndex].effect.splice(selectedEffectIndex, 0, {
+                                    type: 'v2EndIndent',
+                                    indent: editTrigger.indent + 1,
+                                    endOfLoop: editTrigger.type === 'v2Loop' || editTrigger.type === 'v2LoopNTimes'
+                                })
+                                
                                 if(addElse){
                                     value[selectedIndex].effect.splice(selectedEffectIndex, 0, {
                                         type: 'v2Else',
@@ -2002,12 +2008,6 @@
                                         indent: editTrigger.indent + 1
                                     })
                                 }
-
-                                value[selectedIndex].effect.splice(selectedEffectIndex, 0, {
-                                    type: 'v2EndIndent',
-                                    indent: editTrigger.indent + 1,
-                                    endOfLoop: editTrigger.type === 'v2Loop' || editTrigger.type === 'v2LoopNTimes'
-                                })
                             }
                             value[selectedIndex].effect.splice(selectedEffectIndex, 0, editTrigger)
                         }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
When saving nested if/else blocks, v2EndIndent was incorrectly being added after v2Else when addElse was enabled. This PR corrects the positioning so that v2EndIndent is properly generated before v2Else instead of after it.