### PR TITLE
fix(ci): lowercase the repo owner's name during image push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Build Docker images
         shell: bash
         run: |
-          OWNER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')
-          echo "OWNER=$OWNER" >> $GITHUB_ENV
-          docker build -t ghcr.io/$OWNER/risuai:$(git rev-parse --short "$GITHUB_SHA") -t ghcr.io/$OWNER/risuai:latest .
+          GITHUB_REPOSITORY_OWNER_SMALLCASE=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')
+          echo "GITHUB_REPOSITORY_OWNER_SMALLCASE=$GITHUB_REPOSITORY_OWNER_SMALLCASE" >> $GITHUB_ENV
+          docker build -t ghcr.io/$GITHUB_REPOSITORY_OWNER_SMALLCASE/risuai:$(git rev-parse --short "$GITHUB_SHA") -t ghcr.io/$GITHUB_REPOSITORY_OWNER_SMALLCASE/risuai:latest .
 
       - name: Push Docker images
         shell: bash
         run: |
-          docker push --all-tags ghcr.io/$OWNER/risuai
+          docker push --all-tags ghcr.io/$GITHUB_REPOSITORY_OWNER_SMALLCASE/risuai

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,9 +37,11 @@ jobs:
       - name: Build Docker images
         shell: bash
         run: |
-          docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY_OWNER)/risuai:$(git rev-parse --short "$GITHUB_SHA") -t ghcr.io/$(echo $GITHUB_REPOSITORY_OWNER)/risuai:latest .
+          OWNER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')
+          echo "OWNER=$OWNER" >> $GITHUB_ENV
+          docker build -t ghcr.io/$OWNER/risuai:$(git rev-parse --short "$GITHUB_SHA") -t ghcr.io/$OWNER/risuai:latest .
 
       - name: Push Docker images
         shell: bash
         run: |
-          docker push --all-tags ghcr.io/$(echo $GITHUB_REPOSITORY_OWNER)/risuai
+          docker push --all-tags ghcr.io/$OWNER/risuai


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
  - ghcr test finished(https://github.com/Acet-Aminophen/RisuAI/actions/runs/16337807611/job/46153275055)
- [x] Have you added type definitions?

# Description
Hi there.
This commit fixes an error where ghcr upload fails if the GitHub username contains uppercase letters.