### PR TITLE
feat: Rework user memos with resource optimization and opt-in

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1137,4 +1137,10 @@ export const languageEnglish = {
     folderNameInput: "Please input the new folder name",
     folderRemoveLengthError: "To remove a folder, it must not contain any entries.",
     personaNote: "Persona Note",
+    userMemos: "Memos",
+    userMemosEmptyMessage: "No user memos yet.",
+    userMemosDelete: "Are you sure you want to delete this user memo?",
+    userMemoInitialize: "No saved memo data found in this chat session. Would you like to start a new memo?",
+    userMemosEnabled: "Enable User Memos",
+    userMemosError: "Could not proceed due to an issue with the memo data format. Please check your chat data or export it for backup.",
 }

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1002,4 +1002,9 @@ export const languageKorean = {
     "claudeBatching": "Claude 배칭",
     "folderNameInput": "새 폴더 이름을 입력해주세요",
     "folderRemoveLengthError": "폴더를 제거하려면 폴더가 비어 있어야 합니다.",
+    "userMemosEmptyMessage": "저장된 사용자 메모가 없습니다.",
+    "userMemos": "메모",
+    "userMemosDelete": "해당 메모를 삭제하시겠습니까?",
+    "userMemoInitialize": "현재 채팅 세션에서 저장된 메모 데이터를 찾을 수 없습니다. 이 채팅에서 메모를 새로 시작하시겠습니까?",
+    "userMemosEnabled": "유저 메모 활성화",
 }

--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -207,6 +207,10 @@
     {/if}
 {/if}
 <div class="flex items-center mt-4">
+    <Check bind:check={DBState.db.userMemosEnabled} name={language.userMemosEnabled}>
+    </Check>
+</div>
+<div class="flex items-center mt-4">
     <Check bind:check={DBState.db.dynamicAssets} name={language.dynamicAssets}>
         <Help key="dynamicAssets"/>
     </Check>

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1051,6 +1051,7 @@ export interface Database{
     promptTextInfoInsideChat:boolean
     claudeBatching:boolean
     claude1HourCaching:boolean
+    userMemosEnabled:boolean
 }
 
 interface SeparateParameters{
@@ -1548,6 +1549,7 @@ export interface Chat{
     bindedPersona?:string
     fmIndex?:number
     hypaV3Data?:SerializableHypaV3Data
+    userMemos?: {[chatId: string]: UserMemo[]}
     folderId?:string
     lastDate?:number
 }
@@ -1557,6 +1559,15 @@ export interface ChatFolder{
     name?:string
     color?:string
     folded:boolean
+}
+
+export interface UserMemo {
+    id: string
+    title: string
+    createdAt: string   // ISO string for JSON compatibility
+    updatedAt: string   // (Date becomes string when exported/imported)
+    content: string
+    locked?: boolean
 }
 
 export interface Message{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

Thank you for the previous feedback [#881](!https://github.com/kwaroran/RisuAI/pull/881). I've taken more time to think about this feature, especially regarding resource usage and data safety. I've completely reworked the implementation to be much more careful and would be grateful if you could take a moment to review this new approach.

---

### TL;DR
- What's Changed: The feature is now
    - **opt-in**
    - **stores notes in one central place** (not on every message)
    - **not modify the message object** implementation
    - asks for user **confirmation** before first use
    - has **platform-aware limits** to manage resources. For example, the web version is limited to 3 memos of 3KB(up to ~600 tokens) each, and users can see the real-time byte size as they type.
- Why It's Better than `{{// }}`CBS: It provides a more user-friendly way to manage structured notes for messages, without needing to edit the message content itself. `{{// }}` CBS more like a *hidden comment* than a *true memo* in the context of chat-level usage.

---

Here's how I've addressed the main concerns:

**1. New Approach: Memos are Now Not Stored on Individual Messages**
The memo data is now stored in a single `userMemos` object within the chat session, not on each individual message. This keeps the core message objects lightweight.

**2. It's Fully Opt-In and User-Confirmed.**
- Disabled by Default: First, users must enable the feature in Advanced Settings.
- One-Time Confirmation: Even after enabling it, the userMemos object is only created after the user explicitly confirms it for that specific chat session. This is an important safeguard: instead of automatically initializing if data is missing (which could risk overwriting a corrupted state), it asks for the user's input. The user is the most reliable source to know if they've previously written notes in that chat. This approach prevents accidental data loss and ensures that only users who actively consent are impacted.

**3. A Note on Data Safety and Storage Choice**
I believe the thoughts and ideas a user writes down during a session are deeply tied to that specific conversation. This makes them far more valuable than temporary data like translation caches. This strong coupling is why they must be seamlessly imported and exported with the chat session itself.

This is the primary reason I chose this integrated approach over external storage like LocalForage. While I considered other options, an external server database has too high a barrier to entry for most users. Using a lightweight DB for the Tauri version was another possibility, but I was concerned it would lead to a fragmented user experience, where notes might behave differently across the Web, Node, and Tauri versions.

This is why the initialization code looks so careful:
```javascript
// A brief explanation of the code's purpose
// This code first checks if 'userMemos' is truly missing.
// If it is, it asks the user for confirmation before creating it.
// If the data exists but seems corrupted (e.g., it's not an object),
// it logs an error and stops, to avoid overwriting anything.

if(!Object.prototype.hasOwnProperty.call(targetChat, 'userMemos')){
    const r = await confirm(`${language.userMemoInitialize}`)
    if(!r){ return }
    targetChat.userMemos = {}
}
else if(typeof targetChat.userMemos !== "object" || targetChat.userMemos === null || Array.isArray(targetChat.userMemos)){
    console.error(`[Memo Add] Invalid 'userMemos' type detected...`)
    return
}
```

**4. Platform-Aware Limits**
To further minimize impact, the resource limits are now different for each environment. For example, the Web version is restricted to just 3 memos of 3KB each, while the Node and Tauri versions allow for more generous limits.

---

I genuinely believe many users would love this feature. I've tried my best to minimize its impact while prioritizing a seamless user experience and data safety.

However, if this revised approach still doesn't align with your vision, please feel free to close this PR. I appreciate all the feedback you've given. :)

Thank you again for your time and for considering this revised proposal!