### PR TITLE
fix: Add debounce to saveDb to resolve abnormal lag.

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -350,6 +350,10 @@ export async function saveDb(){
 
         let selIdState = $state(0)
         let oldSaveHash = ''
+        
+        // Debounce time for saving the database
+        const debounceTime = 1000; // 1 second
+        let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
         selectedCharID.subscribe((v) => {
             selIdState = v
@@ -362,8 +366,12 @@ export async function saveDb(){
                     $state.snapshot(DBState.db[key])
                 }
             }
-
-            changed = true
+            if (saveTimeout) {
+                clearTimeout(saveTimeout);
+            }
+            saveTimeout = setTimeout(() => {
+                changed = true;
+            }, debounceTime);
         })
     })
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

There is an abnormal lag when modifying the current bot's description, persona's description, etc.

## Prove
All of these lags occur because saveDb is repeatedly called while typing characters.

<img width="452" height="290" alt="image" src="https://github.com/user-attachments/assets/2ffdb514-d6a2-466c-80b6-5020aa75fc49" />

To prove this, I added a log code for debugging.

In this state, if you repeatedly insert a text into the bot's description

<img width="462" height="431" alt="image" src="https://github.com/user-attachments/assets/08dbf91a-c170-44e3-9121-25e67931c431" />

<img width="276" height="237" alt="image" src="https://github.com/user-attachments/assets/0d99c787-33d7-4e30-9d52-04df0a597380" />

It can be seen that the saveDb is repeatedly executed like this.

# Conclusion
In this pr, I added debounce to fix this.
It's a simple patch, so I think there will be no errors and the benefits will be great.
The current debounce time is 1 second, which you may change to the appropriate time.