### PR TITLE
fix: Stabilize Hub Proxy by resolving redirect and request body errors

### DIFF
--- a/src/ts/storage/accountStorage.ts
+++ b/src/ts/storage/accountStorage.ts
@@ -40,7 +40,7 @@ export class AccountStorage{
                 method: "POST",
                 body: value,
                 headers: {
-                    'content-type': 'application/json',
+                    'content-type': 'application/octet-stream',
                     'x-risu-key': key,
                     'x-risu-auth': this.auth,
                     'X-Format': 'nocheck',


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This pull request resolves several critical issues related to the Node.js proxy server, ensuring more stable and reliable communication with backend services.

  Key Changes:

   * Handles 303 Redirects Gracefully (`17c8738f`): The proxy server now properly follows 303 See Other redirects on the server-side. This prevents redirect responses from being sent directly
     to the client, which previously caused JSON parsing errors when the client expected a data response but received an HTML redirect page instead.

   * Fixes Content-Type and Body-Parsing Errors (`7809f262`):
       * Correctly sets the Content-Type to application/octet-stream for binary data uploads, preventing 400 Bad Request errors from body-parser.
       * Adds express.text() middleware to handle text/plain request bodies, resolving Cloudflare Worker exceptions caused by improperly formatted requests.
       * Removes the content-length header from incoming requests before proxying them to avoid RequestContentLengthMismatchError.
       * Fixes a "body locked" error by using the parsed req.body instead of the raw req stream in fetch calls.
       * Refactors the header filtering logic to use an array for improved readability and maintainability (incorporating feedback from @concertypin).

  These fixes have been tested locally and in a Docker environment to confirm they work as expected across different setups.