### PR TITLE
Fix: incorrect references on clipboard paste

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -851,7 +851,7 @@
         }
 
         for(const effect of clipboard.value){
-            value[selectedIndex].effect.splice(selectedEffectIndex, 0, effect)
+            value[selectedIndex].effect.splice(selectedEffectIndex, 0, safeStructuredClone(effect))
             selectedEffectIndex += 1
         }
     }
@@ -869,7 +869,7 @@
         }
 
         for(const trigger of clipboard.value){
-            value.splice(selectedIndex, 0, trigger)
+            value.splice(selectedIndex, 0, safeStructuredClone(trigger))
             selectedIndex += 1
         }
     }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Used safeStructuredClone for clipboard pasting to prevent incorrect object references.