### PR TITLE
Feature: Implement drag-and-drop to reorder trigger types

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -896,9 +896,13 @@
 
     const moveTrigger = (fromIndex: number, toIndex: number) => {
         if (fromIndex === toIndex || fromIndex === 0 || toIndex === 0) return;
+        if (fromIndex < 0 || toIndex < 0 || fromIndex >= value.length || toIndex > value.length) return;
+        if (!value[fromIndex]) return;
         
         let triggers = [...value];
         const movedItem = triggers.splice(fromIndex, 1)[0];
+        if (!movedItem) return;
+        
         triggers.splice(toIndex, 0, movedItem);
         
         // Update selectedIndex if needed
@@ -1220,7 +1224,7 @@
                                     }}
                                     oncontextmenu={(e) => handleContextMenu(e, 0, i)}
                                 >
-                                    {trigger.comment || 'Unnamed Trigger'}
+                                    {trigger?.comment || 'Unnamed Trigger'}
                                 </button>
                             {/if}
                         {/each}
@@ -1263,13 +1267,15 @@
                     }}>
                         <div class="p-2 flex flex-col">
                             <span class="block text-textcolor2">{language.name}</span>
-                            <TextInput value={value[selectedIndex].comment} onchange={(e) => {
+                            <TextInput value={value[selectedIndex]?.comment || ''} onchange={(e) => {
+                                if (!value[selectedIndex]) return;
                                 const comment = e.currentTarget.value
                                 const prev = value[selectedIndex].comment
                                 for(let i = 1; i < value.length; i++){
+                                    if (!value[i] || !value[i].effect) continue;
                                     for(let j = 0; j < value[i].effect.length; j++){
                                         const effect = value[i].effect[j]
-                                        if(effect.type === 'v2RunTrigger' && effect.target === prev){
+                                        if(effect && effect.type === 'v2RunTrigger' && effect.target === prev){
                                             effect.target = comment
                                         }
                                     }
@@ -1279,40 +1285,43 @@
                         </div>
                         <div class="p-2 flex flex-col">
                             <span class="block text-textcolor2">{language.triggerOn}</span>
-                            <SelectInput bind:value={value[selectedIndex].type}>
-                                <OptionInput value="start">{language.triggerStart}</OptionInput>
-                                <OptionInput value="output">{language.triggerOutput}</OptionInput>
-                                <OptionInput value="input">{language.triggerInput}</OptionInput>
-                                <OptionInput value="manual">{language.triggerManual}</OptionInput>
-                                <OptionInput value="display">{language.editDisplay}</OptionInput>
-                                <OptionInput value="request">{language.editProcess}</OptionInput>
-
-                            </SelectInput>
+                            {#if value[selectedIndex]}
+                                <SelectInput bind:value={value[selectedIndex].type}>
+                                    <OptionInput value="start">{language.triggerStart}</OptionInput>
+                                    <OptionInput value="output">{language.triggerOutput}</OptionInput>
+                                    <OptionInput value="input">{language.triggerInput}</OptionInput>
+                                    <OptionInput value="manual">{language.triggerManual}</OptionInput>
+                                    <OptionInput value="display">{language.editDisplay}</OptionInput>
+                                    <OptionInput value="request">{language.editProcess}</OptionInput>
+                                </SelectInput>
+                            {/if}
                         </div>
                     </div>
                     <div class="border border-darkborderc ml-2 rounded-md flex-1 mr-2 overflow-x-auto overflow-y-auto" bind:this={menu0Container}>
-                        {#each value[selectedIndex].effect as effect, i}
-                            <button class="p-2 w-full text-start text-purple-500"
-                                class:hover:bg-selected={selectedEffectIndex !== i}
-                                class:bg-selected={selectedEffectIndex === i}
-                                onclick={() => {
-                                    if(selectedEffectIndex === i && lastClickTime + 500 > Date.now()){
-                                        menuMode = 1
-                                    }
+                        {#if value[selectedIndex] && value[selectedIndex].effect}
+                            {#each value[selectedIndex].effect as effect, i}
+                                <button class="p-2 w-full text-start text-purple-500"
+                                    class:hover:bg-selected={selectedEffectIndex !== i}
+                                    class:bg-selected={selectedEffectIndex === i}
+                                    onclick={() => {
+                                        if(selectedEffectIndex === i && lastClickTime + 500 > Date.now()){
+                                            menuMode = 1
+                                        }
 
-                                    selectMode = 1
-                                    lastClickTime = Date.now()
-                                    selectedEffectIndex = i
-                                }}
-                                oncontextmenu={(e) => handleContextMenu(e, 1, i, effect)}
-                            >
-                                {#if effect.type === 'v2EndIndent'}
-                                    <div class="text-textcolor" style:margin-left={effect.indent + 'rem'}>...</div>
-                                {:else}
-                                    {@html formatEffectDisplay(effect)}
-                                {/if}
-                            </button>
-                        {/each}
+                                        selectMode = 1
+                                        lastClickTime = Date.now()
+                                        selectedEffectIndex = i
+                                    }}
+                                    oncontextmenu={(e) => handleContextMenu(e, 1, i, effect)}
+                                >
+                                    {#if effect && effect.type === 'v2EndIndent'}
+                                        <div class="text-textcolor" style:margin-left={effect.indent + 'rem'}>...</div>
+                                    {:else if effect}
+                                        {@html formatEffectDisplay(effect)}
+                                    {/if}
+                                </button>
+                            {/each}
+                        {/if}
                         <button class="p-2 w-full text-start hover:bg-selected" onclick={() => {
                             //add effect
                             if(lastClickTime + 500 > Date.now()){

--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -905,7 +905,6 @@
         
         triggers.splice(toIndex, 0, movedItem);
         
-        // Update selectedIndex if needed
         if (selectedIndex === fromIndex) {
             selectedIndex = toIndex;
         } else if (fromIndex < selectedIndex && toIndex >= selectedIndex) {
@@ -1205,12 +1204,22 @@
                                 </div>
                                 
                                 <button
-                                    class="p-2 text-start text-textcolor2 hover:text-textcolor hover:cursor-grab active:cursor-grabbing"
+                                    class="p-2 text-start text-textcolor2 hover:text-textcolor hover:cursor-grab active:cursor-grabbing trigger-item"
                                     class:bg-darkbg={selectedIndex === i}
                                     draggable="true"
                                     ondragstart={(e) => {
                                         e.dataTransfer?.setData('text', 'trigger')
                                         e.dataTransfer?.setData('triggerIndex', i.toString())
+                                        
+                                        const dragElement = document.createElement('div')
+                                        dragElement.textContent = trigger?.comment || 'Unnamed Trigger'
+                                        dragElement.className = 'absolute -top-96 -left-96 px-4 py-2 bg-darkbg text-textcolor2 rounded text-sm whitespace-nowrap shadow-lg pointer-events-none z-50'
+                                        document.body.appendChild(dragElement)
+                                        e.dataTransfer?.setDragImage(dragElement, 10, 10)
+                                        
+                                        setTimeout(() => {
+                                            document.body.removeChild(dragElement)
+                                        }, 0)
                                     }}
                                     ondragover={(e) => {
                                         e.preventDefault()

--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -894,6 +894,35 @@
         }
     }
 
+    const moveTrigger = (fromIndex: number, toIndex: number) => {
+        if (fromIndex === toIndex || fromIndex === 0 || toIndex === 0) return;
+        
+        let triggers = [...value];
+        const movedItem = triggers.splice(fromIndex, 1)[0];
+        triggers.splice(toIndex, 0, movedItem);
+        
+        // Update selectedIndex if needed
+        if (selectedIndex === fromIndex) {
+            selectedIndex = toIndex;
+        } else if (fromIndex < selectedIndex && toIndex >= selectedIndex) {
+            selectedIndex = selectedIndex - 1;
+        } else if (fromIndex > selectedIndex && toIndex <= selectedIndex) {
+            selectedIndex = selectedIndex + 1;
+        }
+        
+        value = triggers;
+    }
+
+    const handleTriggerDrop = (targetIndex: number, e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const data = e.dataTransfer?.getData('text');
+        if (data === 'trigger') {
+            const sourceIndex = parseInt(e.dataTransfer?.getData('triggerIndex') || '0');
+            moveTrigger(sourceIndex, targetIndex);
+        }
+    }
+
     const handleKeydown = (e:KeyboardEvent) => {
         console.log(e.key)
         if(e.key === 'Escape'){
@@ -1156,9 +1185,35 @@
                             {#if i === 0}
                                 <!-- Header, skip the first trigger -->
                             {:else}
+                                <div class="w-full h-1 min-h-1 transition-colors duration-200 hover:bg-gray-600" 
+                                    role="listitem"
+                                    ondragover={(e) => {
+                                        e.preventDefault()
+                                        e.currentTarget.classList.add('bg-gray-600')
+                                    }} 
+                                    ondragleave={(e) => {
+                                        e.currentTarget.classList.remove('bg-gray-600')
+                                    }} 
+                                    ondrop={(e) => {
+                                        e.currentTarget.classList.remove('bg-gray-600')
+                                        handleTriggerDrop(i, e)
+                                    }}>
+                                </div>
+                                
                                 <button
-                                    class="p-2 text-start text-textcolor2 hover:text-textcolor"
+                                    class="p-2 text-start text-textcolor2 hover:text-textcolor hover:cursor-grab active:cursor-grabbing"
                                     class:bg-darkbg={selectedIndex === i}
+                                    draggable="true"
+                                    ondragstart={(e) => {
+                                        e.dataTransfer?.setData('text', 'trigger')
+                                        e.dataTransfer?.setData('triggerIndex', i.toString())
+                                    }}
+                                    ondragover={(e) => {
+                                        e.preventDefault()
+                                    }}
+                                    ondrop={(e) => {
+                                        handleTriggerDrop(i, e)
+                                    }}
                                     onclick={() => {
                                         selectMode = 0
                                         selectedIndex = i
@@ -1169,6 +1224,21 @@
                                 </button>
                             {/if}
                         {/each}
+                        
+                        <div class="w-full h-1 min-h-1 transition-colors duration-200 hover:bg-gray-600" 
+                            role="listitem"
+                            ondragover={(e) => {
+                                e.preventDefault()
+                                e.currentTarget.classList.add('bg-gray-600')
+                            }} 
+                            ondragleave={(e) => {
+                                e.currentTarget.classList.remove('bg-gray-600')
+                            }} 
+                            ondrop={(e) => {
+                                e.currentTarget.classList.remove('bg-gray-600')
+                                handleTriggerDrop(value.length, e)
+                            }}>
+                        </div>
                     </div>
                     <div>
                         <button class="p-2 border-t-darkborderc text-start text-textcolor2 hover:text-textcolor focus:bg-bgcolor" onclick={() => {


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR adds a drag-and-drop functionality to the v2Trigger component, allowing users to easily change the order of trigger types.