### PR TITLE
fix:characterCard lorebook import in all type(include url)

### DIFF
--- a/src/ts/characterCards.ts
+++ b/src/ts/characterCards.ts
@@ -1076,14 +1076,15 @@ function convertCharbook(arg:{
             insertorder: book.insertion_order,
             comment: book.name ?? book.comment ?? "",
             content: content,
-            mode: "normal",
+            mode: (book.mode as any) ?? "normal",
             alwaysActive: book.constant ?? false,
             selective: book.selective ?? false,
             extentions: {...extensions, risu_case_sensitive: book.case_sensitive},
             activationPercent: book.extensions?.risu_activationPercent,
             loreCache: book.extensions?.risu_loreCache ?? null,
             //@ts-ignore
-            useRegex: book.use_regex ?? false
+            useRegex: book.use_regex ?? false,
+            folder: book.folder
         })
     }
 
@@ -1125,6 +1126,8 @@ async function createBaseV2(char:character) {
             name: lore.comment,
             comment: lore.comment,
             case_sensitive: caseSensitive,
+            mode: lore.mode ?? "normal",
+            folder: lore.folder,
         })
     }
     char.loreExt ??= {}
@@ -1463,9 +1466,15 @@ export async function exportCharacterCard(char:character, type:'png'|'json'|'cha
     }
 }
 
+// Extended LorebookEntry with RisuAI specific fields
+type RisuLorebookEntry = LorebookEntry & {
+    mode?: string;
+    folder?: string;
+}
+
 export function createBaseV3(char:character){
     
-    let charBook:LorebookEntry[] = []
+    let charBook:RisuLorebookEntry[] = []
     let assets:Array<{
         type: string
         uri: string
@@ -1517,18 +1526,22 @@ export function createBaseV3(char:character){
         ext.risu_loreCache = lore.loreCache
 
         charBook.push({
-            keys: lore.key.split(',').map(r => r.trim()),
-            secondary_keys: lore.selective ? lore.secondkey.split(',').map(r => r.trim()) : undefined,
-            content: lore.content,
-            extensions: ext,
-            enabled: true,
-            insertion_order: lore.insertorder,
-            constant: lore.alwaysActive,
-            selective:lore.selective,
-            name: lore.comment,
-            comment: lore.comment,
-            case_sensitive: caseSensitive,
-            use_regex: lore.useRegex ?? false,
+            ...{
+                keys: lore.key.split(',').map(r => r.trim()),
+                secondary_keys: lore.selective ? lore.secondkey.split(',').map(r => r.trim()) : undefined,
+                content: lore.content,
+                extensions: ext,
+                enabled: true,
+                insertion_order: lore.insertorder,
+                constant: lore.alwaysActive,
+                selective:lore.selective,
+                name: lore.comment,
+                comment: lore.comment,
+                case_sensitive: caseSensitive,
+                use_regex: lore.useRegex ?? false,
+            } as LorebookEntry,
+            mode: lore.mode ?? "normal",
+            folder: lore.folder,
         })
     }
     char.loreExt ??= {}
@@ -1925,6 +1938,8 @@ interface charBookEntry{
     position?: 'before_char' | 'after_char' // whether the entry is placed before or after the character defs
     case_sensitive?:boolean
     use_regex?:boolean
+    mode?: string // RisuAI mode field
+    folder?: string // RisuAI folder field
 }
 
 interface RccCardMetaData{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
- Add RisuLorebookEntry type extending LorebookEntry with mode/folder fields
- Ensure mode and folder fields are preserved across PNG, URL, and V2/V3 imports
- Improve type safety for lorebook entries in character card conversions

This resolves the issue where CharX imports preserve lorebook mode/folder correctly but other import methods (PNG, URL downloads) lose these fields.