### PR TITLE
Fix: swapped span classes for single and double quotes

### DIFF
--- a/src/lib/Setting/Pages/DisplaySettings.svelte
+++ b/src/lib/Setting/Pages/DisplaySettings.svelte
@@ -361,16 +361,16 @@
     </div>
 
     {#if DBState.db.customQuotes}
-        <span class="text-textcolor mt-4">{language.leadingSingleQuote}</span>
+        <span class="text-textcolor mt-4">{language.leadingDoubleQuote}</span>
         <TextInput bind:value={DBState.db.customQuotesData[0]} />
 
-        <span class="text-textcolor mt-4">{language.trailingSingleQuote}</span>
+        <span class="text-textcolor mt-4">{language.trailingDoubleQuote}</span>
         <TextInput bind:value={DBState.db.customQuotesData[1]} />
 
-        <span class="text-textcolor mt-4">{language.leadingDoubleQuote}</span>
+        <span class="text-textcolor mt-4">{language.leadingSingleQuote}</span>
         <TextInput bind:value={DBState.db.customQuotesData[2]} />
 
-        <span class="text-textcolor mt-4">{language.trailingDoubleQuote}</span>
+        <span class="text-textcolor mt-4">{language.trailingSingleQuote}</span>
         <TextInput bind:value={DBState.db.customQuotesData[3]} />
     {/if}
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Corrected span class notation: single and double quotes were swapped.