### PR TITLE
feat: Pass chat index to editDisplay

### DIFF
--- a/src/ts/process/scripts.ts
+++ b/src/ts/process/scripts.ts
@@ -98,9 +98,8 @@ export function resetScriptCache(){
 
 export async function processScriptFull(char:character|groupChat|simpleCharacterArgument, data:string, mode:ScriptMode, chatID = -1, cbsConditions:CbsConditions = {}){
     let db = getDatabase()
-    const originalData = data
     let emoChanged = false
-    data = await runLuaEditTrigger(char, mode, data)
+    data = await runLuaEditTrigger(char, mode, data, { index:chatID })
 
     if(mode === 'editdisplay'){
         const currentChar = getCurrentCharacter()


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

This PR provides current editing chat's index to `editDisplay` callback as its third agrument. This can be used to optimize Lua code greatly by short-circuiting if index is too small compared to `getChatLength()`.

To avoid future breaking changes, I've made it as `meta` object so that any additional properties can be freely added.