### PR TITLE
Fix: Restore Persona Import Functionality

### DIFF
--- a/src/lib/Setting/Pages/PersonaSettings.svelte
+++ b/src/lib/Setting/Pages/PersonaSettings.svelte
@@ -90,16 +90,17 @@
         <BaseRoundedButton
             onClick={async () => {
                 const sel = parseInt(await alertSelect([language.createfromScratch, language.importCharacter]))
-                if(sel === 1){
-                    return
+                if(sel === 0){
+                    DBState.db.personas.push({
+                        name: 'New Persona',
+                        icon: '',
+                        personaPrompt: '',
+                        note: ''
+                    })
+                    changeUserPersona(DBState.db.personas.length - 1)
+                } else if(sel === 1){
+                    await importUserPersona()
                 }
-                DBState.db.personas.push({
-                    name: 'New Persona',
-                    icon: '',
-                    personaPrompt: '',
-                    note: ''
-                })
-                changeUserPersona(DBState.db.personas.length - 1)
             }}
             ><svg viewBox="0 0 24 24" width="1.2em" height="1.2em"
                 ><path


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This pull request fixes the non-functional persona import button found in the persona list. The button now correctly opens the file dialog and imports the selected persona, restoring its intended behavior.