### PR TITLE
feat: Show detailed information on error alert

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1313,4 +1313,6 @@ export const languageEnglish = {
     requestLocation: "Request Location",
     newImageHandlingBeta: "New Image Handling (Beta)",
     settingsExported: "Settings for bug report exported and copied to clipboard.",
+    hideErrorDetails: "Hide Error Details",
+    showErrorDetails: "Show Error Details",
 }

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1176,4 +1176,6 @@ export const languageKorean = {
     "insertAssetPrompt": "에셋 프롬프트 삽입",
     "requestLocation": "리퀘스트 위치",
     "folderRemoveConfirm": "이 폴더에는 로어북이 포함되어 있습니다. 폴더와 그 안의 모든 항목을 삭제하시겠습니까?",
+    "hideErrorDetails": "오류 세부사항 숨기기",
+    "showErrorDetails": "오류 세부사항 보이기",
 }

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -230,7 +230,7 @@
             }
         } catch (error) {
             console.error(error)
-            alertError(`${error}`)
+            alertError(error)
         }
         lastCharId = $selectedCharID
         $doingChat = false

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -24,6 +24,8 @@
     import { getChatBranches } from "src/ts/gui/branches";
     import { getCurrentCharacter } from "src/ts/storage/database.svelte";
 
+    let showDetails = $state(false);
+
     let btn
     let input = $state('')
     let cardExportType = $state('realm')
@@ -36,6 +38,7 @@
         content:string,
     } = $state(null)
     $effect.pre(() => {
+        showDetails = false;
         if(btn){
             btn.focus()
         }
@@ -102,6 +105,22 @@
                 <span class="text-gray-300">{$alertStore.msg}</span>
                 {#if $alertStore.submsg && $alertStore.type !== 'progress'}
                     <span class="text-gray-500 text-sm">{$alertStore.submsg}</span>
+                {/if}
+
+                {#if $alertStore.type === 'error' && $alertStore.stackTrace}
+                    <div class="mt-4">
+                        <Button styled="outlined" size="sm" onclick={() => showDetails = !showDetails}>
+                            {showDetails ? language.hideErrorDetails : language.showErrorDetails}
+                            {#if showDetails}
+                                <XIcon class="inline ml-2" />
+                            {:else}
+                                <ChevronRightIcon class="inline ml-2" />
+                            {/if}
+                        </Button>
+                        {#if showDetails}
+                            <pre class="stack-trace">{@html $alertStore.stackTrace}</pre>
+                        {/if}
+                    </div>
                 {/if}
             {/if}
             {#if $alertStore.type === 'progress'}
@@ -743,5 +762,20 @@
     .vis{
         opacity: 1 !important;
         --tw-bg-opacity: 1 !important;
+    }
+
+    .stack-trace {
+        background-color: var(--risu-theme-bgcolor);
+        color: var(--risu-theme-textcolor2);
+        border: 1px solid var(--risu-theme-darkborderc);
+        border-radius: 0.25rem;
+        padding: 0.5rem;
+        margin-top: 0.5rem;
+        font-family: monospace;
+        font-size: 0.75rem;
+        white-space: pre-wrap;
+        word-break: break-all;
+        max-height: 200px;
+        overflow-y: auto;
     }
 </style>

--- a/src/ts/alert.ts
+++ b/src/ts/alert.ts
@@ -14,6 +14,7 @@ export interface alertData{
     msg: string,
     submsg?: string
     datalist?: [string, string][],
+    stackTrace?: string;
 }
 
 type AlertGenerationInfoStoreData = {
@@ -31,9 +32,12 @@ export function alertError(msg: string | Error) {
     console.error(msg)
     const db = getDatabase()
 
+    let stackTrace: string | undefined = undefined; 
+
     if (typeof(msg) !== 'string') {
         try{
             if (msg instanceof Error) {
+                stackTrace = msg.stack
                 msg = msg.message
             } else {
                 msg = JSON.stringify(msg)
@@ -64,7 +68,8 @@ export function alertError(msg: string | Error) {
     alertStoreImported.set({
         'type': 'error',
         'msg': msg,
-        'submsg': submsg
+        'submsg': submsg,
+        'stackTrace': stackTrace
     })
 }
 

--- a/src/ts/characterCards.ts
+++ b/src/ts/characterCards.ts
@@ -40,7 +40,7 @@ export async function importCharacter() {
             checkCharOrder()
         }
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
         return null
     }
 }
@@ -1459,7 +1459,7 @@ export async function exportCharacterCard(char:character, type:'png'|'json'|'cha
     }
     catch(e){
         console.error(e, e.stack)
-        alertError(`${e}`)
+        alertError(e)
     }
 }
 
@@ -1671,7 +1671,7 @@ export async function shareRisuHub2(char:character, arg:{
             setCurrentCharacter(currentChar)
         }   
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
 
 }

--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -365,7 +365,7 @@ export async function exportChat(page:number){
         }
         alertNormal(language.successExport)
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
 }
 
@@ -503,7 +503,7 @@ export async function importChat(){
             }
         }
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
 }
 
@@ -524,7 +524,7 @@ export async function exportAllChats() {
         await downloadFile(`${char.name}_all_chats_${date}`.replace(/[<>:"/\\|?*.,]/g, "") + '.json', stringl)
         alertNormal(language.successExport)
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
 }
 
@@ -792,7 +792,7 @@ export async function makeGroupImage() {
             msg: ''
         })
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
 }
 

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -743,7 +743,7 @@ export async function loadData() {
                 })
             }
         } catch (error) {
-            alertError(`${error}`)
+            alertError(error)
         }
     }
 }

--- a/src/ts/persona.ts
+++ b/src/ts/persona.ts
@@ -122,7 +122,7 @@ export async function importUserPersona() {
             alertError(language.errors.noData)
         }
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
         return
     }
 }

--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -683,7 +683,7 @@ export async function importLoreBook(mode:'global'|'local'|'sglobal'){
             DBState.db.characters[selectedID].chats[page].localLore = lore
         }
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
 }
 
@@ -747,6 +747,6 @@ export async function exportLoreBook(mode:'global'|'local'|'sglobal'){
 
         alertNormal(language.successExport)
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
 }

--- a/src/ts/process/scripts.ts
+++ b/src/ts/process/scripts.ts
@@ -60,7 +60,7 @@ export async function importRegex(o?:customscript[]):Promise<customscript[]>{
         }
 
     } catch (error) {
-        alertError(`${error}`)
+        alertError(error)
     }
     return o
 }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR has two changes.
1. Modify src/ts/alert.ts and src/lib/Others/AlertComp.svelte so that the error popup can display detailed information about the error.
2. In the existing code, the error history was sent as a string to alertError, resulting in information loss.
In this PR, I modify it to pass the error without type conversion in order to display the stack trace.

If users provide this log along with the bug, it will be very helpful in resolving the bug even if the code is minified.

# Comparison

The existing error pop-up did not provide detailed logs, which was not helpful in resolving bugs as shown below.

<img width="493" height="165" alt="image" src="https://github.com/user-attachments/assets/48283feb-cd59-4815-9320-fe1655233f21" />
<img width="507" height="189" alt="image" src="https://github.com/user-attachments/assets/61adeb2d-9794-4b2a-81b9-5c9498ddbec9" />


Applying this PR changes the error pop-up to this.

<img width="614" height="281" alt="image" src="https://github.com/user-attachments/assets/11db84f9-ac29-4aaf-99e7-69a005136e5a" />
<img width="901" height="502" alt="image" src="https://github.com/user-attachments/assets/b0be15cb-25ef-47bf-b946-fc36dfa31664" />
