### PR TITLE
fix: Risu hub access from node server

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -180,6 +180,12 @@ async function hubProxyFunc(req, res) {
         });
         
         for (const [key, value] of response.headers.entries()) {
+            // Skip encoding-related headers to prevent double decoding
+            if (key.toLowerCase() === 'content-encoding' || 
+                key.toLowerCase() === 'content-length' ||
+                key.toLowerCase() === 'transfer-encoding') {
+                continue;
+            }
             res.setHeader(key, value);
         }
         res.status(response.status);


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Resolves double decoding errors on the Node.js server to fix access to Risu Hub, enabling user login and bot downloads.