### PR TITLE
Feat: Add trigger import/export and improve setvar input

### DIFF
--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -2227,7 +2227,7 @@
                             <OptionInput value="value">{language.triggerInputLabels.value}</OptionInput>
                             <OptionInput value="var">{language.triggerInputLabels.var}</OptionInput>
                         </SelectInput>
-                        <TextInput bind:value={editTrigger.value} />
+                        <TextAreaInput highlight bind:value={editTrigger.value} />
                     {:else if editTrigger.type === 'v2If' || editTrigger.type === 'v2IfAdvanced'}
                         
                         <span class="block text-textcolor">{editTrigger.type === 'v2If' ? language.triggerInputLabels.varName : 'A'}</span>


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- The `setvar` input in v2Triggers has been changed to a `textarea` to improve readability for long values.
- Added functionality to export and import the entire trigger list as a JSON file.