### PR TITLE
fix: retranslate trigger and translation loading spinner visibility

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -24,7 +24,7 @@
     let translating = $state(false)
     let editMode = $state(false)
     let statusMessage:string = $state('')
-    let retranslate = false
+    let retranslate = $state(false)
     interface Props {
         message?: string;
         name?: string;
@@ -217,7 +217,6 @@
                             hover:ring-darkbutton hover:ring rounded-md hover:text-textcolor transition-all flex justify-center items-center" 
                     onclick={() => {
                         retranslate = true
-                        $ReloadGUIPointer = $ReloadGUIPointer + 1
                     }}
             >
                 <RefreshCcwIcon size={20} />
@@ -260,7 +259,8 @@
                     {name}
                     role={role ?? null}
                     bind:translated={translated}
-                    bind:translating={translating} />
+                    bind:translating={translating}
+                    bind:retranslate={retranslate} />
             {/key}
         </span>
     {/if}

--- a/src/lib/ChatScreens/ChatBody.svelte
+++ b/src/lib/ChatScreens/ChatBody.svelte
@@ -5,7 +5,7 @@
     import { alertError } from "../../ts/alert"
     import { ParseMarkdown, postTranslationParse, trimMarkdown, type CbsConditions, type simpleCharacterArgument } from "../../ts/parser.svelte"
     import { getLLMCache, translateHTML } from "../../ts/translator/translator"
-    
+
     interface Props {
         character?: simpleCharacterArgument|string|null
         firstMessage?: boolean
@@ -15,6 +15,7 @@
         role: string|null
         translated: boolean
         translating: boolean
+        retranslate: boolean
     }
 
     let {
@@ -24,14 +25,14 @@
         msgDisplay,
         role,
         translated = $bindable(false),
-        translating = $bindable(false)
+        translating = $bindable(false),
+        retranslate = $bindable(false)
     }: Props =  $props()
 
     // svelte-ignore non_reactive_update
     let lastParsed = ''
     let lastCharArg:string|simpleCharacterArgument = null
     let lastChatId = -10
-    let retranslate = false
 
     function getCbsCondition(){
         try{
@@ -49,7 +50,7 @@
         }
     }
 
-    const markParsing = async (data: string, charArg: string | simpleCharacterArgument, chatID: number, translateText?:boolean, tries?:number) => {
+    const markParsing = async (data: string, charArg: string | simpleCharacterArgument, chatID: number, tries?:number) => {
         let lastParsedQueue = ''
         let mode = 'notrim' as const
         try {
@@ -57,7 +58,7 @@
                 lastParsedQueue = ''
                 lastCharArg = charArg
                 lastChatId = chatID
-                translateText = false
+                let translateText = false
                 try {
                     if(DBState.db.autoTranslate){
                         if(DBState.db.autoTranslateCachedOnly && DBState.db.translatorType === 'llm'){
@@ -89,41 +90,47 @@
                     console.error(error)
                 }
             }
-            if(translateText){
-                if (!retranslate && DBState.db.showTranslationLoading) {
-                    lastParsed = `<div class="flex justify-center items-center"><div class="animate-spin rounded-full h-8 w-8 border-b-2 border-textcolor"></div></div>`
+            if(retranslate || translated){
+                if (DBState.db.showTranslationLoading) {
+                    lastParsed = `<div style="display:flex;justify-content:center;align-items:center;height:48px;"><div style="animation: spin 1s linear infinite; border-radius: 50%; height: 32px; width: 32px; border: 2px solid #3b82f6; border-top: 2px solid transparent;"></div></div><style>@keyframes spin { to { transform: rotate(360deg); } }</style>`
                 }
+
+                let transResult
                 
-                let doRetranslate = retranslate
-                retranslate = false
                 if(DBState.db.translatorType === 'llm' && DBState.db.translateBeforeHTMLFormatting){
                     await sleep(100)
                     translating = true
-                    data = await translateHTML(data, false, charArg, chatID, doRetranslate)
+                    data = await translateHTML(data, false, charArg, chatID, retranslate)
                     translating = false
                     const marked = await ParseMarkdown(data, charArg, mode, chatID, getCbsCondition())
                     lastParsedQueue = marked
                     lastCharArg = charArg
-                    return marked
+                    transResult = marked
                 }
                 else if(!DBState.db.legacyTranslation){
                     const marked = await ParseMarkdown(data, charArg, 'pretranslate', chatID, getCbsCondition())
                     translating = true
-                    const translated = await postTranslationParse(await translateHTML(marked, false, charArg, chatID, doRetranslate))
+                    const translated = await postTranslationParse(await translateHTML(marked, false, charArg, chatID, retranslate))
                     translating = false
                     lastParsedQueue = translated
                     lastCharArg = charArg
-                    return translated
+                    transResult = translated
                 }
                 else{
                     const marked = await ParseMarkdown(data, charArg, mode, chatID, getCbsCondition())
                     translating = true
-                    const translated = await translateHTML(marked, false, charArg, chatID, doRetranslate)
+                    const translated = await translateHTML(marked, false, charArg, chatID, retranslate)
                     translating = false
                     lastParsedQueue = translated
                     lastCharArg = charArg
-                    return translated
+                    transResult = translated
                 }
+
+                setTimeout(() => {
+                    retranslate = false
+                }, 10);
+
+                return transResult
             }
             else{
                 const marked = await ParseMarkdown(data, charArg, mode, chatID, getCbsCondition())
@@ -135,10 +142,10 @@
             //retry
             if(tries > 2){
 
-                alertError(`Error while parsing chat message: ${translateText}, ${error.message}, ${error.stack}`)
+                alertError(`Error while parsing chat message: ${translated}, ${error.message}, ${error.stack}`)
                 return data
             }
-            return await markParsing(data, charArg, chatID, translateText, (tries ?? 0) + 1)
+            return await markParsing(data, charArg, chatID, (tries ?? 0) + 1)
         }
         finally{
             //since trimMarkdown is fast, we don't need to cache it
@@ -146,7 +153,7 @@
         }
     }
 
-    let markParsingResult = $derived.by(() => markParsing(msgDisplay, character, idx, translated))
+    let markParsingResult = $derived.by(() => markParsing(msgDisplay, character, idx))
 </script>
 
 {#await markParsingResult}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fixed an issue where clicking retranslate button did not trigger markParsing due to missing dependency tracking.
- Ensured the translation loading spinner is always visible during translation by using inline styles.
   - Tailwind CSS with a prefix (x-risu-) caused spinner classes like animate-spin to not apply, resulting in the spinner not being displayed.