### PR TITLE
fix: auto translation with 'cached message only' option

### DIFF
--- a/src/lib/ChatScreens/ChatBody.svelte
+++ b/src/lib/ChatScreens/ChatBody.svelte
@@ -51,6 +51,9 @@
     }
 
     const markParsing = async (data: string, charArg: string | simpleCharacterArgument, chatID: number, tries?:number) => {
+        // track 'translated' and 'retranslate' state
+        translated;
+        retranslate;
         let lastParsedQueue = ''
         let mode = 'notrim' as const
         try {


### PR DESCRIPTION
# PR Checklist
- [X] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Fix translation state tracking issue in ChatBody component that prevented auto-translation from working properly.
Ensures that the 'translated' and 'retranslate' states are always tracked and reflected in the ChatBody UI.