### PR TITLE
fix: add null check for addChat in scripting API

### DIFF
--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -182,7 +182,7 @@ export async function runScripted(code:string, arg:{
                     return
                 }
                 let roleData:'user'|'char' = role === 'user' ? 'user' : 'char'
-                ScriptingEngineState.chat.message.push({role: roleData, data: value})
+                ScriptingEngineState.chat.message.push({role: roleData, data: value ?? ''})
             })
             declareAPI('insertChat', (id:string, index:number, role:string, value:string) => {
                 if(!ScriptingSafeIds.has(id)){

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -153,7 +153,7 @@ export async function runScripted(code:string, arg:{
                 }
                 const message = ScriptingEngineState.chat.message?.at(index)
                 if(message){
-                    message.data = value
+                    message.data = value ?? ''
                 }
             })
             declareAPI('setChatRole', (id:string, index:number, value:string) => {
@@ -189,7 +189,7 @@ export async function runScripted(code:string, arg:{
                     return
                 }
                 let roleData:'user'|'char' = role === 'user' ? 'user' : 'char'
-                ScriptingEngineState.chat.message.splice(index, 0, {role: roleData, data: value})
+                ScriptingEngineState.chat.message.splice(index, 0, {role: roleData, data: value ?? ''})
             })
 
             declareAPI('getTokens', async (id:string, value:string) => {

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -18,7 +18,7 @@ export interface Messagec extends Message{
 
 export function messageForm(arg:Message[], loadPages:number){
     function reformatContent(data:string){
-        return data.trim()
+        return data?.trim()
     }
 
     let a:Messagec[] = []


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Normally this shouldn't happen, but I found an issue in triggerLua where adding a chat with null data via the `addChat` API would make that chat inaccessible. This PR prevents that from happening and makes already broken chats accessible.