### PR TITLE
Fix: fetchLog index bug in response streaming (Tauri)

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -806,7 +806,7 @@ export function addFetchLog(arg: {
     url: arg.url,
     chatId: arg.chatId
   });
-  return fetchLog.length - 1;
+  return 0;
 }
 
 /**


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR fixes an indexing bug in the response streaming logic under the Tauri environment.

Previously, `addFetchLog` returned `fetchLog.length - 1`, but because new logs are added to the front of `fetchLog` with `unshift`, the latest log is always at index `0`. As a result, `pipeFetchLog` was updating the wrong log entry during streaming, since it uses `fetchLog[fetchLogIndex].response += chunk` to update the log.

Now, `addFetchLog` always returns `0`, so `pipeFetchLog` updates the correct log entry for streaming responses.

```ts
// Inside fetchNative()
let fetchLogIndex = addFetchLog({ ... });
let readableStream = pipeFetchLog(fetchLogIndex, ...);

// Inside pipeFetchLog()
fetchLog[fetchLogIndex].response += chunk; // <- must point to the latest log
```

---

**Note:**
In `src/ts/process/request.ts` at line 1086, `addFetchLog` is called once more. Since `addFetchLog` is also called in `fetchNative` (`src/ts/globalApi.svelte.ts`), the same log entry might be registered twice.

However, just in case, I did not remove the code at line 1086.

Please review this part if you have time.

`src/ts/process/request.ts` (line 1086):

```ts
    addFetchLog({
        body: body,
        response: "Streaming",
        success: true,
        url: replacerURL,
    })
```

---

If you need further clarification, please let me know. Thank you.

