### PR TITLE
fix: dynamic asset trigger

### DIFF
--- a/src/ts/process/scripts.ts
+++ b/src/ts/process/scripts.ts
@@ -343,7 +343,8 @@ export async function processScriptFull(char:character|groupChat|simpleCharacter
     
 
     if(db.dynamicAssets && (char.type === 'simple' || char.type === 'character') && char.additionalAssets && char.additionalAssets.length > 0){
-        if(!db.dynamicAssetsEditDisplay && mode === 'editdisplay'){
+        if((!db.dynamicAssetsEditDisplay && mode === 'editdisplay')
+            || mode === 'editinput' || mode === 'editprocess'){
             cacheScript(hash, data)
             return {data, emoChanged}
         }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Previously, the dynamic assets processing was being triggered on `editinput` and `editprocess`, not only on `editoutput`.
The `editprocess` trigger mode in particular was running dynamic assets processing on the entire chat history every time a message was sent, causing serious performance issue. 


This PR excludes `editinput` and `editprocess` trigger modes from the processing.


* Before (extreme condition) 
<img width="642" height="41" alt="image" src="https://github.com/user-attachments/assets/06b2e28f-5622-4b67-a149-2fca67f487a4" />

* After
<img width="634" height="29" alt="image" src="https://github.com/user-attachments/assets/f1fccf85-d59d-4577-83c8-7d71e0671da5" />
