### PR TITLE
Fix: Correct navigation for new module creation

### DIFF
--- a/src/lib/Setting/Pages/Module/ModuleSettings.svelte
+++ b/src/lib/Setting/Pages/Module/ModuleSettings.svelte
@@ -130,6 +130,7 @@
                 description: '',
                 id: v4(),
             }
+            mode = 1
         }}>
             <PlusIcon />
         </button>


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR resolves a bug that prevented users from navigating to the 'create new module' page when clicking the '+' button within a module.
The button's event handler has been corrected to ensure proper navigation.