### PR TITLE
fix(hypav3): enhance memory retrieval

### DIFF
--- a/src/lib/Others/HypaV3Modal.svelte
+++ b/src/lib/Others/HypaV3Modal.svelte
@@ -29,7 +29,7 @@
     SearchUI,
     SearchResult,
   } from "./HypaV3Modal/types";
-  import { alertConfirmTwice } from "./HypaV3Modal/utils";
+  import { alertConfirmTwice, handleDualAction } from "./HypaV3Modal/utils";
 
   const hypaV3DataState = $derived(
     DBState.db.characters[$selectedCharID].chats[
@@ -675,73 +675,6 @@
         error: `Error occurred: ${error.message}`,
       };
     }
-  }
-
-  type DualActionParams = {
-    onMainAction?: () => void;
-    onAlternativeAction?: () => void;
-  };
-
-  function handleDualAction(node: HTMLElement, params: DualActionParams = {}) {
-    const DOUBLE_TAP_DELAY = 300;
-
-    const state = {
-      lastTap: 0,
-      tapTimeout: null,
-    };
-
-    const handleTouch = (event: TouchEvent) => {
-      const currentTime = new Date().getTime();
-      const tapLength = currentTime - state.lastTap;
-
-      if (tapLength < DOUBLE_TAP_DELAY && tapLength > 0) {
-        // Double tap detected
-        event.preventDefault();
-        window.clearTimeout(state.tapTimeout); // Cancel the first tap timeout
-        params.onAlternativeAction?.();
-        state.lastTap = 0; // Reset state
-      } else {
-        state.lastTap = currentTime; // First tap
-        // Delayed single tap execution
-        state.tapTimeout = window.setTimeout(() => {
-          if (state.lastTap === currentTime) {
-            // If no double tap occurred
-            params.onMainAction?.();
-          }
-        }, DOUBLE_TAP_DELAY);
-      }
-    };
-
-    const handleClick = (event: MouseEvent) => {
-      if (event.shiftKey) {
-        params.onAlternativeAction?.();
-      } else {
-        params.onMainAction?.();
-      }
-    };
-
-    if ("ontouchend" in window) {
-      // Mobile environment
-      node.addEventListener("touchend", handleTouch);
-    } else {
-      // Desktop environment
-      node.addEventListener("click", handleClick);
-    }
-
-    return {
-      destroy() {
-        if ("ontouchend" in window) {
-          node.removeEventListener("touchend", handleTouch);
-        } else {
-          node.removeEventListener("click", handleClick);
-        }
-
-        window.clearTimeout(state.tapTimeout); // Cleanup timeout
-      },
-      update(newParams: DualActionParams) {
-        params = newParams;
-      },
-    };
   }
 </script>
 

