### PR TITLE
Add support for NAI v4.5 and Multi-Character Prompting. 

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -60,6 +60,8 @@
             reference_strength_multiple: [0.7],
             vibe_data: undefined,
             vibe_model_selection: undefined,
+            use_char_uc: true,
+            use_multi_character_prompt: true,
         }
         if (DBState.db.NAIImgConfig.sampler === 'ddim_v3'){
             DBState.db.NAIImgConfig.sm = false
@@ -290,14 +292,13 @@
             <Check bind:check={DBState.db.NAII2I} name="Enable I2I"/>
 
             {#if DBState.db.NAIImgModel === 'nai-diffusion-4-full'
-            || DBState.db.NAIImgModel === 'nai-diffusion-4-curated-preview'}
+            || DBState.db.NAIImgModel === 'nai-diffusion-4-curated-preview'
+            || DBState.db.NAIImgModel === 'nai-diffusion-4-5-full'
+            || DBState.db.NAIImgModel === 'nai-diffusion-4-5-curated'}
                 <Check bind:check={DBState.db.NAIImgConfig.autoSmea} name='Auto Smea'/>
-                <Check bind:check={DBState.db.NAIImgConfig.use_coords} name='Use coords'/>
                 <Check bind:check={DBState.db.NAIImgConfig.legacy_uc} name='Use legacy uc'/>
-
-                <Check bind:check={DBState.db.NAIImgConfig.v4_prompt.use_coords} name='Use v4 prompt coords'/>
-                <Check bind:check={DBState.db.NAIImgConfig.v4_prompt.use_order} name='Use v4 prompt order'/>
-                <Check bind:check={DBState.db.NAIImgConfig.v4_negative_prompt.legacy_uc} name='Use v4 negative prompt legacy uc'/>
+                <Check bind:check={DBState.db.NAIImgConfig.use_multi_character_prompt} name='Use Multi Character Prompt'/>
+                <Check bind:check={DBState.db.NAIImgConfig.use_char_uc} name='Use auto character uc'/>
             {/if}
 
             {#if DBState.db.NAII2I}

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -225,6 +225,8 @@
                 DBState.db.NAIImgModel = imageModel;
             }}>
                 <OptionInput value="" >Choose...</OptionInput>
+                <OptionInput value="nai-diffusion-4-5-full" >nai-diffusion-4-5-full</OptionInput>
+                <OptionInput value="nai-diffusion-4-5-curated" >nai-diffusion-4-5-curated</OptionInput>
                 <OptionInput value="nai-diffusion-4-full" >nai-diffusion-4-full</OptionInput>
                 <OptionInput value="nai-diffusion-4-curated-preview" >nai-diffusion-4-curated-preview</OptionInput>
                 <OptionInput value="nai-diffusion-3" >nai-diffusion-3</OptionInput>
@@ -240,7 +242,9 @@
             <span class="text-textcolor">Sampler</span>
 
             {#if DBState.db.NAIImgModel === 'nai-diffusion-4-full'
-            || DBState.db.NAIImgModel === 'nai-diffusion-4-curated-preview'}
+            || DBState.db.NAIImgModel === 'nai-diffusion-4-curated-preview'
+            || DBState.db.NAIImgModel === 'nai-diffusion-4-5-full'
+            || DBState.db.NAIImgModel === 'nai-diffusion-4-5-curated'}
                 <SelectInput className="mt-2 mb-4" bind:value={DBState.db.NAIImgConfig.sampler}>
                     <OptionInput value="k_euler_ancestral" >(Recommended)Euler Ancestral</OptionInput>
                     <OptionInput value="k_dpmpp_2s_ancestral" >(Recommended)DPM++ 2S Ancestral</OptionInput>

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -133,6 +133,7 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                     "params_version": 3,
                     "add_original_image": true,
                     "cfg_rescale": db.NAIImgConfig.cfg_rescale,
+                    "characterPrompts": [], // add multi-character prompts
                     "controlnet_strength": 1,
                     "dynamic_thresholding": false,
                     "n_samples": 1,
@@ -145,7 +146,7 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                     "sm": false,
                     "sm_dyn": false,
                     "noise": db.NAIImgConfig.noise,
-                    "noise_schedule": "karras",
+                    "noise_schedule": db.NAIImgConfig.noise_schedule,
                     "normalize_reference_strength_multiple":false,
                     "strength": db.NAIImgConfig.strength,
                     "ucPreset": 3,
@@ -158,25 +159,25 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                     "reference_strength": db.NAIImgConfig.reference_strength_multiple !== undefined ? undefined : db.NAIImgConfig.RefStrength,
                     //add v4
                     "autoSmea": db.NAIImgConfig.autoSmea,
