### PR TITLE
Feature: Add drag-and-drop reordering for prompt presets

### DIFF
--- a/src/lib/Setting/botpreset.svelte
+++ b/src/lib/Setting/botpreset.svelte
@@ -338,8 +338,8 @@
             </div>
         </div>
         {#each DBState.db.botPresets as preset, i}
-            <!-- Drop zone before each preset -->
             <div class="w-full h-1 transition-colors duration-200 hover:bg-gray-600" 
+                role="listitem"
                 ondragover={(e) => {
                     e.preventDefault()
                     e.currentTarget.classList.add('bg-gray-600')
@@ -455,8 +455,8 @@
             </button>
         {/each}
         
-        <!-- Drop zone after all presets -->
         <div class="w-full h-1 transition-colors duration-200 hover:bg-gray-600" 
+            role="listitem"
             ondragover={(e) => {
                 e.preventDefault()
                 e.currentTarget.classList.add('bg-gray-600')

--- a/src/lib/Setting/botpreset.svelte
+++ b/src/lib/Setting/botpreset.svelte
@@ -20,6 +20,8 @@
     let selectedPrompts: string[] = []
     let selectedDiffPreset = $state(-1)
 
+
+
     function isPromptItemPlain(item: PromptItem): item is PromptItemPlain {
         return (
             item.type === 'plain' || item.type === 'jailbreak' || item.type === 'cot'
@@ -67,7 +69,7 @@
         DBState.db.botPresets = botPresets;
     }
 
-    function handlePresetDrop(targetIndex: number, e: DragEvent) {
+    function handlePresetDrop(targetIndex: number, e) {
         e.preventDefault();
         e.stopPropagation();
         const data = e.dataTransfer?.getData('text');
@@ -393,7 +395,7 @@
                             e.stopPropagation()
                             handleDiffMode(i)
                         }} onkeydown={(e) => {
-                            if(e.key === 'Enter'){
+                            if(e.key === 'Enter' && e.currentTarget instanceof HTMLElement){
                                 e.currentTarget.click()
                             }
                         }}>
@@ -404,7 +406,7 @@
                         e.stopPropagation()
                         copyPreset(i)
                     }} onkeydown={(e) => {
-                        if(e.key === 'Enter'){
+                        if(e.key === 'Enter' && e.currentTarget instanceof HTMLElement){
                             e.currentTarget.click()
                         }
                     }}>
@@ -421,7 +423,7 @@
                             $ShowRealmFrameStore = `preset:${i}`
                         }
                     }} onkeydown={(e) => {
-                        if(e.key === 'Enter'){
+                        if(e.key === 'Enter' && e.currentTarget instanceof HTMLElement){
                             e.currentTarget.click()
                         }
                     }}>
@@ -443,7 +445,7 @@
                             changeToPreset(0, false)
                         }
                     }} onkeydown={(e) => {
-                        if(e.key === 'Enter'){
+                        if(e.key === 'Enter' && e.currentTarget instanceof HTMLElement){
                             e.currentTarget.click()
                         }
                     }}>

--- a/src/lib/Setting/botpreset.svelte
+++ b/src/lib/Setting/botpreset.svelte
@@ -337,16 +337,16 @@
         </div>
         {#each DBState.db.botPresets as preset, i}
             <!-- Drop zone before each preset -->
-            <div class="w-full h-1 transition-colors duration-200 hover:bg-green-500" 
+            <div class="w-full h-1 transition-colors duration-200 hover:bg-gray-600" 
                 ondragover={(e) => {
                     e.preventDefault()
-                    e.currentTarget.classList.add('bg-green-500')
+                    e.currentTarget.classList.add('bg-gray-600')
                 }} 
                 ondragleave={(e) => {
-                    e.currentTarget.classList.remove('bg-green-500')
+                    e.currentTarget.classList.remove('bg-gray-600')
                 }} 
                 ondrop={(e) => {
-                    e.currentTarget.classList.remove('bg-green-500')
+                    e.currentTarget.classList.remove('bg-gray-600')
                     handlePresetDrop(i, e)
                 }}>
             </div>
@@ -454,16 +454,16 @@
         {/each}
         
         <!-- Drop zone after all presets -->
-        <div class="w-full h-1 transition-colors duration-200 hover:bg-green-500" 
+        <div class="w-full h-1 transition-colors duration-200 hover:bg-gray-600" 
             ondragover={(e) => {
                 e.preventDefault()
-                e.currentTarget.classList.add('bg-green-500')
+                e.currentTarget.classList.add('bg-gray-600')
             }} 
             ondragleave={(e) => {
-                e.currentTarget.classList.remove('bg-green-500')
+                e.currentTarget.classList.remove('bg-gray-600')
             }} 
             ondrop={(e) => {
-                e.currentTarget.classList.remove('bg-green-500')
+                e.currentTarget.classList.remove('bg-gray-600')
                 handlePresetDrop(DBState.db.botPresets.length, e)
             }}>
         </div>


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR adds the ability to reorder prompt presets using a drag-and-drop interface.