### PR TITLE
fix: handle empty response on google request

### DIFF
--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -871,6 +871,15 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
     }
     
     const result = processTextResponse(rDatas)
+
+    // fail if the result is empty
+    if(!result) {
+        return {
+            type: 'fail',
+            result: `Got empty response: ${JSON.stringify(res.data)}`
+        }
+    }
+
     console.log(result)
     return {
         type: 'success',


### PR DESCRIPTION
# PR Checklist
- [X] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Previously, Google API requests would return empty text responses when content was censored or blocked by safety filters, making it difficult for users to understand what went wrong.

Now empty responses are treated as request failures, which:
- Provides clear error messages for debugging
- Enables automatic retry logic to potentially resolve issues
- Gives users better visibility into why their request failed