### PR TITLE
feat: Improve syntax highlighted code blocks

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -284,19 +284,28 @@ html, body{
   text-decoration: line-through;
 }
 
-.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
-  content: "";
-}
-
-.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
-  content: "";
-}
-
-.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)):not(pre code) {
-  color: var(--tw-prose-pre-code);
+.prose pre {
   background-color: var(--tw-prose-pre-bg);
-  padding: 0.125rem 0.25rem;
+  color: var(--tw-prose-pre-code);
+}
+
+.prose :where(pre code) * {
+  font-family: inherit;
+}
+
+.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::before {
+  content: "";
+}
+
+.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
+  content: "";
+}
+
+.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *)):not(pre code) {
+  background-color: var(--tw-prose-pre-bg);
   border-radius: 0.25rem;
+  color: var(--tw-prose-pre-code);
+  padding: 0.125rem 0.25rem;
 }
 
 .x-risu-risu-inlay-image{

--- a/src/ts/observer.svelte.ts
+++ b/src/ts/observer.svelte.ts
@@ -59,39 +59,46 @@ function nodeObserve(node:HTMLElement){
 
     if(hlLang){
         node.addEventListener('contextmenu', (e)=>{
-            e.preventDefault();
-            const menu = document.createElement('div');
+            e.preventDefault()
+
+            const prevContextMenu = document.getElementById('code-contextmenu')
+            if(prevContextMenu){
+                prevContextMenu.remove()
+            }
+
+            const menu = document.createElement('div')
+            menu.id = 'code-contextmenu'
             menu.setAttribute('class', 'fixed z-50 min-w-[160px] py-2 bg-gray-800 rounded-lg border border-gray-700')
 
-            const copyOption = document.createElement('div');
-            copyOption.textContent = 'Copy';
+            const copyOption = document.createElement('div')
+            copyOption.textContent = 'Copy'
             copyOption.setAttribute('class', 'px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 cursor-pointer')
             copyOption.addEventListener('click', ()=>{
-                navigator.clipboard.writeText(node.getAttribute('x-hl-text'));
-                menu.remove();
+                navigator.clipboard.writeText(node.textContent)
+                menu.remove()
             })
 
             const downloadOption = document.createElement('div');
             downloadOption.textContent = 'Download';
             downloadOption.setAttribute('class', 'px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 cursor-pointer')
             downloadOption.addEventListener('click', ()=>{
-                const a = document.createElement('a');
-                a.href = URL.createObjectURL(new Blob([node.getAttribute('x-hl-text')], {type: 'text/plain'}));
-                a.download = 'code.' + hlLang;
-                a.click();
-                menu.remove();
+                const a = document.createElement('a')
+                a.href = URL.createObjectURL(new Blob([node.textContent], {type: 'text/plain'}))
+                a.download = 'code.' + hlLang
+                a.click()
+                menu.remove()
             })
 
-            menu.appendChild(copyOption);
-            menu.appendChild(downloadOption);
+            menu.appendChild(copyOption)
+            menu.appendChild(downloadOption)
 
-            menu.style.left = e.clientX + 'px';
-            menu.style.top = e.clientY + 'px';
+            menu.style.left = e.clientX + 'px'
+            menu.style.top = e.clientY + 'px'
 
-            document.body.appendChild(menu);
+            document.body.appendChild(menu)
             
             document.addEventListener('click', ()=>{
-                menu.remove();
+                menu?.remove()
             }, {once: true})
         })
     }

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -158,152 +158,165 @@ async function renderHighlightableMarkdown(data:string) {
             }
             //import language if not already loaded
             //we do not refactor this to a function because we want to keep vite to only import the languages that are needed
-            let languageModule:any = null
-            let shotLang = ''
+            let languageModule: typeof import('highlight.js/lib/languages/*')|null = null
+            let fileExt = ''
+
             switch(lang){
+                case 'bash':{
+                    fileExt = 'sh'
+                    lang = 'bash'
+                    if(!hljs.getLanguage('bash')){
+                        languageModule = await import('highlight.js/lib/languages/bash')
+                    }
+                    break
+                }
+                case 'c':
+                case 'cpp':{
+                    fileExt = lang
+                    lang = 'cpp'
+                    if(!hljs.getLanguage('cpp')){
+                        languageModule = await import('highlight.js/lib/languages/cpp')
+                    }
+                    break
+                }
+                case 'cs':
+                case 'csharp':{
+                    fileExt = 'cs'
+                    lang = 'csharp'
+                    if(!hljs.getLanguage('csharp')){
+                        languageModule = await import('highlight.js/lib/languages/csharp')
+                    }
+                    break
+                }
+                case 'css':{
+                    fileExt = 'css'
+                    lang = 'css'
+                    if(!hljs.getLanguage('css')){
+                        languageModule = await import('highlight.js/lib/languages/css')
+                    }
+                    break
+                }
+                case 'dart':{
+                    fileExt = 'dart'
+                    lang = 'dart'
+                    if(!hljs.getLanguage('dart')){
+                        languageModule = await import('highlight.js/lib/languages/dart')
+                    }
+                    break
+                }
+                case 'html':
+                case 'svg':
+                case 'xml':{
+                    fileExt = lang
+                    lang = 'xml'
+                    if(!hljs.getLanguage('xml')){
+                        languageModule = await import('highlight.js/lib/languages/xml')
+                    }
+                    break
+                }
+                case 'java':{
+                    fileExt = 'java'
+                    lang = 'java'
+                    if(!hljs.getLanguage('java')){
+                        languageModule = await import('highlight.js/lib/languages/java')
+                    }
+                    break
+                }
                 case 'js':
+                case 'jsx':
                 case 'javascript':{
+                    fileExt = 'js'
                     lang = 'javascript'
-                    shotLang = 'js'
                     if(!hljs.getLanguage('javascript')){
                         languageModule = await import('highlight.js/lib/languages/javascript')
                     }
                     break
                 }
+                case 'json':{
+                    fileExt = 'json'
+                    lang = 'json'
+                    if(!hljs.getLanguage('json')){
+                        languageModule = await import('highlight.js/lib/languages/json')
+                    }
+                    break
+                }
+                case 'lua':{
+                    fileExt = 'lua'
+                    lang = 'lua'
+                    if(!hljs.getLanguage('lua')){
+                        languageModule = await import('highlight.js/lib/languages/lua')
+                    }
+                    break
+                }
+                case 'markdown':
+                case 'md':{
+                    fileExt = 'md'
+                    lang = 'markdown'
+                    if(!hljs.getLanguage('markdown')){
+                        languageModule = await import('highlight.js/lib/languages/markdown')
+                    }
+                    break
+                }
+                case 'py':
+                case 'python':{
+                    fileExt = 'py'
+                    lang = 'python'
+                    if(!hljs.getLanguage('python')){
+                        languageModule = await import('highlight.js/lib/languages/python')
+                    }
+                    break
+                }
+                case 'rust':{
+                    fileExt = 'rs'
+                    lang = 'rust'
+                    if(!hljs.getLanguage('rust')){
+                        languageModule = await import('highlight.js/lib/languages/rust')
+                    }
+                    break
+                }
+                case 'shell':{
+                    fileExt = 'sh'
+                    lang = 'shell'
+                    if(!hljs.getLanguage('shell')){
+                        languageModule = await import('highlight.js/lib/languages/shell')
+                    }
+                    break
+                }
+                case 'ts':
+                case 'tsx':
+                case 'typescript':{
+                    fileExt = 'ts'
+                    lang = 'typescript'
+                    if(!hljs.getLanguage('typescript')){
+                        languageModule = await import('highlight.js/lib/languages/typescript')
+                    }
+                    break
+                }
                 case 'txt':
                 case 'vtt':{
-                    shotLang = lang
+                    fileExt = lang
                     lang = 'plaintext'
                     if(!hljs.getLanguage('plaintext')){
                         languageModule = await import('highlight.js/lib/languages/plaintext')
                     }
                     break
                 }
-                case 'py':
-                case 'python':{
-                    lang = 'python'
-                    shotLang = 'py'
-                    if(!hljs.getLanguage('python')){
-                        languageModule = await import('highlight.js/lib/languages/python')
-                    }
-                    break
-                }
-                case 'css':{
-                    lang = 'css'
-                    shotLang = 'css'
-                    if(!hljs.getLanguage('css')){
-                        languageModule = await import('highlight.js/lib/languages/css')
-                    }
-                    break
-                }
-                case 'xml':
-                case 'html':{
-                    lang = 'xml'
-                    shotLang = 'xml'
-                    if(!hljs.getLanguage('xml')){
-                        languageModule = await import('highlight.js/lib/languages/xml')
-                    }
-                    break
-                }
-                case 'lua':{
-                    lang = 'lua'
-                    shotLang = 'lua'
-                    if(!hljs.getLanguage('lua')){
-                        languageModule = await import('highlight.js/lib/languages/lua')
-                    }
-                    break
-                }
-                case 'dart':{
-                    lang = 'dart'
-                    shotLang = 'dart'
-                    if(!hljs.getLanguage('dart')){
-                        languageModule = await import('highlight.js/lib/languages/dart')
-                    }
-                    break
-                }
-                case 'java':{
-                    lang = 'java'
-                    shotLang = 'java'
-                    if(!hljs.getLanguage('java')){
-                        languageModule = await import('highlight.js/lib/languages/java')
-                    }
-                    break
-                }
-                case 'rust':{
-                    lang = 'rust'
-                    shotLang = 'rs'
-                    if(!hljs.getLanguage('rust')){
-                        languageModule = await import('highlight.js/lib/languages/rust')
-                    }
-                    break
-                }
-                case 'c':
-                case 'cpp':{
-                    lang = 'cpp'
-                    shotLang = 'cpp'
-                    if(!hljs.getLanguage('cpp')){
-                        languageModule = await import('highlight.js/lib/languages/cpp')
-                    }
-                    break
-                }
-                case 'csharp':
-                case 'cs':{
-                    lang = 'csharp'
-                    shotLang = 'cs'
-                    if(!hljs.getLanguage('csharp')){
-                        languageModule = await import('highlight.js/lib/languages/csharp')
-                    }
-                    break
-                }
-                case 'ts':
-                case 'typescript':{
-                    lang = 'typescript'
-                    shotLang = 'ts'
-                    if(!hljs.getLanguage('typescript')){
-                        languageModule = await import('highlight.js/lib/languages/typescript')
-                    }
-                    break
-                }
-                case 'json':{
-                    lang = 'json'
-                    shotLang = 'json'
-                    if(!hljs.getLanguage('json')){
-                        languageModule = await import('highlight.js/lib/languages/json')
-                    }
-                    break
-                }
                 case 'yaml':{
+                    fileExt = 'yml'
                     lang = 'yaml'
-                    shotLang = 'yml'
                     if(!hljs.getLanguage('yaml')){
                         languageModule = await import('highlight.js/lib/languages/yaml')
                     }
                     break
                 }
-                case 'shell':{
-                    lang = 'shell'
-                    shotLang = 'sh'
-                    if(!hljs.getLanguage('shell')){
-                        languageModule = await import('highlight.js/lib/languages/shell')
-                    }
-                    break
-                }
-                case 'bash':{
-                    lang = 'bash'
-                    shotLang = 'sh'
-                    if(!hljs.getLanguage('bash')){
-                        languageModule = await import('highlight.js/lib/languages/bash')
-                    }
-                    break
-                }
                 case 'risuerror':{
                     lang = 'error'
-                    shotLang = 'error'
+                    fileExt = 'error'
                     break
                 }
                 default:{
                     lang = 'none'
-                    shotLang = 'none'
+                    fileExt = 'none'
                 }
             }
             if(languageModule){
@@ -320,9 +333,7 @@ async function renderHighlightableMarkdown(data:string) {
                     language: lang,
                     ignoreIllegals: true
                 }).value
-                rendered = rendered.replace(placeholder, `<pre class="hljs" x-hl-lang="${shotLang}" x-hl-text="${
-                    Buffer.from(code).toString('hex')
-                }"><code>${highlighted}</code></pre>`)   
+                rendered = rendered.replace(placeholder, `<pre class="hljs" x-hl-lang="${fileExt}"><code>${highlighted}</code></pre>`)   
             }
         } catch (error) {
             


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

## Improve language selection

- Markdown via `markdown` or `md`.
- JavaScript via `jsx`.
- SVG via `svg`.
- TypeScript via `tsx`.

## Improve code block context menu

Close previous context menu before opening a new one.

## Improve code block styles

Forces `--tw-prose-pre-bg` as background, same as non-highlighted `<pre>` blocks.
Forces monospaced fonts.

## Fix file extension

C should be `.c.`, HTML should be `.html`, etc.

## Fix code copy/download

It's copying/downloading base64 encoded string. Uses plain `textContent` of the code block instead.

| Current | PR |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4f77c976-60dd-41ad-86af-bb2f2692d92f) | ![image](https://github.com/user-attachments/assets/5a77a366-1109-4cba-9fe2-4d24e7dba72e) |
