### PR TITLE
Increase payload size limit to 100MB

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -6,8 +6,8 @@ const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
 const fs = require('fs/promises')
 const crypto = require('crypto')
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false}));
-app.use(express.json({ limit: '150mb' }));
-app.use(express.raw({ type: 'application/octet-stream', limit: '150mb' }));
+app.use(express.json({ limit: '100mb' }));
+app.use(express.raw({ type: 'application/octet-stream', limit: '100mb' }));
 const {pipeline} = require('stream/promises')
 const https = require('https');
 const sslPath = path.join(process.cwd(), 'server/node/ssl/certificate');

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -6,8 +6,8 @@ const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
 const fs = require('fs/promises')
 const crypto = require('crypto')
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false}));
-app.use(express.json({ limit: '50mb' }));
-app.use(express.raw({ type: 'application/octet-stream', limit: '50mb' }));
+app.use(express.json({ limit: '150mb' }));
+app.use(express.raw({ type: 'application/octet-stream', limit: '150mb' }));
 const {pipeline} = require('stream/promises')
 const https = require('https');
 const sslPath = path.join(process.cwd(), 'server/node/ssl/certificate');


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
- Partially resolve PayloadTooLargeError: request entity too large in heavy chat environments
- express.json() and express.raw() limits raised: 50MB → 100MB
- Adjusted to match Cloudflare Reverse Proxy/Tunnel Free & Pro plan max upload size (100MB)