-                    "use_coords": db.NAIImgConfig.use_coords,
+                    "use_coords": false,
                     "legacy_uc": db.NAIImgConfig.legacy_uc,
                     "v4_prompt":{
                         caption:{
                             base_caption:genPrompt,
                             char_captions: []
                         },
-                        use_coords: db.NAIImgConfig.v4_prompt.use_coords,
-                        use_order: db.NAIImgConfig.v4_prompt.use_order
+                        use_coords: false,
+                        use_order: true,
                     },
                     "v4_negative_prompt":{
                         caption:{
                             base_caption:neg,
                             char_captions: []
                         },
-                        legacy_uc: db.NAIImgConfig.v4_negative_prompt.legacy_uc,
+                        legacy_uc: db.NAIImgConfig.legacy_uc,
                     },
                     "reference_image_multiple" : [],
-                    "reference_strength_multiple" : [],
+                    "reference_strength_multiple" : db.NAIImgConfig.reference_strength_multiple !== undefined ? [] : undefined,
                 }
             },
             headers:{
@@ -221,6 +222,30 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                     commonReq.body.parameters.reference_strength_multiple.push(strength);
                 }
             }
+        }
+
+        // Add Multi-Character Prompts for v4 and v4.5 
+        if(db.NAIImgConfig.use_multi_character_prompt && (db.NAIImgModel.includes('nai-diffusion-4-full') || db.NAIImgModel.includes('nai-diffusion-4-curated') ||
+           db.NAIImgModel.includes('nai-diffusion-4-5-full') || db.NAIImgModel.includes('nai-diffusion-4-5-curated'))) {
+            let Captions = genPrompt.split('|').map((caption, index) => caption.trim());
+            let base_caption = Captions[0];
+            let char_captions = Captions.slice(1);
+            commonReq.body.parameters.v4_prompt.caption.base_caption = base_caption;
+            commonReq.body.input = base_caption;
+            commonReq.body.parameters.v4_prompt.caption.char_captions = char_captions.map(caption => ({
+                "char_caption": caption,
+                "centers": [{x: 0.5, y: 0.5}],  // Default center, NAI will automatically adjust
+            }))
+            commonReq.body.parameters.characterPrompts = char_captions.map(caption => ({
+                "center": {x: 0.5, y: 0.5}, // Default center, NAI will automatically adjust
+                "enabled": true,
+                "prompt": caption,
+                "uc": db.NAIImgConfig.use_char_uc ? "lowres, aliasing, " : "", // undesired content, can be default or empty
+            }))
+            commonReq.body.parameters.v4_negative_prompt.caption.char_captions = char_captions.map(caption => ({
+                "char_caption": db.NAIImgConfig.use_char_uc ? "lowres, aliasing, " : "", // undesired content, can be default or empty
+                "centers": [{x: 0.5, y: 0.5}],  // Default center, NAI will automatically adjust
+            })) 
         }
 
         if(db.NAII2I){

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -286,7 +286,9 @@ export function setDatabase(data:Database){
                     char_captions:[]
                 },
                 legacy_uc:false,
-            }
+            },
+            use_char_uc:true,
+            use_multi_character_prompt:true,
         }
     }
     //add NAI v4 (사용중인 사람용 추가 DB Init)
@@ -1444,6 +1446,9 @@ export interface NAIImgConfig{
     reference_strength_multiple?:number[],
     vibe_data?:NAIVibeData,
     vibe_model_selection?:string
+    //add multi-character prompt 
+    use_multi_character_prompt:boolean,
+    use_char_uc:boolean,
 }
 
 //add 4


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

- Added nai-diffusion-4-5-full/curated to the Image generation NovelAI model list.
- Updated the list of noise samplers supported by the v4.5 model
- Added the Multi Character Prompt feature supported by NAI v4 and v4.5
- Fixed an issue where NAI v4 would throw a 400 error when the vibe transfer slot was empty.
- Fixed an issue where the user could not change the noise scheduler in NAI.

# Details
## Added NAI v4.5 into the model list 
![image](https://github.com/user-attachments/assets/ef41a400-5714-4356-810a-dee872ce1073)
![image](https://github.com/user-attachments/assets/e68794d7-371f-4645-9aa4-40ebc5b5a540)

## Multi Character Prompt
These four toggles are shown only when NAI v4 or v4.5 is selected.
![image](https://github.com/user-attachments/assets/4775cb76-b684-4e5d-8103-3f81b0e896a6)

- Auto Smea: no feature available. future-proof?
- Use legacy uc: not recommended, but essential when referencing older images
- Use Multi Character Prompt: recommended. The main prompt will be automatically parsed as "Base prompt | Char1 prompt | Char2 prompt | ... " 
- Use auto character uc: recommended. When the Multi-Character Prompt toggle is enabled, the default uc (undesired content) tags "lowres, aliasing, " will be added to each character.
