### PR TITLE
feat: Add data attributes for chat id

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -728,6 +728,7 @@
 
 <div class="flex max-w-full justify-center risu-chat"
      data-chat-index={idx}
+     data-chat-id={DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].chatId}
      style={isLastMemory ? `border-top:${DBState.db.memoryLimitThickness}px solid rgba(98, 114, 164, 0.7);` : ''}
      onclickcapture={handleButtonTriggerWithin}>
     <div class="text-textcolor mt-1 ml-4 mr-4 mb-1 p-2 bg-transparent flex-grow border-t-gray-900 border-opacity-30 border-transparent flexium items-start max-w-full" >


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Hello!

This PR adds `data-chat-id` attributes to each chat message element.

#### Why is this needed?

Using only the chat index can be unclear for plugins or external tools that need to work with a specific chat message.

Exposing the unique `chatId` on the DOM element makes this identification much clearer and more reliable.

#### How does this PR solve the problem?

By adding these data attributes, plugins can now easily and safely get the unique `chatId` from the DOM element.

---

This is a small change, but I believe it will make it safer to implement plugins that interact with individual chat messages.

Let me know if you have any questions. Thank you! 