### PR TITLE
Moved the body.tool removal to fix GoggleAI error.

### DIFF
--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -485,15 +485,21 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
             `https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/publishers/google/models/${arg.modelInfo.internalID}:${endpoint}`
         
         // VertexAI api will return error if functionDeclarations is empty
-        if(body.tools?.functionDeclarations?.length === 0){
-            body.tools = undefined
-        }
+        // moved out of if statement as LLMFormat.GoogleCloud requests also need this removed
+        //if(body.tools?.functionDeclarations?.length === 0){
+        //    body.tools = undefined
+        //}
     }
     else if(arg.modelInfo.format === LLMFormat.GoogleCloud && arg.useStreaming){
         url = `https://generativelanguage.googleapis.com/v1beta/models/${arg.modelInfo.internalID}:streamGenerateContent?key=${db.google.accessToken}`
     }
     else{
         url = `https://generativelanguage.googleapis.com/v1beta/models/${arg.modelInfo.internalID}:generateContent?key=${db.google.accessToken}`
+    }
+
+    // GoogleAI api will also return an error if functionDeclarations is empty
+    if(body.tools?.functionDeclarations?.length === 0){
+        body.tools = undefined
     }
 
     if(arg.previewBody){


### PR DESCRIPTION
# PR Checklist
- [X] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Moved the body.tools removal out of the GoogleCloud.VertexAIGemini if statement so it will also be applied for newer models that use the LLMFormat.GoogleCloud

This fixes an issue when calling the GoogleAI directly without any tools loaded it will produce the error:
```
{
  "error": {
    "code": 400,
    "message": "The GenerateContentRequest proto is invalid:\n * tools[0].tool_type: required one_of 'tool_type' must have one initialized field",
    "status": "INVALID_ARGUMENT"
  }
}
```
This is identified as a bug in: https://discord.com/channels/1108412316619391006/1382932637072752680
I was able to reproduce and fix the error with this very minor change.