### PR TITLE
Fix: Apply indentation to all lines for Trigger V2 effect description

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -1056,7 +1056,7 @@
             return `<span class="text-blue-500">${d || 'null'}</span>`
         })
 
-        return `<span class="text-purple-500" style="margin-left:${(effect as triggerEffectV2).indent}rem">${txt}</span>`
+        return `<div class="text-purple-500" style="margin-left:${(effect as triggerEffectV2).indent}rem">${txt}</div>`
     }
     
     onMount(() => {
@@ -1228,7 +1228,7 @@
                                 oncontextmenu={(e) => handleContextMenu(e, 1, i, effect)}
                             >
                                 {#if effect.type === 'v2EndIndent'}
-                                    <span class="text-textcolor" style:margin-left={effect.indent + 'rem'}>...</span>
+                                    <div class="text-textcolor" style:margin-left={effect.indent + 'rem'}>...</div>
                                 {:else}
                                     {@html formatEffectDisplay(effect)}
                                 {/if}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
![image](https://github.com/user-attachments/assets/8489b932-6a8b-4e3a-8af3-c22a84928aed)

This PR addresses an issue where the indentation for the Trigger V2 effect description was only applied to the first line.

To improve code readability, the indentation has now been applied consistently to all lines of the effect description.

This was achieved by changing the surrounding element from a `<span>` to a `<div>`, removing the inline structure that prevented multi-line indentation.