### PR TITLE
Feature: Add back button to GridCatalog

### DIFF
--- a/src/lib/Others/GridCatalog.svelte
+++ b/src/lib/Others/GridCatalog.svelte
@@ -59,7 +59,18 @@
 <div class="h-full w-full flex justify-center">
     <div class="h-full p-6 bg-darkbg max-w-full w-2xl flex flex-col overflow-y-auto">
         <div class="mx-4 mb-6 flex flex-col">
-            <TextInput placeholder="Search" bind:value={search} size="lg" autocomplete="off"/>
+            <div class="flex items-center gap-3 mb-2">
+                <button 
+                    class="flex items-center justify-center p-2 rounded-lg hover:bg-selected transition-colors flex-shrink-0"
+                    onclick={() => endGrid()}
+                    title="Back"
+                >
+                    <ArrowLeft size={20} />
+                </button>
+                <div class="flex-1">
+                    <TextInput placeholder="Search" bind:value={search} size="lg" autocomplete="off" fullwidth={true}/>
+                </div>
+            </div>
             <div class="flex flex-wrap gap-2 mt-2">
                 <Button styled={selected === 3 ? 'primary' : 'outlined'} size="sm" onclick={() => {selected = 3}}>
                     {language.simple}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR introduces a back button to the GridCatalog screen. This allows users to easily navigate back to the previous view.

![image](https://github.com/user-attachments/assets/97fb5657-7581-4b92-991d-ea87f88cd138)
