### PR TITLE
fix: Make sure to update whole chat when necessary

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -175,8 +175,6 @@
         const triggerName = origin.getAttribute('risu-trigger')
         const btnEvent = origin.getAttribute('risu-btn')
 
-        console.log(origin, triggerName, btnEvent)
-
         const triggerResult =
             triggerName ?
                 await runTrigger(currentChar, 'manual', {
@@ -244,7 +242,7 @@
             {language.noMessage}
         </div>
     {:else}
-        {@const chatReloadPointer = $ReloadChatPointer[idx] ?? 0}
+        {@const chatReloadPointer = $ReloadGUIPointer + ($ReloadChatPointer[idx] ?? 0)}
         {@const totalLengthPointer = (idx > totalLength - 6) ? totalLength : 0}
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/Setting/Pages/Module/ModuleChatMenu.svelte
+++ b/src/lib/Setting/Pages/Module/ModuleChatMenu.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-    import { CheckCircle2Icon, Globe, XIcon } from "lucide-svelte";
+    import { CheckCircle2Icon, XIcon } from "lucide-svelte";
     import { language } from "src/lang";
     import Button from "src/lib/UI/GUI/Button.svelte";
     import TextInput from "src/lib/UI/GUI/TextInput.svelte";
     import type { RisuModule } from "src/ts/process/modules";
     
-    import { DBState } from 'src/ts/stores.svelte';
+    import { DBState, ReloadGUIPointer } from 'src/ts/stores.svelte';
     import { selectedCharID } from "src/ts/stores.svelte";
     import { SettingsMenuIndex, settingsOpen } from "src/ts/stores.svelte";
+
     interface Props {
         close?: any;
         alertMode?: boolean;
@@ -89,6 +90,7 @@
                                         DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].modules.push(rmodule.id)
                                     }
                                     DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].modules = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].modules
+                                    $ReloadGUIPointer += 1
                                 }}>
                                     <CheckCircle2Icon size={18}/>
                                 </button>

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -77,10 +77,6 @@ CustomCSSStore.subscribe((css) => {
     }
 })
 
-ReloadGUIPointer.subscribe(() => {
-    ReloadChatPointer.set({})
-})
-
 export function createSimpleCharacter(char:character|groupChat){
     if((!char) || char.type === 'group'){
         return null
@@ -118,6 +114,7 @@ export const QuickSettings = $state({
 export const disableHighlight = writable(true)
 
 ReloadGUIPointer.subscribe(() => {
+    ReloadChatPointer.set({})
     resetScriptCache()
 })
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

Made sure that changes to `$ReloadGUIPointer` really, really update the heavy part. Also, changing per-chat module activation will result in `$ReloadGUIPointer` increase as well.

Confirmed reloading with the new chat list implementation.