--- a/src/lib/Others/HypaV3Modal/modal-header.svelte
+++ b/src/lib/Others/HypaV3Modal/modal-header.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import {
+    SearchIcon,
+    StarIcon,
+    SettingsIcon,
+    MoreVerticalIcon,
+    BarChartIcon,
+    Trash2Icon,
+    XIcon,
+  } from "lucide-svelte";
+  import { language } from "src/lang";
+  import {
+    hypaV3ModalOpen,
+    settingsOpen,
+    SettingsMenuIndex,
+    DBState,
+    selectedCharID,
+  } from "src/ts/stores.svelte";
+  import type { SearchUI } from "./types";
+  import { alertConfirmTwice } from "./utils";
+
+  interface Props {
+    searchUIState: SearchUI;
+    filterImportant: boolean;
+    dropdownOpen: boolean;
+    filterSelected: boolean;
+  }
+
+  let {
+    searchUIState = $bindable(null),
+    filterImportant = $bindable(false),
+    dropdownOpen = $bindable(false),
+    filterSelected = $bindable(false),
+  }: Props = $props();
+
+  async function toggleSearch() {
+    if (searchUIState === null) {
+      searchUIState = {
+        ref: null,
+        query: "",
+        results: [],
+        currentResultIndex: -1,
+        requestedSearchFromIndex: -1,
+        isNavigating: false,
+      };
+
+      // Focus on search element after it's rendered
+      await tick();
+
+      if (searchUIState.ref) {
+        searchUIState.ref.focus();
+      }
+    } else {
+      searchUIState = null;
+    }
+  }
+
+  function toggleFilterImportant() {
+    searchUIState = null;
+    filterImportant = !filterImportant;
+  }
+
+  function openGlobalSettings() {
+    $hypaV3ModalOpen = false;
+    $settingsOpen = true;
+    $SettingsMenuIndex = 2; // Other bot settings
+  }
+
+  function openDropdown(e: MouseEvent) {
+    e.stopPropagation();
+    dropdownOpen = true;
+  }
+
+  function toggleFilterSelected() {
+    searchUIState = null;
+    filterSelected = !filterSelected;
+  }
+
+  async function resetData() {
+    if (
+      await alertConfirmTwice(
+        language.hypaV3Modal.resetConfirmMessage,
+        language.hypaV3Modal.resetConfirmSecondMessage
+      )
+    ) {
+      DBState.db.characters[$selectedCharID].chats[
+        DBState.db.characters[$selectedCharID].chatPage
+      ].hypaV3Data = {
+        summaries: [],
+      };
+    }
+  }
+
+  function closeModal() {
+    $hypaV3ModalOpen = false;
+  }
+</script>
+
+<div class="flex items-center justify-between mb-2 sm:mb-4">
+  <!-- Modal Title -->
+  <h1 class="text-lg font-semibold sm:text-2xl text-zinc-300">
+    {language.hypaV3Modal.titleLabel}
+  </h1>
+
+  <!-- Buttons Container -->
+  <div class="flex items-center gap-2">
+    <!-- Open Search Button -->
+    <button
+      class="p-2 transition-colors text-zinc-400 hover:text-zinc-200"
+      tabindex="-1"
+      onclick={async () => await toggleSearch()}
+    >
+      <SearchIcon class="w-6 h-6" />
+    </button>
+
+    <!-- Filter Important Summary Button -->
+    <button
+      class="p-2 transition-colors {filterImportant
+        ? 'text-yellow-400 hover:text-yellow-300'
+        : 'text-zinc-400 hover:text-zinc-200'}"
+      tabindex="-1"
+      onclick={toggleFilterImportant}
+    >
+      <StarIcon class="w-6 h-6" />
+    </button>
+
+    <!-- Open Global Settings Button -->
+    <button
+      class="p-2 transition-colors text-zinc-400 hover:text-zinc-200"
+      tabindex="-1"
+      onclick={openGlobalSettings}
+    >
+      <SettingsIcon class="w-6 h-6" />
+    </button>
+
+    <!-- Open Dropdown Button -->
+    <div class="relative">
+      <button
+        class="p-2 transition-colors text-zinc-400 hover:text-zinc-200"
+        tabindex="-1"
+        onclick={openDropdown}
+      >
+        <MoreVerticalIcon class="w-6 h-6" />
+      </button>
+
+      {#if dropdownOpen}
+        <div
+          class="absolute right-0 z-10 p-2 mt-1 border rounded-md shadow-lg border-zinc-700 bg-zinc-800"
+        >
+          <!-- Buttons Container -->
+          <div class="flex items-center gap-2">
+            <!-- Filter Selected Summary Button -->
+            <button
+              class="p-2 transition-colors {filterSelected
+                ? 'text-blue-400 hover:text-blue-300'
+                : 'text-zinc-400 hover:text-zinc-200'}"
+              tabindex="-1"
+              onclick={toggleFilterSelected}
+            >
+              <BarChartIcon class="w-6 h-6" />
+            </button>
+
+            <!-- Reset Data Button -->
+            <button
+              class="p-2 transition-colors text-zinc-400 hover:text-rose-300"
+              tabindex="-1"
+              onclick={async () => await resetData()}
+            >
+              <Trash2Icon class="w-6 h-6" />
+            </button>
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Close Modal Button -->
+    <button
+      class="p-2 transition-colors text-zinc-400 hover:text-zinc-200"
+      tabindex="-1"
+      onclick={closeModal}
+    >
+      <XIcon class="w-6 h-6" />
+    </button>
+  </div>
+</div>

