### PR TITLE
Fix: API key priority for Custom Models with Claude format

### DIFF
--- a/src/ts/process/request.ts
+++ b/src/ts/process/request.ts
@@ -2927,7 +2927,7 @@ async function requestClaude(arg:RequestDataArgumentExtended):Promise<requestDat
     const aiModel = arg.aiModel
     const useStreaming = arg.useStreaming
     let replacerURL = arg.customURL ?? ('https://api.anthropic.com/v1/messages')
-    let apiKey = (aiModel === 'reverse_proxy') ?  db.proxyKey : db.claudeAPIKey
+    let apiKey = arg.key || ((aiModel === 'reverse_proxy') ? db.proxyKey : db.claudeAPIKey)
     const maxTokens = arg.maxTokens
     if(aiModel === 'reverse_proxy' && db.autofillRequestUrl){
         if(replacerURL.endsWith('v1')){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Fixed a bug where, when using Custom Models with the Claude format, the API key specified in the Custom Models settings was ignored. Instead, the global 'Claude API Key' from the Chat Bot tab was incorrectly being used unless a proxy was configured.

The logic has been updated to correctly prioritize API keys:
1.  Use the API key provided in Custom Models settings `arg.key` if it exists.
2.  Perform the proxy check.
3.  Use the global 'Claude API Key' as a fallback if the conditions above are not met.

Let me know if you'd like any adjustments! Good luck with your PR! 😊