### PR TITLE
Feature: Add timing metadata to chat request information tab

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -17,6 +17,7 @@
     import { alertClear, alertConfirm, alertNormal, alertRequestData, alertWait } from "../../ts/alert"
     import { ParseMarkdown, type CbsConditions, type simpleCharacterArgument } from "../../ts/parser.svelte"
     import { getCurrentCharacter, getCurrentChat, setCurrentChat, type MessageGenerationInfo } from "../../ts/storage/database.svelte"
+    import { selectedCharID } from "../../ts/stores.svelte"
     import { HideIconStore, ReloadGUIPointer, selIdState } from "../../ts/stores.svelte"
     import AutoresizeArea from "../UI/GUI/TextAreaResizable.svelte"
     import ChatBody from './ChatBody.svelte'
@@ -200,8 +201,12 @@
             <button class="text-sm p-1 text-textcolor2 border-darkborderc float-end mr-2 my-1
                             hover:ring-darkbutton hover:ring rounded-md hover:text-textcolor transition-all flex justify-center items-center" 
                     onclick={() => {
+                        const currentGenerationInfo = idx >= 0 ? 
+                            DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[idx].generationInfo :
+                            messageGenerationInfo
+
                         alertRequestData({
-                            genInfo: messageGenerationInfo,
+                            genInfo: currentGenerationInfo,
                             idx: idx,
                         })
                     }}

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -274,6 +274,22 @@
                     <span class="text-purple-500 justify-self-end">{JSON.stringify(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[$alertGenerationInfoStore.idx]).length} Bytes</span>
                     <span class="text-yellow-500">Time</span>
                     <span class="text-yellow-500 justify-self-end">{(new Date(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[$alertGenerationInfoStore.idx].time ?? 0)).toLocaleString()}</span>
+                    {#if $alertGenerationInfoStore.genInfo.stageTiming}
+                        {@const stage1 = parseFloat(((($alertGenerationInfoStore.genInfo.stageTiming.stage1 ?? 0) / 1000).toFixed(1)))}
+                        {@const stage2 = parseFloat(((($alertGenerationInfoStore.genInfo.stageTiming.stage2 ?? 0) / 1000).toFixed(1)))}
+                        {@const stage3 = parseFloat(((($alertGenerationInfoStore.genInfo.stageTiming.stage3 ?? 0) / 1000).toFixed(1)))}
+                        {@const stage4 = parseFloat(((($alertGenerationInfoStore.genInfo.stageTiming.stage4 ?? 0) / 1000).toFixed(1)))}
+                        {@const totalRounded = (stage1 + stage2 + stage3 + stage4).toFixed(1)}
+                        <span class="text-gray-400">Timing</span>
+                        <span class="text-gray-400 justify-self-end">
+                            <span style="color: #60a5fa;">{stage1}</span> + 
+                            <span style="color: #db2777;">{stage2}</span> + 
+                            <span style="color: #34d399;">{stage3}</span> + 
+                            <span style="color: #8b5cf6;">{stage4}</span> = 
+                            <span class="text-white font-bold">{totalRounded}s</span>
+                        </span>
+                    {/if}
+
                     <span class="text-green-500">Tokens</span>
                     {#await tokenize(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[$alertGenerationInfoStore.idx].data)}
                         <span class="text-green-500 justify-self-end">Loading</span>

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1578,6 +1578,12 @@ export interface MessageGenerationInfo{
     inputTokens?: number
     outputTokens?: number
     maxContext?: number
+    stageTiming?: {
+        stage1?: number
+        stage2?: number
+        stage3?: number
+        stage4?: number
+    }
 }
 
 export interface MessagePresetInfo{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

![image](https://github.com/user-attachments/assets/8e68d8d2-b186-4e20-9945-64d5da2f10f5)

## Summary
Added a new "Timing" tab to the chat request metadata section.

## Changes
- Added timing calculations for 4 key stages of the request-response cycle
- Displays time duration from request submission to response arrival
- Enhanced request metadata with performance tracking information

## Benefits
- Provides visibility into request processing performance
- Helps identify potential bottlenecks in the communication flow
- Improves debugging and monitoring capabilities