### PR TITLE
fix(ci) : buildx required error

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
 - ghcr test finished(https://github.com/Acet-Aminophen/RisuAI/actions/runs/16644870206)
- [x] Have you added type definitions?

# Description
Hi there.
This commit resolves the error prints 'ERROR: failed to build: Multi-platform build is not supported for the docker driver.'