--- a/src/lib/Others/HypaV3Modal/types.ts
+++ b/src/lib/Others/HypaV3Modal/types.ts
@@ -1,0 +1,44 @@
+export interface SummaryUI {
+  originalRef: HTMLTextAreaElement;
+  isTranslating: boolean;
+  translation: string | null;
+  translationRef: HTMLTextAreaElement;
+  isRerolling: boolean;
+  rerolledText: string | null;
+  isRerolledTranslating: boolean;
+  rerolledTranslation: string | null;
+  rerolledTranslationRef: HTMLTextAreaElement;
+  chatMemoRefs: HTMLButtonElement[];
+}
+
+export interface ExpandedMessageUI {
+  summaryIndex: number;
+  selectedChatMemo: string;
+  isTranslating: boolean;
+  translation: string | null;
+  translationRef: HTMLTextAreaElement;
+}
+
+export interface SearchUI {
+  ref: HTMLInputElement;
+  query: string;
+  results: SearchResult[];
+  currentResultIndex: number;
+  requestedSearchFromIndex: number;
+  isNavigating: boolean;
+}
+
+export type SearchResult = SummarySearchResult | ChatMemoSearchResult;
+
+export interface SummarySearchResult {
+  type: "summary";
+  summaryIndex: number;
+  start: number;
+  end: number;
+}
+
+export interface ChatMemoSearchResult {
+  type: "chatmemo";
+  summaryIndex: number;
+  memoIndex: number;
+}

--- a/src/lib/Others/HypaV3Modal/utils.ts
+++ b/src/lib/Others/HypaV3Modal/utils.ts
@@ -1,0 +1,10 @@
+import { alertConfirm } from "src/ts/alert";
+
+export async function alertConfirmTwice(
+  firstMessage: string,
+  secondMessage: string
+): Promise<boolean> {
+  return (
+    (await alertConfirm(firstMessage)) && (await alertConfirm(secondMessage))
+  );
+}

--- a/src/lib/Others/HypaV3Modal/utils.ts
+++ b/src/lib/Others/HypaV3Modal/utils.ts
@@ -8,3 +8,73 @@ export async function alertConfirmTwice(
     (await alertConfirm(firstMessage)) && (await alertConfirm(secondMessage))
   );
 }
+
+export type DualActionParams = {
+  onMainAction?: () => void;
+  onAlternativeAction?: () => void;
+};
+
+export function handleDualAction(
+  element: HTMLElement,
+  params: DualActionParams = {}
+) {
+  const DOUBLE_TAP_DELAY = 300;
+
+  const state = {
+    lastTap: 0,
+    tapTimeout: null,
+  };
+
+  const handleTouch = (event: TouchEvent) => {
+    const currentTime = new Date().getTime();
+    const tapLength = currentTime - state.lastTap;
+
+    if (tapLength < DOUBLE_TAP_DELAY && tapLength > 0) {
+      // Double tap detected
+      event.preventDefault();
+      window.clearTimeout(state.tapTimeout); // Cancel the first tap timeout
+      params.onAlternativeAction?.();
+      state.lastTap = 0; // Reset state
+    } else {
+      state.lastTap = currentTime; // First tap
+      // Delayed single tap execution
+      state.tapTimeout = window.setTimeout(() => {
+        if (state.lastTap === currentTime) {
+          // If no double tap occurred
+          params.onMainAction?.();
+        }
+      }, DOUBLE_TAP_DELAY);
+    }
+  };
+
+  const handleClick = (event: MouseEvent) => {
+    if (event.shiftKey) {
+      params.onAlternativeAction?.();
+    } else {
+      params.onMainAction?.();
+    }
+  };
+
+  if ("ontouchend" in window) {
+    // Mobile environment
+    element.addEventListener("touchend", handleTouch);
+  } else {
+    // Desktop environment
+    element.addEventListener("click", handleClick);
+  }
+
+  return {
+    destroy() {
+      if ("ontouchend" in window) {
+        element.removeEventListener("touchend", handleTouch);
+      } else {
+        element.removeEventListener("click", handleClick);
+      }
+
+      window.clearTimeout(state.tapTimeout); // Cleanup timeout
+    },
+    update(newParams: DualActionParams) {
+      params = newParams;
+    },
+  };
+}

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -90,7 +90,7 @@ export const MODAL_DISPLAYMODE = {
   All: "All",
   Range: "Range",
   Recent: "Recent",
-  Metrics: "Metrics",
+  Selected: "Selected",
 } as const;
 
 export type ModalDisplayMode =

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1,6 +1,10 @@
 import { type memoryVector, HypaProcesser, similarity } from "./hypamemory";
 import { TaskRateLimiter } from "./taskRateLimiter";
