### PR TITLE
fix: remove `inspector` import for brower compatibility

### DIFF
--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -18,7 +18,6 @@
   import { v4 } from "uuid";
   import { MCPClient } from "src/ts/process/mcp/mcplib";
     import { getDatabase } from "src/ts/storage/database.svelte";
-    import { url } from "inspector";
 
     let estaStorage:{
         key:string,


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
The import of the Node.js "inspector" (which was unnecessary) module caused a runtime error when running `pnpm dev` in the browser environment, as this module is not available outside of Node.js. 