### PR TITLE
fix: Cbs random, pick Bug where the first element cannot be picked

### DIFF
--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -1973,14 +1973,14 @@ export function registerCBS(arg:CBSRegisterArg) {
                 else{
                     arr = args[0].replace(/\\,/g, '§X').split(/\:|\,/g)
                 }
-                const randomIndex = Math.floor(Math.random() * (arr.length - 1)) + 1
+                const randomIndex = Math.floor(Math.random() * arr.length)
                 if(matcherArg.tokenizeAccurate){
                     return arr[0]
                 }
                 return arr[randomIndex]?.replace(/§X/g, ',') ?? ''
             }
 
-            const randomIndex = Math.floor(Math.random() * (args.length - 1)) + 1
+            const randomIndex = Math.floor(Math.random() * args.length)
             if(matcherArg.tokenizeAccurate){
                 return args[0]
             }
@@ -2012,14 +2012,14 @@ export function registerCBS(arg:CBSRegisterArg) {
                 else{
                     arr = args[0].replace(/\\,/g, '§X').split(/\:|\,/g)
                 }
-                const randomIndex = Math.floor(hashRand * (arr.length - 1)) + 1
+                const randomIndex = Math.floor(hashRand * arr.length)
                 if(matcherArg.tokenizeAccurate){
                     return arr[0]
                 }
                 return arr[randomIndex]?.replace(/§X/g, ',') ?? ''
             }
 
-            const randomIndex = Math.floor(hashRand * (args.length - 1)) + 1
+            const randomIndex = Math.floor(hashRand * args.length)
             if(matcherArg.tokenizeAccurate){
                 return args[0]
             }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
<img width="2419" height="638" alt="image" src="https://github.com/user-attachments/assets/01d343bb-b497-40d8-be16-289fcb405c44" />
The picture above shows the current bug.