### PR TITLE
Fix Vite build failure caused by Web Worker and import.meta.url usage

### DIFF
--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -1058,7 +1058,7 @@ class PyodideContext{
     apis: Record<string, (...args:any[]) => any> = {};
     inited: boolean = false;
     constructor(){
-        this.worker = new Worker(new URL('./pyworker.js', import.meta.url), {
+        this.worker = new Worker(new URL('./pyworker.ts', import.meta.url), {
             type: 'module'
         })
         this.worker.onmessage = (event:MessageEvent) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig(({command, mode}) => {
       }) : null
     ],
 
+    // Vite defaults to 'iife' for workers, which breaks when using import.meta.url with code-splitting.
+    // Set to 'es' to allow proper ESM worker bundling and fix build errors.
+    worker: {
+      format: 'es',
+    },
+
     // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
     // prevent vite from obscuring rust errors
     clearScreen: false,


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Fixes [#894](https://github.com/kwaroran/RisuAI/issues/894)

The issue was caused by:
- A mismatched file extension in `new Worker(new URL(...))`, where the worker was declared as `pyworker.js` but only `pyworker.ts` existed
- Vite's default worker format being `iife`, which is incompatible with code-splitting and import.meta.url

Fixes:
- Changed worker path to `pyworker.ts`
- Set `worker.format: 'es'` in vite.config.ts

This ensures compatibility with static bundling environments like Docker and CI builds.

# Note
I tested this in the default web (Docker + Vite) environment only.  
I haven’t tested in local (e.g., Tauri) or node-hosted versions because I’m not fully familiar with the build system.

The change seems frontend-only and likely environment-independent, but feel free to let me know if further testing is needed.
