### PR TITLE
fix: prevent infinite backup accumulation on Tauri/Node

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -459,7 +459,7 @@ export async function saveDb(){
  */
 async function getDbBackups() {
     let db = getDatabase()
-    if(db?.account?.useSync){
+    if(db?.account?.useSync && !isTauri && !isNodeServer){
         return []
     }
     if(isTauri){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Previously, DB backups accumulated infinitely on Tauri/Node environments due to the account sync cleanup logic being skipped when sync was enabled. 
Since account sync is unavailable on Tauri/Node, this caused backup files to grow without limit. 
Fixed by ensuring backup cleanup runs on these platforms regardless of sync settings.
![image](https://github.com/user-attachments/assets/6d5cf629-2358-4910-b6b2-6f7b4bdbd29e)


