### PR TITLE
Feature: Add indent guides to v2Trigger

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -1220,9 +1220,28 @@
                             </SelectInput>
                         </div>
                     </div>
-                    <div class="border border-darkborderc ml-2 rounded-md flex-1 mr-2 overflow-x-auto overflow-y-auto" bind:this={menu0Container}>
+                    <div class="border border-darkborderc ml-2 rounded-md flex-1 mr-2 overflow-x-auto overflow-y-auto relative" bind:this={menu0Container}>
                         {#each value[selectedIndex].effect as effect, i}
-                            <button class="p-2 w-full text-start text-purple-500"
+                            {#if effect.type === 'v2If' || effect.type === 'v2IfAdvanced' || effect.type === 'v2Loop' || effect.type === 'v2LoopNTimes' || effect.type === 'v2Else'}
+                                {@const blockIndent = (effect as triggerEffectV2).indent}
+                                {@const endIndex = value[selectedIndex].effect.findIndex((e, idx) => 
+                                    idx > i && e.type === 'v2EndIndent' && (e as triggerEffectV2).indent === blockIndent + 1
+                                )}
+                                {#if endIndex !== -1}
+                                    <div 
+                                        class="absolute w-px bg-gray-600 opacity-40"
+                                        style="left: {0.5 + blockIndent * 1}rem; top: {(i + 1) * 2.5}rem; height: {(endIndex - i - 0.5) * 2.5}rem;"
+                                    ></div>
+                                    <div 
+                                        class="absolute h-px bg-gray-600 opacity-40"
+                                        style="left: {0.5 + blockIndent * 1}rem; top: {(endIndex + 0.5) * 2.5}rem; width: 0.5rem;"
+                                    ></div>
+                                {/if}
+                            {/if}
+                        {/each}
+                        
+                        {#each value[selectedIndex].effect as effect, i}
+                            <button class="p-2 w-full text-start text-purple-500 relative"
                                 class:hover:bg-selected={selectedEffectIndex !== i}
                                 class:bg-selected={selectedEffectIndex === i}
                                 onclick={() => {

--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -1101,7 +1101,7 @@
         contextMenu = false
     }}>
         {#if contextMenu}
-            <div class="absolute flex-col gap-2 w-28 p-2 flex bg-darkbg border border-darkborderc rounded-md" style={contextMenuLoc.style}>
+            <div class="absolute flex-col gap-2 w-28 p-2 flex bg-darkbg border border-darkborderc rounded-md z-50" style={contextMenuLoc.style}>
                 {#if selectedEffectIndex !== -1 && value[selectedIndex].effect[selectedEffectIndex].type !== 'v2EndIndent' && selectMode === 1}
                     <button class="text-textcolor2 hover:text-textcolor" onclick={() => {
                         menuMode = 3


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
![image](https://github.com/user-attachments/assets/049f1d7a-e753-46d6-9b8b-a1b5d4690485)

Improves readability of the v2Trigger by adding vertical lines to visualize indentation levels.
