### PR TITLE
Fix: Add missing runAxLLM type to trigger effects

### DIFF
--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -27,7 +27,7 @@ export interface triggerscript{
 export type triggerCondition = triggerConditionsVar|triggerConditionsExists|triggerConditionsChatIndex
 
 export type triggerEffect = triggerEffectV1|triggerCode|triggerEffectV2
-export type triggerEffectV1 = triggerEffectCutChat|triggerEffectModifyChat|triggerEffectImgGen|triggerEffectRegex|triggerEffectRunLLM|triggerEffectCheckSimilarity|triggerEffectSendAIprompt|triggerEffectShowAlert|triggerEffectSetvar|triggerEffectSystemPrompt|triggerEffectImpersonate|triggerEffectCommand|triggerEffectStop|triggerEffectRunTrigger
+export type triggerEffectV1 = triggerEffectCutChat|triggerEffectModifyChat|triggerEffectImgGen|triggerEffectRegex|triggerEffectRunLLM|triggerEffectCheckSimilarity|triggerEffectSendAIprompt|triggerEffectShowAlert|triggerEffectSetvar|triggerEffectSystemPrompt|triggerEffectImpersonate|triggerEffectCommand|triggerEffectStop|triggerEffectRunTrigger|triggerEffectRunAxLLM
 export type triggerEffectV2 =   triggerV2Header|triggerV2IfVar|triggerV2Else|triggerV2EndIndent|triggerV2SetVar|triggerV2Loop|triggerV2BreakLoop|
                                 triggerV2RunTrigger|triggerV2ConsoleLog|triggerV2StopTrigger|triggerV2CutChat|triggerV2ModifyChat|triggerV2SystemPrompt|triggerV2Impersonate|
                                 triggerV2Command|triggerV2SendAIprompt|triggerV2ImgGen|triggerV2CheckSimilarity|triggerV2RunLLM|triggerV2ShowAlert|triggerV2ExtractRegex|


### PR DESCRIPTION
Resolves TypeScript compilation errors in TriggerData.svelte by adding the missing runAxLLM type to the triggerEffectV1 union type.

## Changes
- Added  to the  type definition in 
- This fixes TypeScript errors where  was referenced but not included in the type union

## Testing
- TypeScript compilation errors in TriggerData.svelte are now resolved
- The runAxLLM trigger effect type is now properly recognized