### PR TITLE
Feature: Add regex test() method to v2Trigger

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -287,6 +287,8 @@ export const languageEnglish = {
         v2ShowAlertDesc: "Show alert with {{value}}",
         v2ExtractRegex: "Extract Regex",
         v2ExtractRegexDesc: "Extract text from {{value}} with regex {{regexType}} {{regex}} and flags {{flagsType}} {{flags}}, then store result as {{resultType}} {{result}} => {{outputVar}}",
+        v2RegexTest: "Regex Test",
+        v2RegexTestDesc: "Test {{value}} with regex {{regex}} and flags {{flags}} => {{outputVar}}",
         v2GetLastMessage: "Get Last Message",
         v2GetLastMessageDesc: "Get Last Message => {{outputVar}}",
         v2GetMessageAtIndex: "Get Message at Index",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -236,6 +236,8 @@ export const languageKorean = {
         "v2ShowAlertDesc": "{{value}}로 알림 표시",
         "v2ExtractRegex": "정규식 추출",
         "v2ExtractRegexDesc": "{{value}}에서 정규식  {{regex}} 및 플래그 {{flags}}를 사용하여 텍스트 추출, 결과를 {{result}}로 저장 => {{outputVar}}",
+        "v2RegexTest": "정규식 테스트",
+        "v2RegexTestDesc": "{{value}}에서 정규식 {{regex}} 및 플래그 {{flags}}로 매칭 테스트 => {{outputVar}}",
         "v2GetLastMessage": "마지막 메시지 가져오기",
         "v2GetLastMessageDesc": "마지막 메시지 가져오기 => {{outputVar}}",
         "v2GetMessageAtIndex": "인덱스에서 메시지 가져오기",

--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -70,6 +70,7 @@
         'v2GetLorebookIndexViaName',
 
         //String
+        'v2RegexTest',
         'v2ExtractRegex',
         'v2GetCharAt',
         'v2GetCharCount',
@@ -808,6 +809,20 @@
                     depth: '3',
                     depthType: 'value',
                     outputVar: ''
+                }
+                break;
+            }
+            case 'v2RegexTest':{
+                editTrigger = {
+                    type: 'v2RegexTest',
+                    value: '',
+                    valueType: 'value',
+                    regex: '',
+                    regexType: 'value',
+                    flags: '',
+                    flagsType: 'value',
+                    outputVar: '',
+                    indent: 0
                 }
                 break;
             }
@@ -1985,6 +2000,29 @@
                     {:else if editTrigger.type === 'v2UpdateChatAt'}
                         <span class="block text-textcolor">{language.index}</span>
                         <TextInput bind:value={editTrigger.index} />
+                    {:else if editTrigger.type === 'v2RegexTest'}
+                        <span>{language.input}</span>
+                        <SelectInput bind:value={editTrigger.valueType}>
+                            <OptionInput value="value">{language.value}</OptionInput>
+                            <OptionInput value="var">{language.var}</OptionInput>
+                        </SelectInput>
+                        <TextInput bind:value={editTrigger.value} />
+                        <span>Regex: IN</span>
+                        <SelectInput bind:value={editTrigger.regexType}>
+                            <OptionInput value="value">{language.value}</OptionInput>
+                            <OptionInput value="var">{language.var}</OptionInput>
+                        </SelectInput>
+                        <TextInput bind:value={editTrigger.regex} />
+
+                        <span>Regex: FLAG</span>
+                        <SelectInput bind:value={editTrigger.flagsType}>
+                            <OptionInput value="value">{language.value}</OptionInput>
+                            <OptionInput value="var">{language.var}</OptionInput>
+                        </SelectInput>
+                        <TextInput bind:value={editTrigger.flags} />
+
+                        <span class="block text-textcolor">{language.outputVar}</span>
+                        <TextInput bind:value={editTrigger.outputVar} />
                     {:else}
                         <span>{language.noConfig}</span>
                     {/if}

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -39,7 +39,7 @@ export type triggerEffectV2 =   triggerV2Header|triggerV2IfVar|triggerV2Else|tri
                                 triggerV2SliceArrayVar|triggerV2GetIndexOfValueInArrayVar|triggerV2RemoveIndexFromArrayVar|triggerV2ConcatString|triggerV2GetLastUserMessage|
                                 triggerV2GetLastCharMessage|triggerV2GetAlertInput|triggerV2GetDisplayState|triggerV2SetDisplayState|triggerV2UpdateGUI|triggerV2UpdateChatAt|triggerV2Wait|
                                 triggerV2GetRequestState|triggerV2SetRequestState|triggerV2GetRequestStateRole|triggerV2SetRequestStateRole|triggerV2GetReuqestStateLength|triggerV2IfAdvanced|
-                                triggerV2QuickSearchChat|triggerV2StopPromptSending|triggerV2Tokenize
+                                triggerV2QuickSearchChat|triggerV2StopPromptSending|triggerV2Tokenize|triggerV2RegexTest
 
 export type triggerConditionsVar = {
     type:'var'|'value'
@@ -719,6 +719,18 @@ export type triggerV2Tokenize = {
     outputVar:string
 }
 
+export type triggerV2RegexTest = {
+    type: 'v2RegexTest',
+    value: string,
+    valueType: 'var'|'value',
+    regex: string,
+    regexType: 'var'|'value',
+    flags: string,
+    flagsType: 'var'|'value',
+    outputVar: string,
+    indent: number
+}
+
 const safeSubset = [
     'v2SetVar',
     'v2If',
@@ -731,6 +743,7 @@ const safeSubset = [
     'v2StopTrigger',
     'v2Random',
     'v2ExtractRegex',
+    'v2RegexTest',
     'v2GetCharAt',
     'v2GetCharCount',
     'v2ToLowerCase',
@@ -1945,6 +1958,19 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
                 case 'v2Tokenize':{
                     const value = effect.valueType === 'value' ? risuChatParser(effect.value,{chara:char}) : getVar(risuChatParser(effect.value,{chara:char}))
                     setVar(effect.outputVar, (await tokenize(value)).toString())
+                    break
+                }
+                case 'v2RegexTest':{
+                    try {
+                        const value = effect.valueType === 'value' ? risuChatParser(effect.value,{chara:char}) : getVar(risuChatParser(effect.value,{chara:char}))
+                        const regexPattern = effect.regexType === 'value' ? risuChatParser(effect.regex,{chara:char}) : getVar(risuChatParser(effect.regex,{chara:char}))
+                        const flags = effect.flagsType === 'value' ? risuChatParser(effect.flags,{chara:char}) : getVar(risuChatParser(effect.flags,{chara:char}))
+                        const regex = new RegExp(regexPattern, flags)
+                        const result = regex.test(value)
+                        setVar(effect.outputVar, result ? '1' : '0')
+                    } catch (error) {
+                        setVar(effect.outputVar, '0')
+                    }
                     break
                 }
             }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR introduces a new `test()` method to `v2Trigger`, named 'Regex Test'.

It performs a regular expression search on an input value. The output variable is set to `1` if the input matches the regex, and `0` otherwise.