### PR TITLE
Feature: Add delete and reorder functionality to Custom Model accordion

### DIFF
--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -300,6 +300,16 @@
 
     {#each DBState.db.customModels as model, index}
         <Arcodion styled name={model.name ?? "Unnamed"}>
+            <div class="flex justify-between items-center mb-4">
+                <span class="text-lg font-medium">{model.name ?? "Unnamed"}</span>
+                <Button styled="outlined" onclick={() => {
+                    let models = DBState.db.customModels
+                    models.splice(index, 1)
+                    DBState.db.customModels = models
+                }}>
+                    <TrashIcon />
+                </Button>
+            </div>
             <span class="text-textcolor">{language.name}</span>
             <TextInput size={"sm"} bind:value={DBState.db.customModels[index].name}/>
             <span class="text-textcolor">{language.proxyRequestModel}</span>
@@ -385,11 +395,6 @@
             })
         }}>
             <PlusIcon />
-        </Button>
-        <Button onclick={() => {
-            DBState.db.customModels.pop()
-        }}>
-            <TrashIcon />
         </Button>
     </div>
 </Arcodion>

--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -14,7 +14,7 @@
     import { Capacitor } from "@capacitor/core";
     import { capStorageInvestigation } from "src/ts/storage/mobileStorage";
     import Arcodion from "src/lib/UI/Arcodion.svelte";
-  import { PlusIcon, TrashIcon } from "lucide-svelte";
+  import { PlusIcon, TrashIcon, ArrowUp, ArrowDown } from "lucide-svelte";
   import { v4 } from "uuid";
   import { MCPClient } from "src/ts/process/mcp/mcplib";
 
@@ -314,17 +314,41 @@
                     openedModels = new Set(openedModels)
                 }}
             >
-                <span class="mr-2">{model.name ?? "Unnamed"}</span>
-                <Button styled="outlined" onclick={(e) => {
-                    e.stopPropagation()
-                    let models = DBState.db.customModels
-                    models.splice(index, 1)
-                    DBState.db.customModels = models
-                    openedModels.delete(model.id)
-                    openedModels = new Set(openedModels)
-                }}>
-                    <TrashIcon />
-                </Button>
+                <span class="text-left">{model.name ?? "Unnamed"}</span>
+                <div class="flex items-center gap-1">
+                    <Button size="sm" styled="outlined" onclick={(e) => {
+                        e.stopPropagation()
+                        if(index === 0) return
+                        let models = DBState.db.customModels
+                        let temp = models[index]
+                        models[index] = models[index - 1]
+                        models[index - 1] = temp
+                        DBState.db.customModels = models
+                    }}>
+                        <ArrowUp />
+                    </Button>
+                    <Button size="sm" styled="outlined" onclick={(e) => {
+                        e.stopPropagation()
+                        if(index === DBState.db.customModels.length - 1) return
+                        let models = DBState.db.customModels
+                        let temp = models[index]
+                        models[index] = models[index + 1]
+                        models[index + 1] = temp
+                        DBState.db.customModels = models
+                    }}>
+                        <ArrowDown />
+                    </Button>
+                    <Button size="sm" styled="outlined" onclick={(e) => {
+                        e.stopPropagation()
+                        let models = DBState.db.customModels
+                        models.splice(index, 1)
+                        DBState.db.customModels = models
+                        openedModels.delete(model.id)
+                        openedModels = new Set(openedModels)
+                    }}>
+                        <TrashIcon />
+                    </Button>
+                </div>
             </button>
             {#if openedModels.has(model.id)}
                 <div class="flex flex-col border border-selected p-2 rounded-b-md overflow-x-auto">

--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -23,6 +23,8 @@
         size:string,
     }[] = $state([])
 
+    let openedModels = $state(new Set<string>())
+
     const characterSets = [
         'Latn',
         'Hani',
@@ -298,18 +300,34 @@
 
 <Arcodion styled name={language.customModels} className="overflow-x-auto">
 
-    {#each DBState.db.customModels as model, index}
-        <Arcodion styled name={model.name ?? "Unnamed"}>
-            <div class="flex justify-between items-center mb-4">
-                <span class="text-lg font-medium">{model.name ?? "Unnamed"}</span>
-                <Button styled="outlined" onclick={() => {
+    {#each DBState.db.customModels as model, index (model.id)}
+        <div class="flex flex-col mt-2">
+            <button class="hover:bg-selected px-6 py-2 text-lg rounded-t-md border-selected border flex justify-between items-center"
+                class:bg-selected={openedModels.has(model.id)}
+                class:rounded-b-md={!openedModels.has(model.id)}
+                onclick={() => {
+                    if (openedModels.has(model.id)) {
+                        openedModels.delete(model.id)
+                    } else {
+                        openedModels.add(model.id)
+                    }
+                    openedModels = new Set(openedModels)
+                }}
+            >
+                <span class="mr-2">{model.name ?? "Unnamed"}</span>
+                <Button styled="outlined" onclick={(e) => {
+                    e.stopPropagation()
                     let models = DBState.db.customModels
                     models.splice(index, 1)
                     DBState.db.customModels = models
+                    openedModels.delete(model.id)
+                    openedModels = new Set(openedModels)
                 }}>
                     <TrashIcon />
                 </Button>
-            </div>
+            </button>
+            {#if openedModels.has(model.id)}
+                <div class="flex flex-col border border-selected p-2 rounded-b-md overflow-x-auto">
             <span class="text-textcolor">{language.name}</span>
             <TextInput size={"sm"} bind:value={DBState.db.customModels[index].name}/>
             <span class="text-textcolor">{language.proxyRequestModel}</span>
@@ -378,7 +396,9 @@
                 {@render CustomFlagButton(index,'deepSeekThinkingInput', 18)}
                 {@render CustomFlagButton(index,'deepSeekThinkingOutput', 19)}
             </Arcodion>
-        </Arcodion>
+                </div>
+            {/if}
+        </div>
     {/each}
     <div class="flex items-center mt-4">
         <Button onclick={() => {

--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -400,8 +400,8 @@
             {/if}
         </div>
     {/each}
-    <div class="flex items-center mt-4">
-        <Button onclick={() => {
+    <div class="flex flex-col mt-2">
+        <button class="hover:bg-selected px-6 py-2 text-lg rounded-md border-selected border flex justify-center items-center cursor-pointer" onclick={() => {
             DBState.db.customModels.push({
                 internalId: "",
                 url: "",
@@ -415,7 +415,7 @@
             })
         }}>
             <PlusIcon />
-        </Button>
+        </button>
     </div>
 </Arcodion>
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
![image](https://github.com/user-attachments/assets/262ac3a0-5501-478b-a4c2-d78bb43c6451)

Added delete and reorder features to the Custom Model accordion component. Also implemented saving and reflecting the expansion state (open/closed) for each item.