### PR TITLE
feat: use pixel-based resizing on writing inlay image

### DIFF
--- a/src/ts/process/files/inlays.ts
+++ b/src/ts/process/files/inlays.ts
@@ -82,17 +82,15 @@ export async function writeInlayImage(imgObj:HTMLImageElement, arg:{name?:string
             drawHeight = imgObj.height
             drawWidth = imgObj.width
 
-            //resize image to fit inlay, if it's too big (max 1024px)
-            if(drawHeight > 1024){
-                drawWidth = drawWidth * (1024 / drawHeight)
-                drawHeight = 1024
+            //resize image to fit inlay, if total pixels exceed 1024*1024
+            const maxPixels = 1024 * 1024
+            const currentPixels = drawHeight * drawWidth
+            
+            if(currentPixels > maxPixels){
+                const scaleFactor = Math.sqrt(maxPixels / currentPixels)
+                drawWidth = Math.floor(drawWidth * scaleFactor)
+                drawHeight = Math.floor(drawHeight * scaleFactor)
             }
-            if(drawWidth > 1024){
-                drawHeight = drawHeight * (1024 / drawWidth)
-                drawWidth = 1024
-            }
-            drawHeight = Math.floor(drawHeight)
-            drawWidth = Math.floor(drawWidth)
 
             canvas.width = drawWidth
             canvas.height = drawHeight


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Change inlay image resizing from max 1024px width/height to max 1024×1024 total pixels.

**Before:** Images resized if width OR height > 1024px
**After:** Images resized only if total pixels > 1,048,576

## Benefits
- Supports NovelAI default resolutions like 1216×832 without unnecessary downscaling
- Preserves aspect ratios while maintaining memory limits
- More flexible resolution support within pixel budget

## Examples
- ✅ 1216×832 = 1,011,712 pixels (now allowed)
- ✅ 2048×512 = 1,048,576 pixels (now allowed)
- ❌ 2048×1024 = 2,097,152 pixels (still resized)