### PR TITLE
Fix: Incorrect request for custom models with Google format

### DIFF
--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -478,10 +478,19 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     }    
     
     let url = ''
+    let apiKey = arg.key || db.google.accessToken
     
     if(arg.customURL){
-        const u = new URL(arg.customURL)
-        u.searchParams.set('key', db.proxyKey)
+        let baseURL = arg.customURL
+        if (!baseURL.endsWith('/')) {
+            baseURL += '/'
+        }
+        const endpoint = arg.useStreaming ? 'streamGenerateContent' : 'generateContent'
+        const u = new URL(`models/${arg.modelInfo.internalID}:${endpoint}`, baseURL)
+        u.searchParams.set('key', apiKey)
+        if (arg.useStreaming) {
+            u.searchParams.set('alt', 'sse')
+        }
         url = u.toString()
     }
     else if(arg.modelInfo.format === LLMFormat.VertexAIGemini){
@@ -492,10 +501,10 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
         
         }
     else if(arg.modelInfo.format === LLMFormat.GoogleCloud && arg.useStreaming){
-        url = `https://generativelanguage.googleapis.com/v1beta/models/${arg.modelInfo.internalID}:streamGenerateContent?key=${db.google.accessToken}&alt=sse`
+        url = `https://generativelanguage.googleapis.com/v1beta/models/${arg.modelInfo.internalID}:streamGenerateContent?key=${apiKey}&alt=sse`
     }
     else{
-        url = `https://generativelanguage.googleapis.com/v1beta/models/${arg.modelInfo.internalID}:generateContent?key=${db.google.accessToken}`
+        url = `https://generativelanguage.googleapis.com/v1beta/models/${arg.modelInfo.internalID}:generateContent?key=${apiKey}`
     }
     // will return error if functionDeclarations is empty
     if(body.tools?.functionDeclarations?.length === 0){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This commit fixes a bug where requests for custom models using the Google format were sent with a hardcoded global key and a malformed URL that was missing the model name.