### PR TITLE
fix: Ensure bot folder image visibility across browser sessions

### DIFF
--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -114,7 +114,7 @@
           id: folder.id,
           name: folder.name,
           color: folder.color,
-          img: folder.img,
+          img: folder.imgFile,
         });
       }
     }
@@ -477,7 +477,7 @@
           {:else if char.type === "folder"}
             {#key char.color}
             {#key char.name}
-              <SidebarAvatar src="slot" size="56" rounded={IconRounded} bordered name={char.name} color={char.color} backgroundimg={char.img}
+              <SidebarAvatar src="slot" size="56" rounded={IconRounded} bordered name={char.name} color={char.color} backgroundimg={char.img ? getCharImage(char.img, "plain") : ""}
               oncontextmenu={async (e) => {
                 e.preventDefault()
                 const sel = parseInt(await alertSelect([language.renameFolder,language.changeFolderColor,language.changeFolderImage,language.cancel]))

--- a/src/lib/SideBars/SidebarAvatar.svelte
+++ b/src/lib/SideBars/SidebarAvatar.svelte
@@ -9,7 +9,7 @@
     onClick?: any;
     bordered?: boolean;
     color?: string;
-    backgroundimg?: string;
+    backgroundimg?: string|Promise<string>;
     children?: import('svelte').Snippet;
     oncontextmenu?: (event: MouseEvent & {
         currentTarget: EventTarget & HTMLDivElement;
@@ -42,6 +42,7 @@
 >
   {#if src}
     {#if src === "slot"}
+      {#await backgroundimg}
       <div
         class="bg-skin-border sidebar-avatar rounded-md bg-top flex items-center justify-center bg-opacity-50"
         class:bg-darkbg={color === 'default' || color === ''}
@@ -57,15 +58,34 @@
         style:width={size + "px"}
         style:height={size + "px"}
         style:minWidth={size + "px"}
-        style:background-image={backgroundimg ? `url('${backgroundimg}')` : undefined}
-        style:background-size={backgroundimg ? "cover" : undefined}
-        style:background-position={backgroundimg ? "center" : undefined}
+        class:rounded-md={!rounded} class:rounded-full={rounded} 
+      ></div>
+      {:then resolvedBgImg}
+      <div
+        class="bg-skin-border sidebar-avatar rounded-md bg-top flex items-center justify-center bg-opacity-50"
+        class:bg-darkbg={color === 'default' || color === ''}
+        class:bg-red-700={color === 'red'}
+        class:bg-yellow-700={color === 'yellow'}
+        class:bg-green-700={color === 'green'}
+        class:bg-blue-700={color === 'blue'}
+        class:bg-indigo-700={color === 'indigo'}
+        class:bg-purple-700={color === 'purple'}
+        class:bg-pink-700={color === 'pink'}
+
+
+        style:width={size + "px"}
+        style:height={size + "px"}
+        style:minWidth={size + "px"}
+        style:background-image={resolvedBgImg ? `url('${resolvedBgImg}')` : undefined}
+        style:background-size={resolvedBgImg ? "cover" : undefined}
+        style:background-position={resolvedBgImg ? "center" : undefined}
         class:rounded-md={!rounded} class:rounded-full={rounded} 
       >
-      {#if !backgroundimg}
+      {#if !resolvedBgImg}
         {@render children?.()}
       {/if}
-    </div>
+        </div>
+    {/await}
     {:else}
       {#await src}
         <div


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
Hello! This PR fixes an issue with folder images for bots.

## Problem
Previously, when a folder image was uploaded, it saved correctly but did not display properly when viewed in a different browser or a new session (like an incognito window).

## Solution
I've updated the code to use the existing `getCharImage` function to load the folder image, just like it's done for other bot images. This ensures the image is rendered correctly.

Please let me know if you have any feedback or if there are any other issues. Thank you!