### PR TITLE
Add gemini 2.5 pro stable

### DIFF
--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -1120,6 +1120,16 @@ export const LLMModels: LLMModel[] = [
         recommended: true
     },
     {
+        name: "Gemini Pro 2.5",
+        id: 'gemini-2.5-pro',
+        provider: LLMProvider.GoogleCloud,
+        format: LLMFormat.GoogleCloud,
+        flags: [LLMFlags.geminiBlockOff,LLMFlags.hasImageInput, LLMFlags.hasImageOutput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput,  LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole],
+        parameters: ['temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        tokenizer: LLMTokenizer.GoogleCloud,
+        recommended: true
+    },
+    {
         name: "Gemini Flash 2.5 Preview (04/17)",
         id: 'gemini-2.5-flash-preview-04-17',
         provider: LLMProvider.GoogleCloud,

--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -1124,7 +1124,7 @@ export const LLMModels: LLMModel[] = [
         id: 'gemini-2.5-pro',
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
-        flags: [LLMFlags.geminiBlockOff,LLMFlags.hasImageInput, LLMFlags.hasImageOutput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput,  LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole],
+        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput,  LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking],
         parameters: ['temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Add support for the stable release of Gemini 2.5 Pro (`gemini-2.5-pro`) which is currently missing from the model list.