### PR TITLE
add: Google Imagen to image generation provider

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -173,6 +173,7 @@
             <OptionInput value="stability" >Stability API</OptionInput>
             <OptionInput value="fal" >Fal.ai</OptionInput>
             <OptionInput value="comfyui" >ComfyUI</OptionInput>
+            <OptionInput value="Imagen" >Imagen</OptionInput>
 
             <!-- Legacy -->
             {#if DBState.db.sdProvider === 'comfy'}
@@ -590,6 +591,43 @@
             {/if}
 
 
+        {/if}
+
+        {#if DBState.db.sdProvider === 'Imagen'}
+            <span class="text-textcolor mt-2">GoogleAI API Key</span>
+            <TextInput marginBottom={true} size={"sm"} placeholder="..." hideText={DBState.db.hideApiKey} bind:value={DBState.db.google.accessToken}/>
+            
+            <span class="text-textcolor">Model</span>
+            <SelectInput className="mb-4" bind:value={DBState.db.ImagenModel}>
+                <OptionInput value="imagen-4.0-generate-001" >Imagen 4</OptionInput>
+                <OptionInput value="imagen-4.0-ultra-generate-001" >Imagen 4 Ultra</OptionInput>
+                <OptionInput value="imagen-4.0-fast-generate-001" >Imagen 4 Fast</OptionInput>
+                <OptionInput value="imagen-3.0-generate-002" >Imagen 3.0</OptionInput>
+            </SelectInput>
+
+            {#if DBState.db.ImagenModel === 'imagen-4.0-generate-001' || DBState.db.ImagenModel === 'imagen-4.0-ultra-generate-001'}
+                <span class="text-textcolor">Image size</span>
+                <SelectInput className="mb-4" bind:value={DBState.db.ImagenImageSize}>
+                    <OptionInput value="1K" >1K</OptionInput>
+                    <OptionInput value="2K" >2K</OptionInput>
+                </SelectInput>
+            {/if}
+
+            <span class="text-textcolor">Aspect ratio</span>
+            <SelectInput className="mb-4" bind:value={DBState.db.ImagenAspectRatio}>
+                <OptionInput value="1:1" >1:1</OptionInput>
+                <OptionInput value="3:4" >3:4</OptionInput>
+                <OptionInput value="4:3" >4:3</OptionInput>
+                <OptionInput value="9:16" >9:16</OptionInput>
+                <OptionInput value="16:9" >16:9</OptionInput>
+            </SelectInput>
+
+            <span class="text-textcolor">Person generation</span>
+            <SelectInput className="mb-4" bind:value={DBState.db.ImagenPersonGeneration}>
+                <OptionInput value="allow_all" >Allow all</OptionInput>
+                <OptionInput value="allow_adult" >Allow adult</OptionInput>
+                <OptionInput value="dont_allow" >Don't allow</OptionInput>
+            </SelectInput>
         {/if}
     </Arcodion>
 {/if}

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -594,5 +594,54 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
             CharEmotion.set(charemotions)
         }
     }
+    if(db.sdProvider === 'Imagen') {
+        const model = db.ImagenModel
+        const size = db.ImagenImageSize
+        const aspect = db.ImagenAspectRatio
+        const person = db.ImagenPersonGeneration
+
+        let body:any = {
+            instances: [{
+                prompt: genPrompt
+            }],
+            parameters: {
+                sampleCount: 1,
+                aspectRatio: aspect,
+                personGeneration: person,
+            }
+        }
+
+        if(model === 'imagen-4.0-generate-001' || model === 'imagen-4.0-ultra-generate-001') {
+            body.parameters = {
+                ...body.parameters,
+                sampleImageSize: size
+            }
+        }
+
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:predict?key=${db.google.accessToken}`
+
+        const res = await globalFetch(url, {
+            headers: {
+                "Content-Type": "application/json"
+            },
+            method: 'POST',
+            body: body,
+        })
+
+        if(!res.ok) {
+            alertError(JSON.stringify(res.data))
+            return false
+        }
+
+        const img64 = res.data?.predictions?.[0]?.bytesBase64Encoded
+
+        if(!img64) {
+            alertError(JSON.stringify(res.data))
+            return false
+        }
+        
+        const mimeType = res.data?.predictions?.[0]?.mimeType || 'image/png'
+        return `data:${mimeType};base64,${img64}`
+    }
     return ''
 }

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -574,6 +574,10 @@ export function setDatabase(data:Database){
     data.rememberToolUsage ??= true
     data.simplifiedToolUse ??= false
     data.streamGeminiThoughts ??= false
+    data.ImagenModel ??= 'imagen-4.0-generate-001'
+    data.ImagenImageSize ??= '1K'
+    data.ImagenAspectRatio ??= '1:1'
+    data.ImagenPersonGeneration ??= 'allow_all'
     //@ts-ignore
     if(!globalThis.__NODE__ && !window.__TAURI_INTERNALS__){
         //this is intended to forcely reduce the size of the database in web
@@ -1076,6 +1080,10 @@ export interface Database{
     streamGeminiThoughts:boolean
     verbosity:number
     dynamicOutput?:DynamicOutput
+    ImagenModel:string
+    ImagenImageSize:string
+    ImagenAspectRatio:string
+    ImagenPersonGeneration:string
 }
 
 interface SeparateParameters{


### PR DESCRIPTION
# PR Checklist
- [X] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [X] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Add Google Imagen as image generation provider

- Support for Imagen 4, Imagen 4 Ultra, Imagen 4 Fast, and Imagen 3.0
- Configurable image size, aspect ratio, and person generation settings
- Negative prompt is not supported for these models.
