### PR TITLE
feat: Improve Google/OpenAI request experience with tool use, including response streaming

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1139,5 +1139,6 @@ export const languageEnglish = {
     personaNote: "Persona Note",
     mcpAccessPrompt: "{{tool}} is trying to \"{{action}}\". do you want to allow this?",
     rememberToolUsage: "Remember tool usage",
+    simplifiedToolUse: "Simplified tool usage",
     toolCalled: "Tool '{{tool}}' Called",
 }

--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -242,6 +242,9 @@
     <Check bind:check={DBState.db.rememberToolUsage} name={language.rememberToolUsage}></Check>
 </div>
 <div class="flex items-center mt-4">
+    <Check bind:check={DBState.db.simplifiedToolUse} name={language.simplifiedToolUse}></Check>
+</div>
+<div class="flex items-center mt-4">
     <Check bind:check={DBState.db.useTokenizerCaching} name={language.useTokenizerCaching}>
     </Check>
 </div>

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -568,6 +568,7 @@ export function setDatabase(data:Database){
     data.customModels ??= []
     data.authRefreshes ??= []
     data.rememberToolUsage ??= true
+    data.simplifiedToolUse ??= false
     //@ts-ignore
     if(!globalThis.__NODE__ && !window.__TAURI_INTERNALS__){
         //this is intended to forcely reduce the size of the database in web
@@ -1052,6 +1053,7 @@ export interface Database{
     claudeBatching:boolean
     claude1HourCaching:boolean
     rememberToolUsage:boolean
+    simplifiedToolUse:boolean
 }
 
 interface SeparateParameters{


### PR DESCRIPTION
# PR Checklist
- [X] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [X] Have you added type definitions?

---

# Description
This PR significantly improves the overall experience (MCP) for Google and OpenAI requests, continuing the work from PR https://github.com/kwaroran/RisuAI/pull/927. 
It resolves critical issues related to tool usage logs and context in OpenAI, fixes response streaming for Google requests, and enables simultaneous use of tools with streaming for both Google and OpenAI. Additionally, new options have been introduced in the advanced settings to enhance user control over tool display and logging.

## Problem Solved
*   **OpenAI Tool Log & Context Correction:** Previously, tool usage logs in OpenAI requests were incorrectly placed at the start of the response, rather than their actual position within the conversation flow. Furthermore, these logs only showed the final model text response, instead of the entire tool-use process. This PR corrects these issues for accurate representation.
*   **Google Request Streaming Enabled:** Response streaming is now fully available in Google requests.
*   **Simultaneous Streaming & Tool Use:** Response streaming and tools can now be used simultaneously on both Google and OpenAI requests.
    *   (Example: response streaming + tool + Google request)

         https://github.com/user-attachments/assets/00f6e504-1743-40e9-bb1b-743159120002

*   **Google Role Name Correction:** Corrected role names in Google requests from uppercase (`'USER'`, `'MODEL'`) to lowercase (`'user'`, `'model'`, `'function'`) to align with Google's API documentation (Source: [Firebase Google Docs](https://firebase.google.com/docs/ai-logic/function-calling?hl=ko&api=vertex)).
*   **`rememberToolUsage` Fix for Google:** Fixed an issue where the `rememberToolUsage` option was not applied properly in Google requests.

## Added Features
*   **`simplifiedToolUse` option** (default: `false`)
    *   **Location:** Advanced Settings
    *   **Purpose:** Streamlines the display and context of tool call logs.
    *   **Details:**
        Normally, tool calling results in a verbose full log, including all intermediate contextual steps (e.g., `A -> Tool A -> B -> Tool B -> C`).
        When `simplifiedToolUse` is enabled, these intermediate steps (A, B) are omitted from both the follow-up request context and the final chat display (e.g., `Tool A -> Tool B -> C`).
        While this involves **sacrificing some intermediate contextual output**, it provides a significantly cleaner and more focused view in the chat interface.
    *   **Example (simplifiedToolUse enabled):**
    
        https://github.com/user-attachments/assets/14676552-64bd-432f-a8d3-17ebae00a0b4

*   **`rememberToolUsage` option** (default: `true`)
    *   **Location:** Advanced Settings
    *   **Purpose:** Controls whether tool call history is preserved.
    *   **Details:**
        If enabled, executed tool calls and their results will be logged in the chat history. Crucially, these tool call results will also be included in subsequent requests as part of the conversation context, allowing the system to remember past tool interactions.
    *   **Example (rememberToolUsage disabled):**
    
        https://github.com/user-attachments/assets/f137e4b5-8329-40b8-93d9-cd4823ef13c4

* If the follow-up request after a tool call fails, it will be retried up to `requestRetrys` times

## Notes
*   **Experimental Censorship Mitigation & Inference Fix:**
    Through extensive experimentation with Google tool calling requests, it was found that placing `functionResponse` content directly at the end of the request body could lead to significantly increased censorship. A technique of appending an empty user message (i.e., a user role with empty text content) to the end of the request body was found to effectively bypass this censorship and also resolve certain model inference issues. This functionality is currently implemented in the code but disabled by default, pending further testing and stabilization.

src/ts/process/request/google.ts
![image](https://github.com/user-attachments/assets/a88c22a2-ed08-473b-b3f6-9454c107e4ad)

*   **OpenAI Multi-line & Tool Incompatibility:**
    OpenAI requests do not support simultaneous usage of multiline generation and tools. Attempting to combine them will result in an error.
*   **Future Consideration (Anthropic):**
    Similar improvements in tool handling with response streaming might be beneficial for Anthropic models