### PR TITLE
ci: use pre-built image from ghcr instead of build

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,9 @@ You can get detailed information on https://github.com/kwaroran/RisuAI/wiki (Wor
 
 You can also run RisuAI using Docker. This method is particularly useful for web hosting.
 
-1. Clone the repository:
+1. Run the Docker container:
    ```
-   git clone https://github.com/kwaroran/RisuAI.git
-   cd RisuAI
-   ```
-
-2. Build and run the Docker container:
-   ```
-   docker-compose up -d
+   curl -L https://raw.githubusercontent.com/kwaroran/RisuAI/refs/heads/main/docker-compose.yml | docker compose -f - up -d
    ```
 
-3. Access RisuAI at `http://localhost:6001` in your web browser.
+2. Access RisuAI at `http://localhost:6001` in your web browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: risuai
+
 services:
   risuai:
     container_name: risuai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   risuai:
     container_name: risuai
-    build: .
+    image: ghcr.io/kwaroran/risuai:latest
     restart: always
     ports:
       - 6001:6001


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
Hi there.
 - Update README.md to run without the git pull process, as the 'latest' tag is now available.
 - Modify docker-compose.yml to prevent the stack name from the device name.
 
For your information, Windows(after april 2018 update) also supports curl.