### PR TITLE
Troubleshooting PayloadTooLargeError: request entity too large in heavy chat environments

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -6,8 +6,8 @@ const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
 const fs = require('fs/promises')
 const crypto = require('crypto')
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false}));
-app.use(express.json({ limit: '50mb' }));
-app.use(express.raw({ type: 'application/octet-stream', limit: '50mb' }));
+app.use(express.json({ limit: '150mb' }));
+app.use(express.raw({ type: 'application/octet-stream', limit: '150mb' }));
 const {pipeline} = require('stream/promises')
 const https = require('https');
 const sslPath = path.join(process.cwd(), 'server/node/ssl/certificate');


### PR DESCRIPTION
Troubleshooting PayloadTooLargeError: request entity too large in heavy chat environments

# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Shouldn't 150mb be enough...?
