### PR TITLE
feat: add per-message user commentary feature

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1128,6 +1128,8 @@ export const languageEnglish = {
     promptInfoEmptyMessage: "No prompt information is available for this message.",
     promptInfoEmptyToggle: "No custom toggles are currently active.",
     promptInfoEmptyText: "No prompt text has been saved.",
+    commentaries: "Comments",
+    commentariesEmptyMessage: "No comments yet.",
     escapeOutput: "Escape Output",
     claudeBatching: "Claude Batching",
     claude1HourCaching: "Claude 1 Hour Caching",    

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1130,6 +1130,7 @@ export const languageEnglish = {
     promptInfoEmptyText: "No prompt text has been saved.",
     commentaries: "Comments",
     commentariesEmptyMessage: "No comments yet.",
+    commentariesDelete: "Are you sure you want to delete this comment?",
     escapeOutput: "Escape Output",
     claudeBatching: "Claude Batching",
     claude1HourCaching: "Claude 1 Hour Caching",    

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -995,6 +995,8 @@ export const languageKorean = {
     "promptInfoEmptyMessage": "이 메시지에 대한 프롬프트 정보가 없습니다.",
     "promptInfoEmptyToggle": "활성화된 커스텀 토글이 없습니다.",
     "promptInfoEmptyText": "저장된 프롬프트 텍스트가 없습니다.",
+    "commentariesEmptyMessage": "저장된 코멘트가 없습니다.",
+    "commentaries": "코멘트",
     "escapeOutput": "출력 이스케이프",
     "claudeBatching": "Claude 배칭",
     "folderNameInput": "새 폴더 이름을 입력해주세요",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -997,6 +997,7 @@ export const languageKorean = {
     "promptInfoEmptyText": "저장된 프롬프트 텍스트가 없습니다.",
     "commentariesEmptyMessage": "저장된 코멘트가 없습니다.",
     "commentaries": "코멘트",
+    "commentariesDelete": "해당 코멘트를 삭제하시겠습니까?",
     "escapeOutput": "출력 이스케이프",
     "claudeBatching": "Claude 배칭",
     "folderNameInput": "새 폴더 이름을 입력해주세요",

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -63,6 +63,7 @@
     let commentExpandedId: string | null = $state(null)
     let commentDraftTitle = $state('')
     let commentDraftContent = $state('')
+    const commentDraftByte = $derived(new TextEncoder().encode(commentDraftContent).length)
 </script>
 
 <svelte:window onmessage={async (e) => {
@@ -391,22 +392,25 @@
                                             class="w-full bg-neutral-900 text-gray-100 px-2 py-1 rounded"
                                             readonly={commentary.locked}
                                         ></textarea>
-                                        <div class="mt-3 flex justify-end gap-2">
-                                            <button
-                                                class="px-3 py-1 rounded bg-neutral-700 hover:bg-neutral-600"
-                                                onclick={() => commentExpandedId = null}
-                                            >Cancel</button>
-                                            <button
-                                                class={`px-3 py-1 rounded bg-green-600 ${commentary.locked ? 'opacity-30' : 'hover:bg-green-700 opacity-100'} text-white`} disabled={commentary.locked}
-                                                onclick={() => {
-                                                    if(commentary.locked) return
-                                                    
-                                                    commentary.title = commentDraftTitle.trim() || 'New comment'
-                                                    commentary.content = commentDraftContent
-                                                    commentary.updatedAt = new Date().toISOString()
-                                                    commentExpandedId = null
-                                                }}
-                                            >Save</button>
+                                        <div class="mt-3 flex items-center justify-between">
+                                            <div class={`inline-flex items-center px-2 py-0.5 text-xs font-medium ${commentDraftByte > 50000 ? 'text-red-400' : 'text-gray-200'} bg-neutral-700 rounded-full select-none`}>{commentDraftByte.toLocaleString()} Bytes</div>
+                                            <div class="mt-3 flex justify-end gap-2">
+                                                <button
+                                                    class="px-3 py-1 rounded bg-neutral-700 hover:bg-neutral-600"
+                                                    onclick={() => commentExpandedId = null}
+                                                >Cancel</button>
+                                                <button
+                                                    class={`px-3 py-1 rounded bg-green-600 ${commentary.locked ? 'opacity-30' : 'hover:bg-green-700 opacity-100'} text-white`} disabled={commentary.locked}
+                                                    onclick={() => {
+                                                        if(commentary.locked) return
+                                                        
+                                                        commentary.title = commentDraftTitle.trim() || 'New comment'
+                                                        commentary.content = commentDraftContent
+                                                        commentary.updatedAt = new Date().toISOString()
+                                                        commentExpandedId = null
+                                                    }}
+                                                >Save</button>
+                                            </div>
                                         </div>                                        
                                     </div>
                                 {/if}

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -366,6 +366,9 @@
                                             return
                                         }
                                         
+                                        const r = confirm(`${language.commentariesDelete}`)
+                                        if(!r) return
+
                                         targetMessage.commentaries = targetMessage.commentaries.filter((_, i) => i !== idx)
                                     }} class={`text-textcolor2 ${commentary.locked ? 'opacity-30' : 'hover:text-green-500 opacity-100'} cursor-pointer`} disabled={commentary.locked}>
                                         <XIcon />

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -357,7 +357,7 @@
                                         <span class="text-gray-400 text-sm">{new Date(commentary.createdAt).toLocaleDateString()}</span>
                                         <span class="text-gray-400 text-sm">{new Date(commentary.createdAt).toLocaleTimeString()}</span>
                                     </div>
-                                    <button onclick={(e) => {
+                                    <button onclick={async (e) => {
                                         e.stopPropagation()
                                         if(commentary.locked) return
 
@@ -367,7 +367,7 @@
                                             return
                                         }
                                         
-                                        const r = confirm(`${language.commentariesDelete}`)
+                                        const r = await confirm(`${language.commentariesDelete}`)
                                         if(!r) return
 
                                         targetMessage.commentaries = targetMessage.commentaries.filter((_, i) => i !== idx)

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -1,5 +1,5 @@
 import { get, writable } from "svelte/store";
-import { type character, type MessageGenerationInfo, type Chat, type MessagePresetInfo, changeToPreset, setCurrentChat } from "../storage/database.svelte";
+import { type character, type MessageGenerationInfo, type Chat, type MessagePresetInfo, changeToPreset, setCurrentChat, type Commentary } from "../storage/database.svelte";
 import { DBState } from '../stores.svelte';
 import { CharEmotion, selectedCharID } from "../stores.svelte";
 import { ChatTokenizer, tokenize, tokenizeNum } from "../tokenizer";
@@ -219,6 +219,8 @@ export async function sendChat(chatProcessIndex = -1,arg:{
         }
     }
 // ─────────────────────────────────────────────────────────────
+
+    let messageCommentaries: Commentary[] = []
 
     let currentChar:character
     let caculatedChatTokens = 0
@@ -1431,6 +1433,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                 time: Date.now(),
                 generationInfo,
                 promptInfo,
+                commentaries: messageCommentaries,
             })
         }
         DBState.db.characters[selectedChar].chats[selectedChat].isStreaming = true
@@ -1512,6 +1515,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     time: Date.now(),
                     generationInfo,
                     promptInfo,
+                    commentaries: messageCommentaries,
                 }       
                 if(inlayResult.promise){
                     const p = await inlayResult.promise
@@ -1526,6 +1530,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     time: Date.now(),
                     generationInfo,
                     promptInfo,
+                    commentaries: messageCommentaries,
                 })
                 const ind = DBState.db.characters[selectedChar].chats[selectedChat].message.length - 1
                 if(inlayResult.promise){

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1548,6 +1548,7 @@ export interface Message{
     time?: number
     generationInfo?: MessageGenerationInfo
     promptInfo?: MessagePresetInfo
+    commentaries?: Commentary[]
     name?:string
     otherUser?:boolean
 }
@@ -1564,6 +1565,15 @@ export interface MessagePresetInfo{
     promptName?: string,
     promptToggles?: {key: string, value: string}[],
     promptText?: OpenAIChat[],
+}
+
+export interface Commentary {
+    id: string
+    title: string
+    createdAt: string   // ISO string for JSON compatibility
+    updatedAt: string   // (Date becomes string when exported/imported)
+    content: string
+    locked?: boolean
 }
 
 interface AINsettings{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

## What's New
- Allows users to add, edit, and delete comments for each message
- Comments are saved manually, with an optional lock feature to prevent editing or deletion
- Displays the creation date, last updated date, and byte size for each comment.
- Shows UTF-8 byte size live while editing
- Compatible with the existing session JSON save/load

## Why this feature may be useful

There may be times when users want to leave a short note or thought related to a specific message in a session. Until now, they needed to use a separate note-taking app, which could be inconvenient and distract from the chat experience, since the notes weren't directly connected to the messages.

With this feature, users can directly add comments, notes, or reminders to each message inside RisuAI, making it easier to read, edit, or delete them later.

---

<img src="https://github.com/user-attachments/assets/767762ce-d7f8-4365-8b41-316463c1a3f1" width=400>

- No comments yet

---

<img src="https://github.com/user-attachments/assets/2edcce63-16b6-4ba7-a9e6-cb0814fa4cbf" width=400>

- Users can create a new comment by clicking the "+" button at the bottom.
- Clicking the "lock" button locks the comment, preventing accidental editing or deletion, while still allowing the comment to be read.
- Clicking the delete button shows a confirmation dialog to avoid accidental deletion.
- To prevent storage or management issues, each message currently allows up to 20 comments.

---

<img src="https://github.com/user-attachments/assets/4a9b2d43-a861-4f6b-b70f-bdd20b06afbb" width=400>

- While editing, the current byte size of the comment is shown on the bottom-left.
- Users need to press the "Save" button to save any changes.

---

<img src="https://github.com/user-attachments/assets/ed10db89-6fc9-43e8-a134-c16636c6e6c2" width=400>

- Screenshot after deleting `test3`

---

## Considerations

### Why manual saving rather than automatic?

- **Clearer update dates**: Automatic saving may cause confusion, as the update date would change with every character typed. In contrast, manual saving updates the date only when the user intentionally saves changes, making it easier to keep track of meaningful updates.
- **Reducing mistakes**: Manual saving gives users the ability to easily cancel edits if they make a mistake, without needing an "undo" feature.

### Why dates are stored as `strings` instead of `Date` objects?

- For compatibility when exporting and importing sessions as JSON, storing dates as strings (in ISO format) was safer. Internally, these strings are converted back to `Date` objects only when needed.

```ts
export interface Commentary {
    id: string
    title: string
    createdAt: string   // ISO string for JSON compatibility
    updatedAt: string   // (Date becomes string when exported/imported)
    content: string
    locked?: boolean
}
```

### Why use the field name `commentaries`?

- I felt `memo` or `note` might have been clearer, but those names were already in use for other purposes. The term `comments` also seemed likely to be used internally in the future, so I chose `commentaries` to avoid potential confusion.
  On the user interface, the simpler word "comments" is displayed.

## Possible next steps and ideas

I believe this feature could enhance user engagement, allowing them to easily capture thoughts and notes within RisuAI itself.

Possible future improvements might be:
- Showing visually in the chat UI whether a message has comments.
- Showing a comment count in the message UI.
- Adding sorting or reordering features for convenience.

If you have any concerns or suggestions, or if you feel this feature does not align with the project's direction, please let me know. I'll be happy to discuss further!

Thanks a lot!



