### PR TITLE
Feat: Add Back Button to ModelList

### DIFF
--- a/src/lib/UI/ModelList.svelte
+++ b/src/lib/UI/ModelList.svelte
@@ -6,6 +6,7 @@
     import { language } from "src/lang";
     import CheckInput from "./GUI/CheckInput.svelte";
     import { getModelInfo, getModelList } from 'src/ts/model/modellist';
+    import { ArrowLeft } from "lucide-svelte";
 
     interface Props {
         value?: string;
@@ -40,9 +41,19 @@
             e.stopPropagation()
             onclick?.(e)
         }}>
-            <h1 class="font-bold text-xl">{language.model}
-            </h1>
-            <div class="border-t-1 border-y-selected mt-1 mb-1"></div>
+            <div class="flex items-center gap-3 mb-4">
+                <button 
+                    class="flex items-center justify-center p-2 rounded-lg hover:bg-selected transition-colors flex-shrink-0"
+                    onclick={() => {
+                        openOptions = false
+                    }}
+                    title="Back"
+                >
+                    <ArrowLeft size={20} />
+                </button>
+                <h1 class="font-bold text-xl flex-1">{language.model}</h1>
+            </div>
+            <div class="border-t-1 border-y-selected mb-2"></div>
 
             {#each providers as provider}
                 {#if provider.providerName === '@as-is'}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Added a back button to the top-left corner of the ModelList.
This resolves an issue on mobile devices where users were unable to navigate back on smaller screens due to a lack of clickable space.

<img width="783" height="1537" alt="image" src="https://github.com/user-attachments/assets/73e6f33a-158c-4797-a458-ea5742d7f35e" />