-import { type EmbeddingText, HypaProcessorV2 } from "./hypamemoryv2";
+import {
+  type EmbeddingText,
+  type EmbeddingResult,
+  HypaProcessorV2,
+} from "./hypamemoryv2";
 import {
   type Chat,
   type character,
@@ -48,6 +52,12 @@ interface HypaV3Data {
     lastSimilarSummaries: number[];
     lastRandomSummaries: number[];
   };
+  modalSettings?: {
+    displayMode: ModalDisplayMode;
+    displayRangeFrom: number;
+    displayRangeTo: number;
+    displayRecentCount: number;
+  };
 }
 
 export interface SerializableHypaV3Data {
@@ -75,6 +85,16 @@ interface SummaryChunk {
   text: string;
   summary: Summary;
 }
+
+export const MODAL_DISPLAYMODE = {
+  All: "All",
+  Range: "Range",
+  Recent: "Recent",
+  Metrics: "Metrics",
+} as const;
+
+export type ModalDisplayMode =
+  (typeof MODAL_DISPLAYMODE)[keyof typeof MODAL_DISPLAYMODE];
 
 export interface HypaV3Result {
   currentTokens: number;
@@ -585,13 +605,14 @@ async function hypaMemoryV3MainExp(
 
     // Dynamically generate embedding texts
     const ebdTexts: EmbeddingText<Summary>[] = unusedSummaries.flatMap(
-      (summary) => {
+      (summary, summaryIndex) => {
         const splitted = summary.text
           .split("\n\n")
           .filter((e) => e.trim().length > 0);
 
-        return splitted.map((e) => ({
-          content: e.trim(),
+        return splitted.map((chunk, chunkIndex) => ({
+          id: `${summaryIndex}-${chunkIndex}`,
+          content: chunk.trim(),
           metadata: summary,
         }));
       }
@@ -648,13 +669,25 @@ async function hypaMemoryV3MainExp(
     const recentChats = chats
       .slice(-minChatsForSimilarity)
       .filter((chat) => chat.content.trim().length > 0);
-    const queries: string[] = recentChats.flatMap((chat) => {
-      return chat.content.split("\n\n").filter((e) => e.trim().length > 0);
-    });
+
+    const queries = recentChats
+      .map((chat, index) => {
+        const subQueries = chat.content
+          .split("\n\n")
+          .filter((e) => e.trim().length > 0);
+        const weight =
+          (index + 1) /
+          ((recentChats.length * (recentChats.length + 1)) / 2) /
+          subQueries.length;
+
+        return subQueries.map((content) => ({
+          content,
+          weight,
+        }));
+      })
+      .flat();
 
     if (queries.length > 0) {
-      const scoredSummaries = new Map<Summary, number>();
-
       try {
         // Start of performance measurement: similarity search
         console.log(
@@ -663,8 +696,33 @@ async function hypaMemoryV3MainExp(
         const searchStartTime = performance.now();
 
         const batchScoredResults = await processor.similaritySearchScoredBatch(
-          queries
+          queries.map((query) => query.content)
         );
+
+        /*
+        // Hybrid search may be implemented in the future
+        await keywordEngine.addDocuments(
+          Array.from(processor.vectors.values())
+        );
+
+        const batchkeywordResults = [];
+        for (const query of queries) {
+          batchkeywordResults.push(await keywordEngine.search(query));
+        }
+
+        const batchHybridResults = [];
+        for (let i = 0; i < queries.length; i++) {
+          const [semanticResults] = batchScoredResults[i];
+          const keywordResults = batchkeywordResults[i];
+
+          batchHybridResults.push(
+            simpleRRF<EmbeddingResult<Summary>>([
+              semanticResults,
+              keywordResults,
+            ])
+          );
+        }
+        */
 
         const searchEndTime = performance.now();
         console.debug(
@@ -674,16 +732,40 @@ async function hypaMemoryV3MainExp(
         );
         // End of performance measurement: similarity search
 
-        for (const scoredResults of batchScoredResults) {
-          for (const [ebdResult, similarity] of scoredResults) {
-            const summary = ebdResult.metadata;
+        const rankedChunks = simpleCC<EmbeddingResult<Summary>>(
+          batchScoredResults,
+          (listIndex) => queries[listIndex].weight
+        );
 
-            scoredSummaries.set(
-              summary,
-              (scoredSummaries.get(summary) || 0) + similarity
+        const rankedSummaries = childToParentRRF<
+          EmbeddingResult<Summary>,
+          Summary
+        >(rankedChunks, (chunk) => chunk.metadata);
+
+        while (rankedSummaries.length > 0) {
+          const summary = rankedSummaries.shift();
+          const summaryTokens = await tokenizer.tokenizeChat({
+            role: "system",
+            content: summary.text + summarySeparator,
+          });
+
+          if (
+            summaryTokens + consumedSimilarMemoryTokens >
+            reservedSimilarMemoryTokens
+          ) {
+            console.log(
+              logPrefix,
+              "Stopping similar memory selection:",
+              `\nconsumedSimilarMemoryTokens(${consumedSimilarMemoryTokens}) + summaryTokens(${summaryTokens}) > reservedSimilarMemoryTokens(${reservedSimilarMemoryTokens})`
             );
+            break;
           }
+
+          selectedSimilarSummaries.push(summary);
+          consumedSimilarMemoryTokens += summaryTokens;
         }
+
+        selectedSummaries.push(...selectedSimilarSummaries);
       } catch (error) {
         return {
           currentTokens,
@@ -699,61 +781,6 @@ async function hypaMemoryV3MainExp(
           subMsg: "",
         });
       }
-
-      // Normalize scores
-      if (scoredSummaries.size > 0) {
-        const maxScore = Math.max(...scoredSummaries.values());
-
-        for (const [summary, score] of scoredSummaries.entries()) {
-          scoredSummaries.set(summary, score / maxScore);
-        }
-      }
-
-      // Sort in descending order
-      const scoredArray = [...scoredSummaries.entries()].sort(
-        ([, scoreA], [, scoreB]) => scoreB - scoreA
-      );
-
-      while (scoredArray.length > 0) {
-        const [summary] = scoredArray.shift();
-        const summaryTokens = await tokenizer.tokenizeChat({
-          role: "system",
-          content: summary.text + summarySeparator,
-        });
-
-        /*
-        console.log(
-          logPrefix,
-          "Trying to add similar summary:",
-          "\nSummary Tokens:",
-          summaryTokens,
-          "\nConsumed Similar Memory Tokens:",
-          consumedSimilarMemoryTokens,
-          "\nReserved Tokens:",
-          reservedSimilarMemoryTokens,
-          "\nWould exceed:",
-          summaryTokens + consumedSimilarMemoryTokens >
-            reservedSimilarMemoryTokens
-        );
-        */
-
-        if (
-          summaryTokens + consumedSimilarMemoryTokens >
-          reservedSimilarMemoryTokens
-        ) {
-          console.log(
-            logPrefix,
-            "Stopping similar memory selection:",
-            `\nconsumedSimilarMemoryTokens(${consumedSimilarMemoryTokens}) + summaryTokens(${summaryTokens}) > reservedSimilarMemoryTokens(${reservedSimilarMemoryTokens})`
-          );
-          break;
-        }
-
-        selectedSimilarSummaries.push(summary);
-        consumedSimilarMemoryTokens += summaryTokens;
-      }
-
-      selectedSummaries.push(...selectedSimilarSummaries);
     }
 
     console.log(
@@ -1326,7 +1353,6 @@ async function hypaMemoryV3Main(
       };
     }
 
-    const scoredSummaries = new Map<Summary, number>();
     const recentChats = chats
       .slice(-minChatsForSimilarity)
       .filter((chat) => chat.content.trim().length > 0);
@@ -1364,18 +1390,51 @@ async function hypaMemoryV3Main(
       }
 
       try {
-        for (const query of queries) {
+        const scoredLists: [SummaryChunk, number][][] = [];
+
+        for (let i = 0; i < queries.length; i++) {
+          const query = queries[i];
           const scoredChunks = await processor.similaritySearchScoredEx(query);
 
-          for (const [chunk, similarity] of scoredChunks) {
-            const summary = chunk.summary;
-
-            scoredSummaries.set(
-              summary,
-              (scoredSummaries.get(summary) || 0) + similarity
-            );
-          }
+          scoredLists.push(scoredChunks);
         }
+
+        const rankedChunks = simpleCC<SummaryChunk>(
+          scoredLists,
+          (listIndex, totalLists) => {
+            return (listIndex + 1) / ((totalLists * (totalLists + 1)) / 2);
+          }
+        );
+
+        const rankedSummaries = childToParentRRF<SummaryChunk, Summary>(
+          rankedChunks,
+          (chunk) => chunk.summary
+        );
+
+        while (rankedSummaries.length > 0) {
+          const summary = rankedSummaries.shift();
+          const summaryTokens = await tokenizer.tokenizeChat({
+            role: "system",
+            content: summary.text + summarySeparator,
+          });
+
+          if (
+            summaryTokens + consumedSimilarMemoryTokens >
+            reservedSimilarMemoryTokens
+          ) {
+            console.log(
+              logPrefix,
+              "Stopping similar memory selection:",
+              `\nconsumedSimilarMemoryTokens(${consumedSimilarMemoryTokens}) + summaryTokens(${summaryTokens}) > reservedSimilarMemoryTokens(${reservedSimilarMemoryTokens})`
+            );
+            break;
+          }
+
+          selectedSimilarSummaries.push(summary);
+          consumedSimilarMemoryTokens += summaryTokens;
+        }
+
+        selectedSummaries.push(...selectedSimilarSummaries);
       } catch (error) {
         return {
           currentTokens,
@@ -1385,52 +1444,6 @@ async function hypaMemoryV3Main(
         };
       }
     }
-
-    // Sort in descending order
-    const scoredArray = [...scoredSummaries.entries()].sort(
-      ([, scoreA], [, scoreB]) => scoreB - scoreA
-    );
-
-    while (scoredArray.length > 0) {
-      const [summary] = scoredArray.shift();
-      const summaryTokens = await tokenizer.tokenizeChat({
-        role: "system",
-        content: summary.text + summarySeparator,
-      });
-
-      /*
-      console.log(
-        logPrefix,
-        "Trying to add similar summary:",
-        "\nSummary Tokens:",
-        summaryTokens,
-        "\nConsumed Similar Memory Tokens:",
-        consumedSimilarMemoryTokens,
-        "\nReserved Tokens:",
-        reservedSimilarMemoryTokens,
-        "\nWould exceed:",
-        summaryTokens + consumedSimilarMemoryTokens >
-          reservedSimilarMemoryTokens
-      );
-      */
-
-      if (
-        summaryTokens + consumedSimilarMemoryTokens >
-        reservedSimilarMemoryTokens
-      ) {
-        console.log(
-          logPrefix,
-          "Stopping similar memory selection:",
-          `\nconsumedSimilarMemoryTokens(${consumedSimilarMemoryTokens}) + summaryTokens(${summaryTokens}) > reservedSimilarMemoryTokens(${reservedSimilarMemoryTokens})`
-        );
-        break;
-      }
-
-      selectedSimilarSummaries.push(summary);
-      consumedSimilarMemoryTokens += summaryTokens;
-    }
-
-    selectedSummaries.push(...selectedSimilarSummaries);
 
     console.log(
       logPrefix,
@@ -1781,6 +1794,92 @@ export function createHypaV3Preset(
   };
 }
 
+function simpleCC<T>(
+  scoredLists: [T, number][][],
+  weightFunc?: (listIndex: number, totalLists: number) => number
+): T[] {
+  const scores = new Map<T, number>();
+
+  for (let listIndex = 0; listIndex < scoredLists.length; listIndex++) {
+    const list = scoredLists[listIndex];
+    const weight = weightFunc
+      ? weightFunc(listIndex, scoredLists.length)
+      : 1 / scoredLists.length;
+
+    for (const [item, score] of list) {
+      scores.set(item, (scores.get(item) || 0) + score * weight);
+    }
+  }
+
+  return Array.from(scores.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([item]) => item);
+}
+
+function simpleRRF<T>(rankedLists: T[][], k: number = 60): T[] {
+  const scores = new Map<T, number>();
+
+  for (let listIndex = 0; listIndex < rankedLists.length; listIndex++) {
+    const list = rankedLists[listIndex];
+
+    for (let itemIndex = 0; itemIndex < list.length; itemIndex++) {
+      const item = list[itemIndex];
+      const rank = itemIndex + 1;
+      const rrfTerm = 1 / (k + rank);
+
+      scores.set(item, (scores.get(item) || 0) + rrfTerm);
+    }
+  }
+
+  return Array.from(scores.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([item]) => item);
+}
+
+function childToParentRRF<C, P>(
+  rankedChildren: C[],
+  parentFunc: (child: C) => P,
+  k: number = 60
+): P[] {
+  const scores = new Map<P, number>();
+
+  for (let childIndex = 0; childIndex < rankedChildren.length; childIndex++) {
+    const child = rankedChildren[childIndex];
+    const parent = parentFunc(child);
+    const rank = childIndex + 1;
+    const rrfTerm = 1 / (k + rank);
+
+    scores.set(parent, (scores.get(parent) || 0) + rrfTerm);
+  }
+
+  return Array.from(scores.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([parent]) => parent);
+}
+
+function normalizeScores<T>(scoredList: [T, number][]): [T, number][] {
+  if (scoredList.length === 0) {
+    return [];
+  }
+
+  const scores = scoredList.map(([, score]) => score);
+  const minScore = Math.min(...scores);
+  const maxScore = Math.max(...scores);
+
+  if (minScore === maxScore) {
+    if (minScore === 0) {
+      return scoredList.map(([item]) => [item, 0]);
+    }
+
+    return scoredList.map(([item]) => [item, 1]);
+  }
+
+  return scoredList.map(([item, score]) => {
+    const normalizedScore = (score - minScore) / (maxScore - minScore);
+    return [item, normalizedScore];
+  });
+}
+
 interface SummaryChunkVector {
   chunk: SummaryChunk;
   vector: memoryVector;
@@ -1828,7 +1927,7 @@ class HypaProcesserEx extends HypaProcesser {
         chunk: scv.chunk,
         similarity: similarity(queryVector, scv.vector.embedding),
       }))
-      .sort((a, b) => (a.similarity > b.similarity ? -1 : 0))
+      .sort((a, b) => b.similarity - a.similarity)
       .map((result) => [result.chunk, result.similarity]);
   }
 }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

## Summary

Resolved the issue where the last user message was ignored during similarity search in the HypaV3 memory system due to equal weighting, and introduced an improved ranking algorithm using Convex Combination and RRF-inspired scoring.

## Problem Context
In the existing system, equal weights were applied to the last 3 messages (e.g., User-AI-User), causing AI messages, which are typically longer and have more paragraphs, to dominate the similarity search, resulting in the last user message being ignored during retrieval.

## What's Changed
1. **Temporal differential weighting**: Assign higher weights to recent messages using `(index + 1) / recentChats.length`
2. **Sub-query normalization (Exp only)**: Divide weights by the number of paragraphs in each message to mitigate length-based bias
3. **Multi-stage ranking**: Apply differential weighting with CC, then aggregate chunk scores to summary scores using RRF-style scoring for final selection

## Credit
This PR was implemented based on a suggestion by @clwmz