### PR TITLE
Fix: Robust argument parsing for {{call}} syntax to support nested CBS

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -8,7 +8,7 @@ import { get } from 'svelte/store';
 import css, { type CssAtRuleAST } from '@adobe/css-tools'
 import { SizeStore, selectedCharID } from './stores.svelte';
 import { calcString } from './process/infunctions';
-import { findCharacterbyId, getPersonaPrompt, getUserIcon, getUserName, parseKeyValue, pickHashRand, replaceAsync} from './util';
+import { findCharacterbyId, getPersonaPrompt, getUserIcon, getUserName, parseKeyValue, pickHashRand, replaceAsync } from './util';
 import { getInlayAsset } from './process/files/inlays';
 import { getModuleAssets, getModuleLorebooks, getModules, type RisuModule } from './process/modules';
 import type { OpenAIChat } from './process/index.svelte';
@@ -33,8 +33,8 @@ const markdownItOptions = {
 const md = markdownit(markdownItOptions)
 const mdHighlight = markdownit({
     highlight: function (str, lang) {
-        if(lang){
-            return `<pre-hljs-placeholder lang="${lang}">`+ str +'</pre-hljs-placeholder>';
+        if (lang) {
+            return `<pre-hljs-placeholder lang="${lang}">` + str + '</pre-hljs-placeholder>';
         }
         return ''
     },
@@ -46,18 +46,18 @@ mdHighlight.disable(['code'])
 
 DOMPurify.addHook("uponSanitizeElement", (node: HTMLElement, data) => {
     if (data.tagName === "iframe") {
-       const src = node.getAttribute("src") || "";
-       if (!src.startsWith("https://www.youtube.com/embed/")) {
-          return node.parentNode.removeChild(node);
-       }
+        const src = node.getAttribute("src") || "";
+        if (!src.startsWith("https://www.youtube.com/embed/")) {
+            return node.parentNode.removeChild(node);
+        }
     }
-    if(data.tagName === 'img'){
+    if (data.tagName === 'img') {
         const loading = node.getAttribute("loading")
-        if(!loading){
-            node.setAttribute("loading","lazy")
+        if (!loading) {
+            node.setAttribute("loading", "lazy")
         }
         const decoding = node.getAttribute("decoding")
-        if(!decoding){
+        if (!decoding) {
             node.setAttribute("decoding", "async")
         }
 
@@ -66,17 +66,17 @@ DOMPurify.addHook("uponSanitizeElement", (node: HTMLElement, data) => {
 });
 
 DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-    switch(data.attrName){
-        case 'style':{
+    switch (data.attrName) {
+        case 'style': {
             break
         }
-        case 'class':{
-            if(data.attrValue){
+        case 'class': {
+            if (data.attrValue) {
                 data.attrValue = data.attrValue.split(' ').map((v) => {
-                    if(v.startsWith('hljs')){
+                    if (v.startsWith('hljs')) {
                         return v
                     }
-                    if(v.startsWith('x-risu-')){
+                    if (v.startsWith('x-risu-')) {
                         return v
                     }
                     return "x-risu-" + v
@@ -84,8 +84,8 @@ DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
             }
             break
         }
-        case 'href':{
-            if(data.attrValue.startsWith('http://') || data.attrValue.startsWith('https://')){
+        case 'href': {
+            if (data.attrValue.startsWith('http://') || data.attrValue.startsWith('https://')) {
                 node.setAttribute('target', '_blank')
                 break
             }
@@ -113,16 +113,16 @@ const replacements = [
     ';', //0xE9BF
 ]
 
-export function risuUnescape(text:string){
+export function risuUnescape(text: string) {
     return text.replace(/[\uE9b8-\uE9bf]/g, (f) => {
         const index = f.charCodeAt(0) - 0xE9B8
         return replacements[index]
     })
 }
 
-export function risuEscape(text:string){
+export function risuEscape(text: string) {
     return text.replace(/[{}()]/g, (f) => {
-        switch(f){
+        switch (f) {
             case '{': return '\uE9B8'
             case '}': return '\uE9B9'
             case '(': return '\uE9BA'
@@ -132,18 +132,18 @@ export function risuEscape(text:string){
     })
 }
 
-function renderMarkdown(md:markdownit, data:string){
+function renderMarkdown(md: markdownit, data: string) {
     let quotes = ['“', '”', '‘', '’']
-    if(DBState.db?.customQuotes){
+    if (DBState.db?.customQuotes) {
         quotes = DBState.db.customQuotesData ?? quotes
     }
     let text = risuUnescape(md.render(data.replace(/“|”/g, '"').replace(/‘|’/g, "'")))
 
-    if(DBState.db?.unformatQuotes){
+    if (DBState.db?.unformatQuotes) {
         text = text.replace(/\uE9b0/gu, quotes[0]).replace(/\uE9b1/gu, quotes[1])
         text = text.replace(/\uE9b2/gu, quotes[2]).replace(/\uE9b3/gu, quotes[3])
     }
-    else{
+    else {
         text = text.replace(/\uE9b0/gu, '<mark risu-mark="quote2">' + quotes[0]).replace(/\uE9b1/gu, quotes[1] + '</mark>')
         text = text.replace(/\uE9b2/gu, '<mark risu-mark="quote1">' + quotes[2]).replace(/\uE9b3/gu, quotes[3] + '</mark>')
     }
@@ -151,201 +151,201 @@ function renderMarkdown(md:markdownit, data:string){
     return text
 }
 
-async function renderHighlightableMarkdown(data:string) {
+async function renderHighlightableMarkdown(data: string) {
     let rendered = renderMarkdown(mdHighlight, data)
     const highlightPlaceholders = rendered.match(/<pre-hljs-placeholder lang="(.+?)">(.+?)<\/pre-hljs-placeholder>/gms)
-    if (!highlightPlaceholders){
+    if (!highlightPlaceholders) {
         return rendered
     }
 
-    for (const placeholder of highlightPlaceholders){
+    for (const placeholder of highlightPlaceholders) {
         try {
             let lang = placeholder.match(/lang="(.+?)"/)?.[1]
             const code = placeholder.match(/<pre-hljs-placeholder lang=".+?">(.+?)<\/pre-hljs-placeholder>/ms)?.[1]
-            if (!lang || !code){
+            if (!lang || !code) {
                 continue
             }
             //import language if not already loaded
             //we do not refactor this to a function because we want to keep vite to only import the languages that are needed
-            let languageModule: typeof import('highlight.js/lib/languages/*')|null = null
+            let languageModule: typeof import('highlight.js/lib/languages/*') | null = null
             let fileExt = ''
 
-            switch(lang){
-                case 'bash':{
+            switch (lang) {
+                case 'bash': {
                     fileExt = 'sh'
                     lang = 'bash'
-                    if(!hljs.getLanguage('bash')){
+                    if (!hljs.getLanguage('bash')) {
                         languageModule = await import('highlight.js/lib/languages/bash')
                     }
                     break
                 }
                 case 'c':
-                case 'cpp':{
+                case 'cpp': {
                     fileExt = lang
                     lang = 'cpp'
-                    if(!hljs.getLanguage('cpp')){
+                    if (!hljs.getLanguage('cpp')) {
                         languageModule = await import('highlight.js/lib/languages/cpp')
                     }
                     break
                 }
                 case 'cs':
-                case 'csharp':{
+                case 'csharp': {
                     fileExt = 'cs'
                     lang = 'csharp'
-                    if(!hljs.getLanguage('csharp')){
+                    if (!hljs.getLanguage('csharp')) {
                         languageModule = await import('highlight.js/lib/languages/csharp')
                     }
                     break
                 }
-                case 'css':{
+                case 'css': {
                     fileExt = 'css'
                     lang = 'css'
-                    if(!hljs.getLanguage('css')){
+                    if (!hljs.getLanguage('css')) {
                         languageModule = await import('highlight.js/lib/languages/css')
                     }
                     break
                 }
-                case 'dart':{
+                case 'dart': {
                     fileExt = 'dart'
                     lang = 'dart'
-                    if(!hljs.getLanguage('dart')){
+                    if (!hljs.getLanguage('dart')) {
                         languageModule = await import('highlight.js/lib/languages/dart')
                     }
                     break
                 }
                 case 'html':
                 case 'svg':
-                case 'xml':{
+                case 'xml': {
                     fileExt = lang
                     lang = 'xml'
-                    if(!hljs.getLanguage('xml')){
+                    if (!hljs.getLanguage('xml')) {
                         languageModule = await import('highlight.js/lib/languages/xml')
                     }
                     break
                 }
-                case 'java':{
+                case 'java': {
                     fileExt = 'java'
                     lang = 'java'
-                    if(!hljs.getLanguage('java')){
+                    if (!hljs.getLanguage('java')) {
                         languageModule = await import('highlight.js/lib/languages/java')
                     }
                     break
                 }
                 case 'js':
                 case 'jsx':
-                case 'javascript':{
+                case 'javascript': {
                     fileExt = 'js'
                     lang = 'javascript'
-                    if(!hljs.getLanguage('javascript')){
+                    if (!hljs.getLanguage('javascript')) {
                         languageModule = await import('highlight.js/lib/languages/javascript')
                     }
                     break
                 }
-                case 'json':{
+                case 'json': {
                     fileExt = 'json'
                     lang = 'json'
-                    if(!hljs.getLanguage('json')){
+                    if (!hljs.getLanguage('json')) {
                         languageModule = await import('highlight.js/lib/languages/json')
                     }
                     break
                 }
-                case 'lua':{
+                case 'lua': {
                     fileExt = 'lua'
                     lang = 'lua'
-                    if(!hljs.getLanguage('lua')){
+                    if (!hljs.getLanguage('lua')) {
                         languageModule = await import('highlight.js/lib/languages/lua')
                     }
                     break
                 }
                 case 'markdown':
-                case 'md':{
+                case 'md': {
                     fileExt = 'md'
                     lang = 'markdown'
-                    if(!hljs.getLanguage('markdown')){
+                    if (!hljs.getLanguage('markdown')) {
                         languageModule = await import('highlight.js/lib/languages/markdown')
                     }
                     break
                 }
                 case 'py':
-                case 'python':{
+                case 'python': {
                     fileExt = 'py'
                     lang = 'python'
-                    if(!hljs.getLanguage('python')){
+                    if (!hljs.getLanguage('python')) {
                         languageModule = await import('highlight.js/lib/languages/python')
                     }
                     break
                 }
-                case 'rust':{
+                case 'rust': {
                     fileExt = 'rs'
                     lang = 'rust'
-                    if(!hljs.getLanguage('rust')){
+                    if (!hljs.getLanguage('rust')) {
                         languageModule = await import('highlight.js/lib/languages/rust')
                     }
                     break
                 }
-                case 'shell':{
+                case 'shell': {
                     fileExt = 'sh'
                     lang = 'shell'
-                    if(!hljs.getLanguage('shell')){
+                    if (!hljs.getLanguage('shell')) {
                         languageModule = await import('highlight.js/lib/languages/shell')
                     }
                     break
                 }
                 case 'ts':
                 case 'tsx':
-                case 'typescript':{
+                case 'typescript': {
                     fileExt = 'ts'
                     lang = 'typescript'
-                    if(!hljs.getLanguage('typescript')){
+                    if (!hljs.getLanguage('typescript')) {
                         languageModule = await import('highlight.js/lib/languages/typescript')
                     }
                     break
                 }
                 case 'txt':
-                case 'vtt':{
+                case 'vtt': {
                     fileExt = lang
                     lang = 'plaintext'
-                    if(!hljs.getLanguage('plaintext')){
+                    if (!hljs.getLanguage('plaintext')) {
                         languageModule = await import('highlight.js/lib/languages/plaintext')
                     }
                     break
                 }
-                case 'yaml':{
+                case 'yaml': {
                     fileExt = 'yml'
                     lang = 'yaml'
-                    if(!hljs.getLanguage('yaml')){
+                    if (!hljs.getLanguage('yaml')) {
                         languageModule = await import('highlight.js/lib/languages/yaml')
                     }
                     break
                 }
-                case 'risuerror':{
+                case 'risuerror': {
                     lang = 'error'
                     fileExt = 'error'
                     break
                 }
-                default:{
+                default: {
                     lang = 'none'
                     fileExt = 'none'
                 }
             }
-            if(languageModule){
+            if (languageModule) {
                 hljs.registerLanguage(lang, languageModule.default)
             }
-            if(lang === 'none'){
+            if (lang === 'none') {
                 rendered = rendered.replace(placeholder, `<pre><code>${md.utils.escapeHtml(code)}</code></pre>`)
             }
-            else if(lang === 'error'){
+            else if (lang === 'error') {
                 rendered = rendered.replace(placeholder, `<div class="risu-error"><h1>${language.error}</h1>${md.utils.escapeHtml(code)}</div>`)
             }
-            else{
+            else {
                 const highlighted = hljs.highlight(code, {
                     language: lang,
                     ignoreIllegals: true
                 }).value
-                rendered = rendered.replace(placeholder, `<pre class="hljs" x-hl-lang="${fileExt}"><code>${highlighted}</code></pre>`)   
+                rendered = rendered.replace(placeholder, `<pre class="hljs" x-hl-lang="${fileExt}"><code>${highlighted}</code></pre>`)
             }
         } catch (error) {
-            
+
         }
     }
 
@@ -355,7 +355,7 @@ async function renderHighlightableMarkdown(data:string) {
 
 export const assetRegex = /{{(raw|path|img|image|video|audio|bgm|bg|emotion|asset|video-img|source)::(.+?)}}/gms
 
-async function getAssetSrc(assetArr: string[][], name: string, assetPaths: {[key: string]:{path: string[], ext?: string}}) {
+async function getAssetSrc(assetArr: string[][], name: string, assetPaths: { [key: string]: { path: string[], ext?: string } }) {
     for (const asset of assetArr) {
         if (trimmer(asset[0].toLocaleLowerCase()) !== trimmer(name)) continue
         const assetPath = await getFileSrc(asset[1])
@@ -364,14 +364,14 @@ async function getAssetSrc(assetArr: string[][], name: string, assetPaths: {[key
             path: [],
             ext: asset[2]
         }
-        if(assetPaths[key].ext === asset[2]){
+        if (assetPaths[key].ext === asset[2]) {
             assetPaths[key].path.push(assetPath)
         }
         return
     }
 }
 
-async function getEmoSrc(emoArr: string[][], emoPaths: {[key: string]:{path: string}}) {
+async function getEmoSrc(emoArr: string[][], emoPaths: { [key: string]: { path: string } }) {
     for (const emo of emoArr) {
         const emoPath = await getFileSrc(emo[1])
         emoPaths[emo[0].toLocaleLowerCase()] = {
@@ -380,23 +380,27 @@ async function getEmoSrc(emoArr: string[][], emoPaths: {[key: string]:{path: str
     }
 }
 
-async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|character, mode:'normal'|'back', arg:{ch:number}){
+async function parseAdditionalAssets(data: string, char: simpleCharacterArgument | character, mode: 'normal' | 'back', arg: { ch: number }) {
     const assetWidthString = (DBState.db.assetWidth && DBState.db.assetWidth !== -1 || DBState.db.assetWidth === 0) ? `max-width:${DBState.db.assetWidth}rem;` : ''
 
-    let assetPaths:{[key:string]:{
-        path:string[]
-        ext?:string
-    }} = {}
-    let emoPaths:{[key:string]:{
-        path:string
-    }} = {}
+    let assetPaths: {
+        [key: string]: {
+            path: string[]
+            ext?: string
+        }
+    } = {}
+    let emoPaths: {
+        [key: string]: {
+            path: string
+        }
+    } = {}
 
     if (char.emotionImages) await getEmoSrc(char.emotionImages, emoPaths)
 
     const videoExtention = ['mp4', 'webm', 'avi', 'm4p', 'm4v']
     let needsSourceAccess = false
 
-    data = await replaceAsync(data, assetRegex, async (full:string, type:string, name:string) => {
+    data = await replaceAsync(data, assetRegex, async (full: string, type: string, name: string) => {
         name = name.toLocaleLowerCase()
         const moduleAssets = getModuleAssets()
         if (char.additionalAssets) {
@@ -406,18 +410,18 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
             await getAssetSrc(moduleAssets, name, assetPaths)
         }
 
-        if(type === 'emotion'){
+        if (type === 'emotion') {
             const path = emoPaths[name]?.path
-            if(!path){
+            if (!path) {
                 return ''
             }
             return `<img src="${path}" alt="${path}" style="${assetWidthString} "/>`
         }
 
-        if(type === 'source'){
+        if (type === 'source') {
             needsSourceAccess = true
-            switch(name){
-                case 'char':{
+            switch (name) {
+                case 'char': {
                     return '\uE9b4CHAR\uE9b4'
                 }
                 case 'user': {
@@ -428,24 +432,24 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
 
         let path = assetPaths[name]
 
-        if(!path){
-            if(DBState.db.legacyMediaFindings){
+        if (!path) {
+            if (DBState.db.legacyMediaFindings) {
                 return ''
             }
 
             path = await getClosestMatch(char, name, assetPaths)
 
-            if(!path){
+            if (!path) {
                 return ''
             }
         }
 
         let p = path.path[0]
 
-        if(path.path.length > 1){
+        if (path.path.length > 1) {
             p = path.path[Math.floor(arg.ch % p.length)]
         }
-        switch(type){
+        switch (type) {
             case 'raw':
             case 'path':
                 return p
@@ -460,12 +464,12 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
             case 'audio':
                 return `<audio controls autoplay loop><source src="${p}" type="audio/mpeg"></audio>\n`
             case 'bg':
-                if(mode === 'back'){
+                if (mode === 'back') {
                     return `<div style="width:100%;height:100%;background: linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)),url(${p}); background-size: cover;"></div>`
                 }
                 break
-            case 'asset':{
-                if(path.ext && videoExtention.includes(path.ext)){
+            case 'asset': {
+                if (path.ext && videoExtention.includes(path.ext)) {
                     return `<video autoplay muted loop><source src="${p}" type="video/mp4"></video>\n`
                 }
                 return `<img src="${p}" alt="${p}" style="${assetWidthString} "/>\n`
@@ -476,9 +480,9 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
         return ''
     })
 
-    if(needsSourceAccess){
+    if (needsSourceAccess) {
         const chara = getCurrentCharacter()
-        if(chara.image){}
+        if (chara.image) { }
         data = data.replace(/\uE9b4CHAR\uE9b4/g,
             chara.image ? (await getFileSrc(chara.image)) : ''
         )
@@ -487,12 +491,12 @@ async function parseAdditionalAssets(data:string, char:simpleCharacterArgument|c
             getUserIcon() ? (await getFileSrc(getUserIcon())) : ''
         )
     }
-    
+
     return data
 }
 
-async function getClosestMatch(char: simpleCharacterArgument|character, name:string, assetPaths:{[key:string]:{path:string[], ext?:string}}){   
-    if(!char.additionalAssets) return null
+async function getClosestMatch(char: simpleCharacterArgument | character, name: string, assetPaths: { [key: string]: { path: string[], ext?: string } }) {
+    if (!char.additionalAssets) return null
 
     let closest = ''
     let closestDist = 999999
@@ -500,18 +504,18 @@ async function getClosestMatch(char: simpleCharacterArgument|character, name:str
     let targetExt = ''
 
     const trimmedName = trimmer(name)
-    for(const asset of char.additionalAssets) {
+    for (const asset of char.additionalAssets) {
         const key = asset[0].toLocaleLowerCase()
         const dist = getDistance(trimmedName, trimmer(key))
-        if(dist < closestDist){
+        if (dist < closestDist) {
             closest = key
             closestDist = dist
             targetPath = asset[1]
             targetExt = asset[2]
         }
     }
-    
-    if(closestDist > DBState.db.assetMaxDifference){
+
+    if (closestDist > DBState.db.assetMaxDifference) {
         return null
     }
 
@@ -525,31 +529,31 @@ async function getClosestMatch(char: simpleCharacterArgument|character, name:str
 }
 
 //Levenshtein distance, new with 1d array
-export function getDistance(a:string, b:string) {
+export function getDistance(a: string, b: string) {
     const h = a.length + 1
     const w = b.length + 1
     let d = new Int16Array(h * w)
-    for(let i=0;i<h;i++){
+    for (let i = 0; i < h; i++) {
         d[i * w] = i
     }
-    for(let i=0;i<w;i++){
+    for (let i = 0; i < w; i++) {
         d[i] = i
     }
-    for(let i=1; i<h; i++){
-        for(let j=1;j<w;j++){
+    for (let i = 1; i < h; i++) {
+        for (let j = 1; j < w; j++) {
             d[i * w + j] = Math.min(
-                d[(i-1) * w + j-1] + (a.charAt(i-1)===b.charAt(j-1) ? 0 : 1),
-                d[(i-1) * w + j]+1, d[i * w + j-1]+1
+                d[(i - 1) * w + j - 1] + (a.charAt(i - 1) === b.charAt(j - 1) ? 0 : 1),
+                d[(i - 1) * w + j] + 1, d[i * w + j - 1] + 1
             )
         }
     }
     return d[h * w - 1]
 }
 
-function trimmer(str:string){
+function trimmer(str: string) {
     const ext = ['webp', 'png', 'jpg', 'jpeg', 'gif', 'mp4', 'webm', 'avi', 'm4p', 'm4v', 'mp3', 'wav', 'ogg']
-    for(const e of ext){
-        if(str.endsWith('.' + e)){
+    for (const e of ext) {
+        if (str.endsWith('.' + e)) {
             str = str.substring(0, str.length - e.length - 1)
         }
     }
@@ -557,16 +561,16 @@ function trimmer(str:string){
     return str.trim().replace(/[_ -.]/g, '')
 }
 
-async function parseInlayAssets(data:string){
+async function parseInlayAssets(data: string) {
     const inlayMatch = data.match(/{{(inlay|inlayed|inlayeddata)::(.+?)}}/g)
-    if(inlayMatch){
-        for(const inlay of inlayMatch){
+    if (inlayMatch) {
+        for (const inlay of inlayMatch) {
             const inlayType = inlay.startsWith('{{inlayed') ? 'inlayed' : 'inlay'
             const id = inlay.substring(inlay.indexOf('::') + 2, inlay.length - 2)
             const asset = await getInlayAsset(id)
             let prefix = inlayType !== 'inlay' ? `<div class="risu-inlay-image">` : ''
             let postfix = inlayType !== 'inlay' ? `</div>\n\n` : ''
-            switch(asset?.type){
+            switch (asset?.type) {
                 case 'image':
                     data = data.replace(inlay, `${prefix}<img src="${asset.data}"/>${postfix}`)
                     break
@@ -577,13 +581,13 @@ async function parseInlayAssets(data:string){
                     data = data.replace(inlay, `${prefix}<audio controls><source src="${asset.data}" type="audio/mpeg"></audio>${postfix}`)
                     break
             }
-            
+
         }
     }
     return data
 }
 
-export interface simpleCharacterArgument{
+export interface simpleCharacterArgument {
     type: 'simple'
     additionalAssets?: [string, string, string][]
     customscript: customscript[]
@@ -593,7 +597,7 @@ export interface simpleCharacterArgument{
     triggerscript?: triggerscript[]
 }
 
-function parseThoughtsAndTools(data:string){
+function parseThoughtsAndTools(data: string) {
     let result = '', i = 0
     while (i < data.length) {
         if (data.substr(i, 10) === '<Thoughts>') {
@@ -611,34 +615,34 @@ function parseThoughtsAndTools(data:string){
         }
         result += data[i++]
     }
-    return result.replace(/<tool_call>(.+?)<\/tool_call>/gms, (full, txt:string) => {
-        return `<div class="x-risu-tool-call">🛠️ ${language.toolCalled.replace('{{tool}}',txt.split('\uf100')?.[1] ?? 'unknown')}</div>\n\n`
+    return result.replace(/<tool_call>(.+?)<\/tool_call>/gms, (full, txt: string) => {
+        return `<div class="x-risu-tool-call">🛠️ ${language.toolCalled.replace('{{tool}}', txt.split('\uf100')?.[1] ?? 'unknown')}</div>\n\n`
     })
 }
 
 export async function ParseMarkdown(
-    data:string,
-    charArg:(character|simpleCharacterArgument | groupChat | string) = null,
-    mode:'normal'|'back'|'pretranslate'|'notrim' = 'normal',
-    chatID=-1,
-    cbsConditions:CbsConditions = {}
+    data: string,
+    charArg: (character | simpleCharacterArgument | groupChat | string) = null,
+    mode: 'normal' | 'back' | 'pretranslate' | 'notrim' = 'normal',
+    chatID = -1,
+    cbsConditions: CbsConditions = {}
 ) {
     let firstParsed = ''
     const additionalAssetMode = (mode === 'back') ? 'back' : 'normal'
-    let char = (typeof(charArg) === 'string') ? (findCharacterbyId(charArg)) : (charArg)
+    let char = (typeof (charArg) === 'string') ? (findCharacterbyId(charArg)) : (charArg)
 
-    if(char && char.type !== 'group'){
+    if (char && char.type !== 'group') {
         data = await parseAdditionalAssets(data, char, additionalAssetMode, {
             ch: chatID
         })
         firstParsed = data
     }
 
-    if(char){
+    if (char) {
         data = (await processScriptFull(char, data, 'editdisplay', chatID, cbsConditions)).data
     }
 
-    if(firstParsed !== data && char && char.type !== 'group'){
+    if (firstParsed !== data && char && char.type !== 'group') {
         data = await parseAdditionalAssets(data, char, additionalAssetMode, {
             ch: chatID
         })
@@ -649,29 +653,29 @@ export async function ParseMarkdown(
     data = parseThoughtsAndTools(data)
 
     data = encodeStyle(data)
-    if(mode === 'normal' || mode === 'notrim'){
+    if (mode === 'normal' || mode === 'notrim') {
         data = await renderHighlightableMarkdown(data)
 
-        if(mode === 'notrim'){
+        if (mode === 'notrim') {
             return data
         }
     }
     return trimMarkdown(data)
 }
 
-export function trimMarkdown(data:string){
+export function trimMarkdown(data: string) {
     return decodeStyle(DOMPurify.sanitize(data, {
         ADD_TAGS: ["iframe", "style", "risu-style", "x-em"],
-        ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "risu-ctrl" ,"risu-btn", 'risu-trigger', 'risu-mark', 'x-hl-lang', 'x-hl-text'],
+        ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "risu-ctrl", "risu-btn", 'risu-trigger', 'risu-mark', 'x-hl-lang', 'x-hl-text'],
     }))
 }
 
-export async function postTranslationParse(data:string){
+export async function postTranslationParse(data: string) {
     let lines = data.split('\n')
 
-    for(let i=0;i<lines.length;i++){
+    for (let i = 0; i < lines.length; i++) {
         const trimed = lines[i].trim()
-        if(trimed.startsWith('<')){
+        if (trimed.startsWith('<')) {
             lines[i] = trimed
         }
     }
@@ -680,7 +684,7 @@ export async function postTranslationParse(data:string){
     return data
 }
 
-export function parseMarkdownSafe(data:string, arg:{
+export function parseMarkdownSafe(data: string, arg: {
     forbidTags?: string[],
 } = {}) {
     return DOMPurify.sanitize(renderMarkdown(md, data), {
@@ -691,21 +695,21 @@ export function parseMarkdownSafe(data:string, arg:{
 
 
 const styleRegex = /\<style\>(.+?)\<\/style\>/gms
-function encodeStyle(txt:string){
+function encodeStyle(txt: string) {
     return txt.replaceAll(styleRegex, (f, c1) => {
         return "<risu-style>" + Buffer.from(c1).toString('hex') + "</risu-style>"
     })
 }
 const styleDecodeRegex = /\<risu-style\>(.+?)\<\/risu-style\>/gms
 
-function decodeStyleRule(rule:CssAtRuleAST){
-    if(rule.type === 'rule'){
-        if(rule.selectors){
-            for(let i=0;i<rule.selectors.length;i++){
-                let slt:string = rule.selectors[i]
-                if(slt){
+function decodeStyleRule(rule: CssAtRuleAST) {
+    if (rule.type === 'rule') {
+        if (rule.selectors) {
+            for (let i = 0; i < rule.selectors.length; i++) {
+                let slt: string = rule.selectors[i]
+                if (slt) {
                     let selectors = (slt.split(' ') ?? []).map((v) => {
-                        if(v.startsWith('.') && !v.startsWith('.x-risu-')){
+                        if (v.startsWith('.') && !v.startsWith('.x-risu-')) {
                             return ".x-risu-" + v.substring(1)
                         }
                         return v
@@ -716,28 +720,28 @@ function decodeStyleRule(rule:CssAtRuleAST){
             }
         }
     }
-    if(rule.type === 'media' || rule.type === 'supports' || rule.type === 'document' || rule.type === 'host' || rule.type === 'container' ){
-        for(let i=0;i<rule.rules.length;i++){
+    if (rule.type === 'media' || rule.type === 'supports' || rule.type === 'document' || rule.type === 'host' || rule.type === 'container') {
+        for (let i = 0; i < rule.rules.length; i++) {
             rule.rules[i] = decodeStyleRule(rule.rules[i])
         }
     }
-    if(rule.type === 'import'){
-       if(rule.import.startsWith('data:')){
+    if (rule.type === 'import') {
+        if (rule.import.startsWith('data:')) {
             rule.import = 'data:,'
-       }
+        }
     }
     return rule
 }
 
-function decodeStyle(text:string){
-    return text.replaceAll(styleDecodeRegex, (full, txt:string) => {
+function decodeStyle(text: string) {
+    return text.replaceAll(styleDecodeRegex, (full, txt: string) => {
         try {
             let text = Buffer.from(txt, 'hex').toString('utf-8')
             text = risuChatParser(text)
             const ast = css.parse(text)
             const rules = ast?.stylesheet?.rules
-            if(rules){
-                for(let i=0;i<rules.length;i++){
+            if (rules) {
+                for (let i = 0; i < rules.length; i++) {
                     rules[i] = decodeStyleRule(rules[i])
                 }
                 ast.stylesheet.rules = rules
@@ -748,7 +752,7 @@ function decodeStyle(text:string){
             })}</style>`
 
         } catch (error) {
-            if(DBState.db.returnCSSError){
+            if (DBState.db.returnCSSError) {
                 return `CSS ERROR: ${error}`
             }
             return ""
@@ -756,16 +760,16 @@ function decodeStyle(text:string){
     })
 }
 
-export async function hasher(data:Uint8Array){
+export async function hasher(data: Uint8Array) {
     return Buffer.from(await crypto.subtle.digest("SHA-256", data)).toString('hex');
 }
 
-export async function convertImage(data:Uint8Array) {
-    if(!DBState.db.imageCompression){
+export async function convertImage(data: Uint8Array) {
+    if (!DBState.db.imageCompression) {
         return data
     }
     const type = checkImageType(data)
-    if(type !== 'Unknown' && type !== 'WEBP' && type !== 'AVIF'){
+    if (type !== 'Unknown' && type !== 'WEBP' && type !== 'AVIF') {
         return await resizeAndConvert(data)
     }
     return data
@@ -821,8 +825,8 @@ async function resizeAndConvert(imageData: Uint8Array): Promise<Buffer> {
 
 type ImageType = 'JPEG' | 'PNG' | 'GIF' | 'BMP' | 'AVIF' | 'WEBP' | 'Unknown';
 
-export function checkImageType(arr:Uint8Array):ImageType {
-    const isJPEG = arr[0] === 0xFF && arr[1] === 0xD8 && arr[arr.length-2] === 0xFF && arr[arr.length-1] === 0xD9;
+export function checkImageType(arr: Uint8Array): ImageType {
+    const isJPEG = arr[0] === 0xFF && arr[1] === 0xD8 && arr[arr.length - 2] === 0xFF && arr[arr.length - 1] === 0xD9;
     const isPNG = arr[0] === 0x89 && arr[1] === 0x50 && arr[2] === 0x4E && arr[3] === 0x47 && arr[4] === 0x0D && arr[5] === 0x0A && arr[6] === 0x1A && arr[7] === 0x0A;
     const isGIF = arr[0] === 0x47 && arr[1] === 0x49 && arr[2] === 0x46 && arr[3] === 0x38 && (arr[4] === 0x37 || arr[4] === 0x39) && arr[5] === 0x61;
     const isBMP = arr[0] === 0x42 && arr[1] === 0x4D;
@@ -838,50 +842,50 @@ export function checkImageType(arr:Uint8Array):ImageType {
     return "Unknown";
 }
 
-function wppParser(data:string){
+function wppParser(data: string) {
     const lines = data.split('\n');
-    let characterDetails:{[key:string]:string[]} = {};
+    let characterDetails: { [key: string]: string[] } = {};
 
     lines.forEach(line => {
 
         // Check for "{" and "}" indicator of object start and end
-        if(line.includes('{')) return;
-        if(line.includes('}')) return;
+        if (line.includes('{')) return;
+        if (line.includes('}')) return;
 
         // Extract key and value within brackets
         let keyBracketStartIndex = line.indexOf('(');
         let keyBracketEndIndex = line.indexOf(')');
-    
-       if(keyBracketStartIndex === -1 || keyBracketEndIndex === -1) 
+
+        if (keyBracketStartIndex === -1 || keyBracketEndIndex === -1)
             throw new Error(`Invalid syntax ${line}`);
-        
-       let key = line.substring(0, keyBracketStartIndex).trim();
 
-         // Validate Key    
-         if(!key) throw new Error(`Missing Key in ${line}`);
+        let key = line.substring(0, keyBracketStartIndex).trim();
 
-      const valueArray=line.substring(keyBracketStartIndex + 1, keyBracketEndIndex)
-          .split(',')
-          .map(str => str.trim());
-      
-      // Validate Values
-      for(let i=0;i<valueArray.length ;i++){
-           if(!valueArray[i])
-               throw new Error(`Empty Value in ${line}`);
-              
-     }
-      characterDetails[key] = valueArray;
-   });
+        // Validate Key    
+        if (!key) throw new Error(`Missing Key in ${line}`);
 
-   return characterDetails;
+        const valueArray = line.substring(keyBracketStartIndex + 1, keyBracketEndIndex)
+            .split(',')
+            .map(str => str.trim());
+
+        // Validate Values
+        for (let i = 0; i < valueArray.length; i++) {
+            if (!valueArray[i])
+                throw new Error(`Empty Value in ${line}`);
+
+        }
+        characterDetails[key] = valueArray;
+    });
+
+    return characterDetails;
 }
 
 
 const rgx = /(?:{{|<)(.+?)(?:}}|>)/gm
 
 export type CbsConditions = {
-    firstmsg?:boolean
-    chatRole?:string
+    firstmsg?: boolean
+    chatRole?: string
 }
 
 let matcherInitialized = false
@@ -889,8 +893,8 @@ let matcherInitialized = false
 
 const matcherMap = new Map<string, RegisterCallback>()
 
-function initMatcher(){
-    if(matcherInitialized) return
+function initMatcher() {
+    if (matcherInitialized) return
     registerCBS({
         registerFunction: function (arg: {
             name: string;
@@ -901,7 +905,7 @@ function initMatcher(){
             internalOnly?: boolean;
         }): void | Promise<void> {
             const callback = arg.callback
-            if(callback === 'doc_only') {
+            if (callback === 'doc_only') {
                 return
             }
             const names = [arg.name, ...arg.alias]
@@ -940,46 +944,46 @@ function initMatcher(){
     matcherInitialized = true
 }
 
-function matcher (p1:string,matcherArg:matcherArg,vars:{[key:string]:string}|null = null ):{
-    text:string,
-    var:{[key:string]:string}
-}|string|null {
+function matcher(p1: string, matcherArg: matcherArg, vars: { [key: string]: string } | null = null): {
+    text: string,
+    var: { [key: string]: string }
+} | string | null {
 
     initMatcher()
 
     try {
-        if(p1.startsWith('? ')){
+        if (p1.startsWith('? ')) {
             const substring = p1.substring(2)
             return calcString(substring).toString()
         }
         const colonIndex = p1.indexOf(':')
         let splited: string[]
-        if(colonIndex !== -1 && p1[colonIndex + 1] === ':'){
+        if (colonIndex !== -1 && p1[colonIndex + 1] === ':') {
             splited = p1.split('::')
         }
-        else{
+        else {
             splited = p1.split(':')
         }
         const name = splited[0].toLocaleLowerCase().replace(/[\s_-]/g, '')
         const args = splited.slice(1)
         const callback = matcherMap.get(name)
-        if(callback){
-            return callback(p1, matcherArg, args,vars)
+        if (callback) {
+            return callback(p1, matcherArg, args, vars)
         }
-    } catch (error) {}
+    } catch (error) { }
 
     return null
 }
 
-const dateTimeFormat = (main:string, time = 0) => {
+const dateTimeFormat = (main: string, time = 0) => {
     const date = time === 0 ? (new Date()) : (new Date(time))
-    if(!main){
+    if (!main) {
         return ''
     }
-    if(main.startsWith(':')){
+    if (main.startsWith(':')) {
         main = main.substring(1)
     }
-    if(main.length > 300){
+    if (main.length > 300) {
         return ''
     }
     return main
@@ -1002,36 +1006,36 @@ const dateTimeFormat = (main:string, time = 0) => {
 
 }
 
-const smMatcher = (p1:string,matcherArg:matcherArg) => {
-    if(!p1){
+const smMatcher = (p1: string, matcherArg: matcherArg) => {
+    if (!p1) {
         return null
     }
     const lowerCased = p1.toLocaleLowerCase()
     const db = matcherArg.db
     const chara = matcherArg.chara
-    switch(lowerCased){
+    switch (lowerCased) {
         case 'char':
-        case 'bot':{
-            if(matcherArg.consistantChar){
+        case 'bot': {
+            if (matcherArg.consistantChar) {
                 return 'botname'
             }
             let selectedChar = get(selectedCharID)
             let currentChar = db.characters[selectedChar]
-            if(currentChar && currentChar.type !== 'group'){
+            if (currentChar && currentChar.type !== 'group') {
                 return currentChar.nickname || currentChar.name
             }
-            if(chara){
-                if(typeof(chara) === 'string'){
+            if (chara) {
+                if (typeof (chara) === 'string') {
                     return chara
                 }
-                else{
+                else {
                     return chara.name
                 }
             }
             return currentChar.nickname || currentChar.name
         }
-        case 'user':{
-            if(matcherArg.consistantChar){
+        case 'user': {
+            if (matcherArg.consistantChar) {
                 return 'username'
             }
             return getUserName()
@@ -1039,10 +1043,10 @@ const smMatcher = (p1:string,matcherArg:matcherArg) => {
     }
 }
 
-const legacyBlockMatcher = (p1:string,matcherArg:matcherArg) => {
+const legacyBlockMatcher = (p1: string, matcherArg: matcherArg) => {
     const bn = p1.indexOf('\n')
 
-    if(bn === -1){
+    if (bn === -1) {
         return null
     }
 
@@ -1050,12 +1054,12 @@ const legacyBlockMatcher = (p1:string,matcherArg:matcherArg) => {
     const content = p1.substring(bn + 1)
     const statement = logic.split(" ", 2)
 
-    switch(statement[0]){
-        case 'if':{
-            if(["","0","-1"].includes(statement[1])){
+    switch (statement[0]) {
+        case 'if': {
+            if (["", "0", "-1"].includes(statement[1])) {
                 return ''
             }
-        
+
             return content.trim()
         }
     }
@@ -1063,12 +1067,12 @@ const legacyBlockMatcher = (p1:string,matcherArg:matcherArg) => {
     return null
 }
 
-type blockMatch = 'ignore'|'parse'|'nothing'|'ifpure'|'pure'|'each'|'function'|'pure-display'|'normalize'|'escape'|'newif'|'newif-falsy'
+type blockMatch = 'ignore' | 'parse' | 'nothing' | 'ifpure' | 'pure' | 'each' | 'function' | 'pure-display' | 'normalize' | 'escape' | 'newif' | 'newif-falsy'
 
-function parseArray(p1:string):string[]{
+function parseArray(p1: string): string[] {
     try {
         const arr = JSON.parse(p1)
-        if(Array.isArray(arr)){
+        if (Array.isArray(arr)) {
             return arr
         }
         return p1.split('§')
@@ -1077,7 +1081,7 @@ function parseArray(p1:string):string[]{
     }
 }
 
-function parseDict(p1:string):{[key:string]:string}{
+function parseDict(p1: string): { [key: string]: string } {
     try {
         return JSON.parse(p1)
     } catch (error) {
@@ -1085,211 +1089,211 @@ function parseDict(p1:string):{[key:string]:string}{
     }
 }
 
-function makeArray(p1:string[]):string{
+function makeArray(p1: string[]): string {
     return JSON.stringify(p1.map((f) => {
-        if(typeof(f) === 'string'){
+        if (typeof (f) === 'string') {
             return f.replace(/::/g, '\\u003A\\u003A')
         }
         return f
     }))
 }
 
-function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,type2?:string,funcArg?:string[]}{
-    if(p1.startsWith('#if') || p1.startsWith('#if_pure ')){
+function blockStartMatcher(p1: string, matcherArg: matcherArg): { type: blockMatch, type2?: string, funcArg?: string[] } {
+    if (p1.startsWith('#if') || p1.startsWith('#if_pure ')) {
         const statement = p1.split(' ', 2)
         const state = statement[1]
-        if(state === 'true' || state === '1'){
+        if (state === 'true' || state === '1') {
             return {
-                type:   p1.startsWith('#if_pure') ? 'ifpure' :
-                        'parse'
+                type: p1.startsWith('#if_pure') ? 'ifpure' :
+                    'parse'
             }
         }
-        return {type:'ignore'}
+        return { type: 'ignore' }
     }
 
-    if(p1.startsWith('#when')){
-        if(p1.startsWith('#when ')){
+    if (p1.startsWith('#when')) {
+        if (p1.startsWith('#when ')) {
             const statement = p1.split(' ', 2)
             const state = statement[1]
-            return {type: (state === 'true' || state === '1') ? 'newif' : 'newif-falsy'}
+            return { type: (state === 'true' || state === '1') ? 'newif' : 'newif-falsy' }
         }
-        else if(p1.startsWith('#when::')){
+        else if (p1.startsWith('#when::')) {
             const statement = p1.split('::').slice(1)
-            if(statement.length === 1){
+            if (statement.length === 1) {
                 const state = statement[0]
-                return {type: (state === 'true' || state === '1') ? 'newif' : 'newif-falsy'}
+                return { type: (state === 'true' || state === '1') ? 'newif' : 'newif-falsy' }
             }
             let mode: 'normal' | 'keep' | 'legacy' = 'normal'
 
-            const isTruthy = (s:string) => {
+            const isTruthy = (s: string) => {
                 return s === 'true' || s === '1'
             }
-            while(statement.length > 1){
+            while (statement.length > 1) {
                 const condition = statement.pop()
                 const operator = statement.pop()
-                switch(operator){
-                    case 'not':{
-                        if(isTruthy(condition)){
+                switch (operator) {
+                    case 'not': {
+                        if (isTruthy(condition)) {
                             statement.push('0')
                         }
-                        else{
+                        else {
                             statement.push('1')
                         }
                         break
                     }
-                    case 'keep':{
+                    case 'keep': {
                         mode = 'keep'
                         break
                     }
-                    case 'legacy':{
+                    case 'legacy': {
                         mode = 'legacy'
                         break
                     }
-                    case 'and':{
+                    case 'and': {
                         const condition2 = statement.pop()
-                        if(isTruthy(condition) && isTruthy(condition2)){
+                        if (isTruthy(condition) && isTruthy(condition2)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'or':{
+                    case 'or': {
                         const condition2 = statement.pop()
-                        if(isTruthy(condition) || isTruthy(condition2)){
+                        if (isTruthy(condition) || isTruthy(condition2)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'is':{
+                    case 'is': {
                         const condition2 = statement.pop()
-                        if(condition === condition2){
+                        if (condition === condition2) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'isnot':{
+                    case 'isnot': {
                         const condition2 = statement.pop()
-                        if(condition !== condition2){
+                        if (condition !== condition2) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'var':{
+                    case 'var': {
                         const variable = getChatVar(condition)
-                        if(isTruthy(variable)){
+                        if (isTruthy(variable)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'toggle':{
+                    case 'toggle': {
                         const variable = getGlobalChatVar('toggle_' + condition)
-                        if(isTruthy(variable)){
+                        if (isTruthy(variable)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'vis':{ //vis = variable is
+                    case 'vis': { //vis = variable is
                         const variable = getChatVar(statement.pop())
-                        if(variable === condition){
+                        if (variable === condition) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'visnot':{ //visnot = variable is not
+                    case 'visnot': { //visnot = variable is not
                         const variable = getChatVar(statement.pop())
-                        if(variable !== condition){
+                        if (variable !== condition) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                     }
-                    case 'tis':{ //tis = toggle is
+                    case 'tis': { //tis = toggle is
                         const variable = getGlobalChatVar('toggle_' + statement.pop())
                         console.log('tis', variable, condition)
-                        if(variable === condition){
+                        if (variable === condition) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case 'tisnot':{ //tisnot = toggle is not
+                    case 'tisnot': { //tisnot = toggle is not
                         const variable = getGlobalChatVar('toggle_' + statement.pop())
-                        if(variable !== condition){
+                        if (variable !== condition) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case '>':{
+                    case '>': {
                         const condition2 = statement.pop()
-                        if(parseFloat(condition) > parseFloat(condition2)){
+                        if (parseFloat(condition) > parseFloat(condition2)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case '<':{
+                    case '<': {
                         const condition2 = statement.pop()
-                        if(parseFloat(condition) < parseFloat(condition2)){
+                        if (parseFloat(condition) < parseFloat(condition2)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case '>=':{
+                    case '>=': {
                         const condition2 = statement.pop()
-                        if(parseFloat(condition) >= parseFloat(condition2)){
+                        if (parseFloat(condition) >= parseFloat(condition2)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    case '<=':{
+                    case '<=': {
                         const condition2 = statement.pop()
-                        if(parseFloat(condition) <= parseFloat(condition2)){
+                        if (parseFloat(condition) <= parseFloat(condition2)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
                     }
-                    default:{
-                        if(isTruthy(condition)){
+                    default: {
+                        if (isTruthy(condition)) {
                             statement.push('1')
                         }
-                        else{
+                        else {
                             statement.push('0')
                         }
                         break
@@ -1298,247 +1302,277 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
             }
 
             const finalCondition = statement[0]
-            if(isTruthy(finalCondition)){
-                switch(mode){
-                    case 'keep':{
-                        return {type: 'newif', type2: 'keep'}
+            if (isTruthy(finalCondition)) {
+                switch (mode) {
+                    case 'keep': {
+                        return { type: 'newif', type2: 'keep' }
                     }
-                    case 'legacy':{
-                        return {type: 'parse'}
+                    case 'legacy': {
+                        return { type: 'parse' }
                     }
-                    default:{
-                        return {type: 'newif'}
+                    default: {
+                        return { type: 'newif' }
                     }
                 }
             }
-            else{
-                switch(mode){
-                    case 'keep':{
-                        return {type: 'newif-falsy', type2: 'keep'}
+            else {
+                switch (mode) {
+                    case 'keep': {
+                        return { type: 'newif-falsy', type2: 'keep' }
                     }
-                    case 'legacy':{
-                        return {type: 'ignore'}
+                    case 'legacy': {
+                        return { type: 'ignore' }
                     }
-                    default:{
-                        return {type: 'newif-falsy'}
+                    default: {
+                        return { type: 'newif-falsy' }
                     }
                 }
             }
         }
-        else{
-            return {type: 'newif-falsy'}
+        else {
+            return { type: 'newif-falsy' }
         }
     }
-    if(p1 === '#pure'){
-        return {type:'pure'}
+    if (p1 === '#pure') {
+        return { type: 'pure' }
     }
-    if(p1 === '#pure_display' || p1 === '#puredisplay'){
-        return {type:'pure-display'}
+    if (p1 === '#pure_display' || p1 === '#puredisplay') {
+        return { type: 'pure-display' }
     }
-    if(p1 === '#code'){
-        return {type:'normalize'}
+    if (p1 === '#code') {
+        return { type: 'normalize' }
     }
-    if(p1 === '#escape'){
-        return {type:'escape'}
+    if (p1 === '#escape') {
+        return { type: 'escape' }
     }
-    if(p1.startsWith('#each')){
+    if (p1.startsWith('#each')) {
         let t2 = p1.substring(5).trim()
-        if(t2.startsWith('as ')){
+        if (t2.startsWith('as ')) {
             t2 = t2.substring(3).trim()
         }
-        return {type:'each',type2:t2}
+        return { type: 'each', type2: t2 }
     }
-    if(p1.startsWith('#func')){
+    if (p1.startsWith('#func')) {
         const statement = p1.split(' ')
-        if(statement.length > 1){
-            return {type:'function',funcArg:statement.slice(1)}
+        if (statement.length > 1) {
+            return { type: 'function', funcArg: statement.slice(1) }
         }
 
     }
 
 
-    return {type:'nothing'}
+    return { type: 'nothing' }
 }
 
-function trimLines(p1:string){
+function trimLines(p1: string) {
     return p1.split('\n').map((v) => {
         return v.trimStart()
     }).join('\n').trim()
 }
 
-function blockEndMatcher(p1:string,type:{type:blockMatch,type2?:string},matcherArg:matcherArg):string{
-    const p1Trimed = p1.trim() 
-    switch(type.type){
+function blockEndMatcher(p1: string, type: { type: blockMatch, type2?: string }, matcherArg: matcherArg): string {
+    const p1Trimed = p1.trim()
+    switch (type.type) {
         case 'pure':
         case 'pure-display':
-        case 'function':{
+        case 'function': {
             return p1Trimed
         }
         case 'parse':
-        case 'each':{
+        case 'each': {
             return trimLines(p1Trimed)
         }
-        case 'ifpure':{
+        case 'ifpure': {
             return p1
         }
         case 'newif':
-        case 'newif-falsy':{
-            const lines =  p1.split("\n")
+        case 'newif-falsy': {
+            const lines = p1.split("\n")
 
-            if(lines.length === 1){
+            if (lines.length === 1) {
                 const elseIndex = p1.indexOf('{{:else}}')
-                if(elseIndex !== -1){
-                    if(type.type === 'newif'){
+                if (elseIndex !== -1) {
+                    if (type.type === 'newif') {
                         return p1.substring(0, elseIndex)
                     }
-                    if(type.type === 'newif-falsy'){
+                    if (type.type === 'newif-falsy') {
                         return p1.substring(elseIndex + 9)
                     }
                 }
-                else{
-                    if(type.type === 'newif'){
+                else {
+                    if (type.type === 'newif') {
                         return p1
                     }
-                    if(type.type === 'newif-falsy'){
+                    if (type.type === 'newif-falsy') {
                         return ''
                     }
                 }
             }
-            
+
             const elseLine = lines.findIndex((v) => {
                 return v.trim() === '{{:else}}'
             })
 
-            if(elseLine !== -1 && type.type === 'newif'){
+            if (elseLine !== -1 && type.type === 'newif') {
                 lines.splice(elseLine) //else line and everything after it is removed
             }
-            if(elseLine !== -1 && type.type === 'newif-falsy'){
+            if (elseLine !== -1 && type.type === 'newif-falsy') {
                 lines.splice(0, elseLine + 1) //everything before else line is removed
             }
-            if(elseLine === -1 && type.type === 'newif-falsy'){
+            if (elseLine === -1 && type.type === 'newif-falsy') {
                 return ''
             }
 
-            if(type.type2 !== 'keep'){
-                while(lines.length > 0 && lines[0].trim() === ''){
+            if (type.type2 !== 'keep') {
+                while (lines.length > 0 && lines[0].trim() === '') {
                     lines.shift()
                 }
-                while(lines.length > 0 && lines[lines.length - 1].trim() === ''){
+                while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
                     lines.pop()
                 }
             }
             return lines.join('\n')
         }
 
-        case 'normalize':{
-            return p1Trimed.trim().replaceAll('\n','').replaceAll('\t','')
-            .replaceAll(/\\u([0-9A-Fa-f]{4})/g, (match, p1) => {
-                return String.fromCharCode(parseInt(p1, 16))
-            })
-            .replaceAll(/\\(.)/g, (match, p1) => {
-                switch(p1){
-                    case 'n':
-                        return '\n'
-                    case 'r':
-                        return '\r'
-                    case 't':
-                        return '\t'
-                    case 'b':
-                        return '\b'
-                    case 'f':
-                        return '\f'
-                    case 'v':
-                        return '\v'
-                    case 'a':
-                        return '\a'
-                    case 'x':
-                        return '\x00'
-                    default:
-                        return p1
-                }
-            })
+        case 'normalize': {
+            return p1Trimed.trim().replaceAll('\n', '').replaceAll('\t', '')
+                .replaceAll(/\\u([0-9A-Fa-f]{4})/g, (match, p1) => {
+                    return String.fromCharCode(parseInt(p1, 16))
+                })
+                .replaceAll(/\\(.)/g, (match, p1) => {
+                    switch (p1) {
+                        case 'n':
+                            return '\n'
+                        case 'r':
+                            return '\r'
+                        case 't':
+                            return '\t'
+                        case 'b':
+                            return '\b'
+                        case 'f':
+                            return '\f'
+                        case 'v':
+                            return '\v'
+                        case 'a':
+                            return '\a'
+                        case 'x':
+                            return '\x00'
+                        default:
+                            return p1
+                    }
+                })
         }
-        case 'escape':{
+        case 'escape': {
             return risuEscape(p1Trimed)
         }
-        default:{
+        default: {
             return ''
         }
     }
 }
 
-export function risuChatParser(da:string, arg:{
-    chatID?:number
-    db?:Database
-    chara?:string|character|groupChat
-    rmVar?:boolean,
-    var?:{[key:string]:string}
-    tokenizeAccurate?:boolean
-    consistantChar?:boolean
-    visualize?:boolean,
-    role?:string
-    runVar?:boolean
-    functions?:Map<string,{data:string,arg:string[]}>
-    callStack?:number
-    cbsConditions?:CbsConditions
-} = {}):string{
-    const chatID = arg.chatID ?? -1
-    const db = arg.db ?? DBState.db
-    const aChara = arg.chara
-    const visualize = arg.visualize ?? false
-    let chara:character|string = null
+export function risuChatParser(da: string, arg: {
+    chatID?: number
+    db?: Database
+    chara?: string | character | groupChat
+    rmVar?: boolean,
+    var?: { [key: string]: string }
+    tokenizeAccurate?: boolean
+    consistantChar?: boolean
+    visualize?: boolean,
+    role?: string
+    runVar?: boolean
+    functions?: Map<string, { data: string, arg: string[] }>
+    callStack?: number
+    cbsConditions?: CbsConditions
+} = {}): string {
+    // --- Debug Settings ---
+    const isDebugMode = true; // Set to false to disable all console logs.
+    const callStack = (arg.callStack ?? 0) + 1;
+    const logIndent = ' '.repeat(callStack * 2);
+    const log = (...args: any[]) => {
+        if (isDebugMode) {
+            console.log(logIndent + '[RisuParser]', ...args);
+        }
+    };
 
-    if(aChara){
-        if(typeof(aChara) !== 'string' && aChara.type === 'group'){
-            if(aChara.chats[aChara.chatPage].message.length > 0){
-                const gc = findCharacterbyId(aChara.chats[aChara.chatPage].message.at(-1).saying ?? '')
-                if(gc.name !== 'Unknown Character'){
-                    chara = gc
+    log(`Call Stack #${callStack} | Input: "${da.substring(0, 100)}${da.length > 100 ? '...' : ''}"`);
+    log('Arguments:', arg);
+
+    // Prevent infinite recursion by limiting the call stack depth.
+    if (callStack > 20) {
+        log('ERROR: Call stack limit reached');
+        return 'ERROR: Call stack limit reached';
+    }
+
+    const chatID = arg.chatID ?? -1;
+    const db = arg.db ?? DBState.db;
+    const aChara = arg.chara;
+    const visualize = arg.visualize ?? false;
+    let chara: character | string = null;
+
+    // Determine the active character, especially for group chats.
+    if (aChara) {
+        if (typeof (aChara) !== 'string' && aChara.type === 'group') {
+            // In a group chat, the active character is the one who sent the last message.
+            if (aChara.chats[aChara.chatPage].message.length > 0) {
+                const gc = findCharacterbyId(aChara.chats[aChara.chatPage].message.at(-1).saying ?? '');
+                if (gc.name !== 'Unknown Character') {
+                    chara = gc;
                 }
             }
-            else{
-                chara = 'bot'
+            // If the chat is empty, default to 'bot'.
+            else {
+                chara = 'bot';
             }
         }
-        else{
-            chara = aChara
+        else {
+            // For non-group chats, use the provided character directly.
+            chara = aChara;
         }
     }
-    if(arg.tokenizeAccurate){
-        const db = arg.db ?? DBState.db
-        const selchar = chara ?? db.characters[get(selectedCharID)]
-        if(!selchar){
-            chara = 'bot'
+    if (arg.tokenizeAccurate) {
+        const db = arg.db ?? DBState.db;
+        const selchar = chara ?? db.characters[get(selectedCharID)];
+        if (!selchar) {
+            chara = 'bot';
         }
     }
+    log('Determined character:', chara);
 
-    
+    // --- Parser State ---
     let pointer = 0;
-    let nested:string[] = [""]
-    let stackType = new Uint8Array(512)
-    let pureModeNest:Map<number,boolean> = new Map()
-    let pureModeNestType:Map<number,string> = new Map()
-    let blockNestType:Map<number,{
-        type:blockMatch,
-        type2?:string
-        funcArg?:string[]
-    }> = new Map()
-    let commentMode = false
-    let commentLatest:string[] = [""]
-    let commentV = new Uint8Array(512)
-    let thinkingMode = false
-    let tempVar:{[key:string]:string} = {}
-    let functions:Map<string,{
-        data:string,
-        arg:string[]
-    }> = arg.functions ?? (new Map())
+    let nested: string[] = [""]; // A stack for handling nested expressions. `nested[0]` is the current buffer.
+    let stackType = new Uint8Array(512); // Tracks the type of each nesting level (e.g., 1 for {{...}}, 5 for blocks).
 
-    arg.callStack = (arg.callStack ?? 0) + 1
+    // State for 'Pure Mode', where `{{...}}` syntax is ignored.
+    let pureModeNest: Map<number, boolean> = new Map();
+    let pureModeNestType: Map<number, string> = new Map();
 
-    if(arg.callStack > 20){
-        return 'ERROR: Call stack limit reached'
-    }
+    // Stores metadata for each active block (e.g., `if`, `each`).
+    let blockNestType: Map<number, {
+        type: blockMatch,
+        type2?: string
+        funcArg?: string[]
+    }> = new Map();
 
+    // Legacy state variables.
+    let commentMode = false;
+    let commentLatest: string[] = [""];
+    let commentV = new Uint8Array(512);
+    let thinkingMode = false;
+
+    // Temporary variables created during parsing (e.g., assignments).
+    let tempVar: { [key: string]: string } = {};
+    // Stores user-defined functions from `{{#function ...}}` blocks.
+    let functions: Map<string, {
+        data: string,
+        arg: string[]
+    }> = arg.functions ?? (new Map());
+
+    arg.callStack = callStack;
+
+    // A consolidated context object passed to helper functions.
     const matcherObj = {
         chatID: chatID,
         chara: chara,
@@ -1552,204 +1586,296 @@ export function risuChatParser(da:string, arg:{
         consistantChar: arg.consistantChar ?? false,
         cbsConditions: arg.cbsConditions ?? {},
         callStack: arg.callStack,
-    }
+    };
+    log('Matcher object created:', matcherObj);
 
-    da = da.replace(/\<(user|char|bot)\>/gi, '{{$1}}')
+    // Pre-processing: Normalize legacy syntax like `<user>` to `{{user}}`.
+    da = da.replace(/\<(user|char|bot)\>/gi, '{{$1}}');
 
     const isPureMode = () => {
-        return pureModeNest.size > 0
-    }
+        return pureModeNest.size > 0;
+    };
     const pureModeType = () => {
-        if(pureModeNest.size === 0){
-            return ''
+        if (pureModeNest.size === 0) {
+            return '';
         }
-        return pureModeNestType.get(nested.length) ?? [...pureModeNestType.values()].at(-1) ?? ''
-    }
-    while(pointer < da.length){
-        switch(da[pointer]){
-            case '{':{
-                if(da[pointer + 1] !== '{' && da[pointer + 1] !== '#'){
-                    nested[0] += da[pointer]
-                    break
+        return pureModeNestType.get(nested.length) ?? [...pureModeNestType.values()].at(-1) ?? '';
+    };
+
+    // --- Main Parsing Loop ---
+    while (pointer < da.length) {
+        const char = da[pointer];
+
+        switch (char) {
+            case '{': {
+                // If it's not a `{{` or `{#` opening, treat it as a literal character.
+                if (da[pointer + 1] !== '{' && da[pointer + 1] !== '#') {
+                    nested[0] += char;
+                    break;
                 }
-                pointer++
-                nested.unshift('')
-                stackType[nested.length] = 1
-                break
+                pointer++;
+                log(`Found '{{' or '{#'. Starting new nest level. Current level: ${nested.length - 1}`);
+                // Start a new nesting level for the expression.
+                nested.unshift('');
+                stackType[nested.length] = 1; // Mark level type as a standard expression.
+                break;
             }
-            case '#':{
-                //legacy if statement, deprecated
-                if(da[pointer + 1] !== '}' || nested.length === 1 || stackType[nested.length] !== 1){
-                    nested[0] += da[pointer]
-                    break
+            case '#': {
+                // Handle legacy `{#...#}` blocks (deprecated).
+                if (da[pointer + 1] !== '}' || nested.length === 1 || stackType[nested.length] !== 1) {
+                    nested[0] += char;
+                    break;
                 }
-                pointer++
-                const dat = nested.shift()
-                const mc = legacyBlockMatcher(dat, matcherObj)
-                nested[0] += mc ?? `{#${dat}#}`
-                break
+                pointer++;
+                const dat = nested.shift();
+                log(`Processing legacy block: {#${dat}#}`);
+                const mc = legacyBlockMatcher(dat, matcherObj);
+                log(`Legacy block result: "${mc}"`);
+                nested[0] += mc ?? `{#${dat}#}`;
+                break;
             }
-            case '}':{
-                if(da[pointer + 1] !== '}' || nested.length === 1 || stackType[nested.length] !== 1){
-                    nested[0] += da[pointer]
-                    break
+            case '}': {
+                // If it's not a `}}` closing, treat it as a literal character.
+                if (da[pointer + 1] !== '}' || nested.length === 1 || stackType[nested.length] !== 1) {
+                    nested[0] += char;
+                    break;
                 }
-                pointer++
-                const dat = nested.shift()
-                if(dat.startsWith('#') || dat.startsWith(':')){
-                    if(isPureMode()){
-                        nested[0] += `{{${dat}}}`
-                        nested.unshift('')
-                        stackType[nested.length] = 6
-                        break
-                    }
-                    const matchResult = blockStartMatcher(dat, matcherObj)
-                    if(matchResult.type === 'nothing'){
-                        nested[0] += `{{${dat}}}`
-                        break
-                    }
-                    else{
-                        nested.unshift('')
-                        stackType[nested.length] = 5
-                        blockNestType.set(nested.length, matchResult)
-                        if( matchResult.type === 'ignore' || matchResult.type === 'pure' ||
-                            matchResult.type === 'each' || matchResult.type === 'function' ||
-                            matchResult.type === 'pure-display' || matchResult.type === 'escape'
-                        ){
-                            pureModeNest.set(nested.length, true)
-                            pureModeNestType.set(nested.length, "block")
-                        }
-                        break
-                    }
-                }
-                if(dat.startsWith('/') && !dat.startsWith('//')){
-                    if(stackType[nested.length] === 5){
-                        const blockType = blockNestType.get(nested.length)
-                        if( blockType.type === 'ignore' || blockType.type === 'pure' ||
+                pointer++;
+                const dat = nested.shift(); // Pop the content of the `{{...}}` from the stack.
+                log(`Found '}}'. Processing content: "${dat}", Current nest level: ${nested.length - 1}`);
+
+                // --- Expression Processing Logic ---
+
+                // Priority 1: Check for block closing tags (e.g., `{{/if}}`).
+                // This must be checked before Pure Mode to allow blocks to terminate correctly.
+                if (dat.startsWith('/') && !dat.startsWith('//')) {
+                    log(`Content is a block ender: "${dat}"`);
+
+                    if (stackType[nested.length] === 5) { // Check if we are actually inside a block.
+                        const blockType = blockNestType.get(nested.length);
+                        log(`Matching block end for type:`, blockType);
+
+                        // If this block type initiated Pure Mode, exit it now.
+                        if (blockType.type === 'ignore' || blockType.type === 'pure' ||
                             blockType.type === 'each' || blockType.type === 'function' ||
                             blockType.type === 'pure-display' || blockType.type === 'escape'
-                        ){
-                            pureModeNest.delete(nested.length)
-                            pureModeNestType.delete(nested.length)
+                        ) {
+                            log(`Exiting PURE MODE.`);
+                            pureModeNest.delete(nested.length);
+                            pureModeNestType.delete(nested.length);
                         }
-                        blockNestType.delete(nested.length)
-                        const dat2 = nested.shift()
-                        const matchResult = blockEndMatcher(dat2, blockType, matcherObj)
-                        if(blockType.type === 'each'){
-                            const subind = blockType.type2.lastIndexOf(' ')
-                            const sub = blockType.type2.substring(subind + 1)
-                            const array = parseArray(blockType.type2.substring(0, subind))
-                            let added = ''
-                            for(let i = 0;i < array.length;i++){
-                                const res = matchResult.replaceAll(`{{slot::${sub}}}`, array[i])
-                                added += res
+                        blockNestType.delete(nested.length);
+
+                        const dat2 = nested.shift(); // Get the raw content of the block.
+                        log(`Block content to be processed: "${dat2}"`);
+
+                        // Special handling for `{{#each}}` blocks.
+                        if (blockType.type === 'each') {
+                            const subind = blockType.type2.lastIndexOf(' ');
+                            const sub = blockType.type2.substring(subind + 1); // slot name
+                            const array = parseArray(blockType.type2.substring(0, subind)); // array data
+                            let added = '';
+                            log(`Processing 'each' block. Array:`, array, `Slot name: ${sub}`);
+
+                            const blockContentTemplate = dat2; // Use the unparsed content as a template.
+                            log(`'each' block raw template: "${blockContentTemplate}"`);
+
+                            for (let i = 0; i < array.length; i++) {
+                                // Step 1: Replace the `{{slot::...}}` placeholder with the current array item.
+                                const resWithSlot = blockContentTemplate.replaceAll(`{{slot::${sub}}}`, array[i]);
+                                log(`[Loop ${i}] String with slot replaced: "${resWithSlot}"`);
+
+                                // Step 2: Recursively parse the result to process other expressions inside the loop.
+                                const finalRes = risuChatParser(resWithSlot, { ...arg, functions: functions });
+                                log(`[Loop ${i}] Parsed result: "${finalRes}"`);
+
+                                added += finalRes;
                             }
-                            da = da.substring(0, pointer + 1) + added.trim() + da.substring(pointer + 1)
-                            break
+
+                            log(`'each' block generated content: "${added}"`);
+                            nested[0] += added;
+                            break; // End of 'each' processing.
                         }
-                        if(blockType.type === 'function'){
-                            console.log(matchResult)
+
+                        const matchResult = blockEndMatcher(dat2, blockType, matcherObj);
+                        log(`Block end processing result: "${matchResult}"`);
+
+                        // Handle `{{#function}}` block definition.
+                        if (blockType.type === 'function') {
+                            log(`Defining function '${blockType.funcArg[0]}' with args`, blockType.funcArg.slice(1));
                             functions.set(blockType.funcArg[0], {
                                 data: matchResult,
                                 arg: blockType.funcArg.slice(1)
-                            })
-                            break
+                            });
+                            log('Current functions map:', functions);
+                            break;
                         }
-                        if(blockType.type === 'pure-display'){
-                            nested[0] += matchResult.replaceAll('{{', '\\{\\{').replaceAll('}}', '\\}\\}')
-                            break
+
+                        // For `pure-display`, escape the output to prevent re-parsing.
+                        if (blockType.type === 'pure-display') {
+                            nested[0] += matchResult.replaceAll('{{', '\\{\\{').replaceAll('}}', '\\}\\}');
+                            break;
                         }
-                        if(matchResult === ''){
-                            break
+
+                        if (matchResult !== '') {
+                            nested[0] += matchResult;
                         }
-                        nested[0] += matchResult
-                        break
+                        break; // End of block closing tag processing.
                     }
-                    if(stackType[nested.length] === 6){
-                        const sft = nested.shift()
-                        nested[0] += sft + `{{${dat}}}`
-                        break
+
+                    // A closing tag appeared where it wasn't expected.
+                    if (stackType[nested.length] === 6) {
+                        const sft = nested.shift();
+                        nested[0] += sft + `{{${dat}}}`;
+                        break;
                     }
                 }
-                if(dat.startsWith('call::')){
-                    if(arg.callStack && arg.callStack > 20){
-                        nested[0] += `ERROR: Call stack limit reached`
-                        break
-                    }
-                    const argData = dat.split('::').slice(1)
-                    const funcName = argData[0]
-                    const func = functions.get(funcName)
-                    console.log(func)
-                    if(func){
-                        let data = func.data
-                        for(let i = 0;i < argData.length;i++){
-                            data = data.replaceAll(`{{arg::${i}}}`, argData[i])
+
+                // Priority 2: If in Pure Mode, treat the expression as literal text.
+                if (isPureMode()) {
+                    log(`In pure mode. Treating "{{${dat}}}" as plain text.`);
+                    nested[0] += `{{${dat}}}`;
+                    break;
+                }
+
+                // --- The following logic only runs when not in Pure Mode ---
+
+                // Priority 3: Check for block starting tags (e.g., `{{#if}}`, `{{:var=1}}`).
+                if (dat.startsWith('#') || dat.startsWith(':')) {
+                    log(`Content is a block starter: "${dat}"`);
+                    const matchResult = blockStartMatcher(dat, matcherObj);
+                    log('Block start match result:', matchResult);
+
+                    if (matchResult.type === 'nothing') {
+                        // Not a valid block, treat as literal text.
+                        nested[0] += `{{${dat}}}`;
+                    } else {
+                        log(`Starting new block of type '${matchResult.type}'. Nesting further.`);
+                        nested.unshift(''); // Push a new level for the block's content.
+                        stackType[nested.length] = 5; // Mark as a block type.
+                        blockNestType.set(nested.length, matchResult);
+
+                        // If this block type requires it, enter Pure Mode.
+                        if (matchResult.type === 'ignore' || matchResult.type === 'pure' ||
+                            matchResult.type === 'each' || matchResult.type === 'function' ||
+                            matchResult.type === 'pure-display' || matchResult.type === 'escape'
+                        ) {
+                            log(`Entering PURE MODE for block type '${matchResult.type}'.`);
+                            pureModeNest.set(nested.length, true);
+                            pureModeNestType.set(nested.length, "block");
                         }
-                        arg.functions = functions
-                        nested[0] += risuChatParser(data, arg)
-                        break
+                    }
+                    break; // End of block starting tag processing.
+                }
+
+                // Priority 4: Check for function calls `{{call::...}}`.
+                if (dat.startsWith('call::')) {
+                    log(`Processing function call: "${dat}"`);
+                    if (arg.callStack && arg.callStack > 20) {
+                        nested[0] += `ERROR: Call stack limit reached`;
+                        break;
+                    }
+
+                    const rawArgs = dat.substring('call::'.length);
+                    const argData = [];
+                    let currentArg = '';
+                    let braceLevel = 0;
+                    // Manually parse arguments to correctly handle nested `{{...}}` within an argument.
+                    for (let i = 0; i < rawArgs.length; i++) {
+                        if (rawArgs.substring(i, i + 2) === '{{') {
+                            braceLevel++;
+                            currentArg += '{{';
+                            i++;
+                        } else if (rawArgs.substring(i, i + 2) === '}}') {
+                            braceLevel--;
+                            currentArg += '}}';
+                            i++;
+                        } else if (rawArgs.substring(i, i + 2) === '::' && braceLevel === 0) {
+                            argData.push(currentArg.trim());
+                            currentArg = '';
+                            i++;
+                        } else {
+                            currentArg += rawArgs[i];
+                        }
+                    }
+                    argData.push(currentArg.trim());
+
+                    const funcName = argData[0];
+                    const funcArgs = argData.slice(1);
+                    const func = functions.get(funcName);
+                    log(`Calling function '${funcName}' with args:`, funcArgs);
+
+                    if (func) {
+                        let data = func.data;
+                        log(`Function body found: "${data}"`);
+                        // Replace argument placeholders `{{arg::N}}` with provided values.
+                        for (let i = 0; i < funcArgs.length; i++) {
+                            const placeholder = `{{arg::${i + 1}}}`;
+                            const replacement = funcArgs[i];
+                            if (data.includes(placeholder)) {
+                                log(`Replacing '${placeholder}' with '${replacement}'`);
+                                data = data.replaceAll(placeholder, replacement);
+                            }
+                        }
+                        arg.functions = functions;
+                        log(`Recursively calling parser for function body: "${data}"`);
+                        nested[0] += risuChatParser(data, arg);
+                    } else {
+                        log(`Function '${funcName}' not found.`);
+                        nested[0] += `{{${dat}}}`;
+                    }
+                    break; // End of function call processing.
+                }
+
+                // Priority 5: Process as a standard variable or expression.
+                const mc = matcher(dat, matcherObj, tempVar);
+                log(`Processing as variable/expression: "${dat}". Result:`, mc);
+                if (!mc && mc !== '') {
+                    // If matcher returns null/undefined, it's not a valid expression.
+                    nested[0] += `{{${dat}}}`;
+                } else if (typeof (mc) === 'string') {
+                    nested[0] += mc;
+                } else {
+                    // Matcher can return an object to update temp variables or force an early return.
+                    nested[0] += mc.text;
+                    tempVar = mc.var;
+                    log(`Variable matcher returned object. Updated tempVar:`, tempVar);
+                    if (tempVar?.['__force_return__']) {
+                        log(`__force_return__ detected. Returning early with value: "${tempVar?.['__return__'] ?? 'null'}"`);
+                        return tempVar?.['__return__'] ?? 'null';
                     }
                 }
-                const mc = isPureMode() ? null :matcher(dat, matcherObj, tempVar)
-                if(!mc && mc !== ''){
-                    nested[0] += `{{${dat}}}`
-                }
-                else if(typeof(mc) === 'string'){
-                    nested[0] += mc
-                }
-                else{
-                    nested[0] += mc.text
-                    tempVar = mc.var
-                    if(tempVar?.['__force_return__']){
-                        return tempVar?.['__return__'] ?? 'null'
-                    }
-                }
-                break
+                break;
             }
-            default:{
-                nested[0] += da[pointer]
-                break
+            default: {
+                // Append any other character to the current buffer.
+                nested[0] += char;
+                break;
             }
         }
-        pointer++
+        pointer++;
     }
-    if(commentMode){
-        nested = commentLatest
-        stackType = commentV
-        if(thinkingMode){
-            nested[0] += `<div>Thinking...</div>`
-        }
-        commentMode = false
-    }
-    if(nested.length === 1){
-        return nested[0]
-    }
-    let result = ''
-    while(nested.length > 1){
-        let dat = (stackType[nested.length] === 1) ? '{{' : "<"
-        dat += nested.shift()
-        result = dat + result
-    }
-    return nested[0] + result
+
+    // After the loop, the final result is what remains in the base level of the stack.
+    return nested[0];
 }
 
 
-
-export function getChatVar(key:string){
+export function getChatVar(key: string) {
     const selectedChar = get(selectedCharID)
     const char = DBState.db.characters[selectedChar]
-    if(!char){
+    if (!char) {
         return 'null'
     }
     const chat = char.chats[char.chatPage]
     chat.scriptstate ??= {}
     const state = (chat.scriptstate['$' + key])
-    if(state === undefined || state === null){
+    if (state === undefined || state === null) {
         const defaultVariables = parseKeyValue(char.defaultVariables).concat(parseKeyValue(DBState.db.templateDefaultVariables))
         const findResult = defaultVariables.find((f) => {
             return f[0] === key
         })
-        if(findResult){
+        if (findResult) {
             return findResult[1]
         }
         return 'null'
@@ -1757,32 +1883,32 @@ export function getChatVar(key:string){
     return state.toString()
 }
 
-export function getGlobalChatVar(key:string){
+export function getGlobalChatVar(key: string) {
     return DBState.db.globalChatVariables[key] ?? 'null'
 }
 
-export function setGlobalChatVar(key:string, value:string){ 
+export function setGlobalChatVar(key: string, value: string) {
     DBState.db.globalChatVariables[key] = value // String to String Map(dictionary)
 }
 
-export function setChatVar(key:string, value:string){
+export function setChatVar(key: string, value: string) {
     const selectedChar = get(selectedCharID)
-    if(!DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate){
+    if (!DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate) {
         DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate = {}
     }
     DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate['$' + key] = value
 }
 
 
-async function editDisplay(text){
+async function editDisplay(text) {
     let rt = ""
-    if(!text.includes("<obs>")){
+    if (!text.includes("<obs>")) {
         return text
     }
 
-    for(let i=0;i<text.length;i++){
+    for (let i = 0; i < text.length; i++) {
         const obfiEffect = "!@#$%^&*"
-        if(Math.random() < 0.4){
+        if (Math.random() < 0.4) {
             rt += obfiEffect[Math.floor(Math.random() * obfiEffect.length)]
         }
         rt += text[i]
@@ -1790,9 +1916,9 @@ async function editDisplay(text){
     return rt
 }
 
-export type PromptParsed ={[key:string]:string|PromptParsed}
+export type PromptParsed = { [key: string]: string | PromptParsed }
 
-export async function promptTypeParser(prompt:string):Promise<string | PromptParsed>{
+export async function promptTypeParser(prompt: string): Promise<string | PromptParsed> {
     //XML type
     try {
         const parser = new DOMParser()
@@ -1802,18 +1928,18 @@ export async function promptTypeParser(prompt:string):Promise<string | PromptPar
 
         const errorNode = root.getElementsByTagName('parsererror')
 
-        if(errorNode.length > 0){
+        if (errorNode.length > 0) {
             throw new Error('XML Parse Error') //fallback to other parser
         }
 
-        const parseNode = (node:Element):string|PromptParsed => {
-            if(node.children.length === 0){
+        const parseNode = (node: Element): string | PromptParsed => {
+            if (node.children.length === 0) {
                 return node.textContent
             }
 
-            const data:{[key:string]:string|PromptParsed} = {}
+            const data: { [key: string]: string | PromptParsed } = {}
 
-            for(let i=0;i<node.children.length;i++){
+            for (let i = 0; i < node.children.length; i++) {
                 const child = node.children[i]
                 data[child.tagName] = parseNode(child)
             }
@@ -1823,14 +1949,14 @@ export async function promptTypeParser(prompt:string):Promise<string | PromptPar
 
         const pnresult = parseNode(root)
 
-        if(typeof(pnresult) === 'string'){
+        if (typeof (pnresult) === 'string') {
             throw new Error('XML Parse Error') //fallback to other parser
         }
 
         return pnresult
 
     } catch (error) {
-        
+
     }
 
     return prompt
@@ -1845,13 +1971,13 @@ export function applyMarkdownToNode(node: Node) {
             if (markdown !== text) {
                 const span = document.createElement('span');
                 span.innerHTML = markdown;
-                
+
                 // inherit inline style from the parent node
                 const parentStyle = (node.parentNode as HTMLElement)?.style;
-                if(parentStyle){
-                    for(let i=0;i<parentStyle.length;i++){
+                if (parentStyle) {
+                    for (let i = 0; i < parentStyle.length; i++) {
                         span.style.setProperty(parentStyle[i], parentStyle.getPropertyValue(parentStyle[i]))
-                    }   
+                    }
                 }
                 (node as Element)?.replaceWith(span);
                 return
@@ -1864,53 +1990,53 @@ export function applyMarkdownToNode(node: Node) {
     }
 }
 
-export function parseChatML(data:string):OpenAIChat[]|null{
+export function parseChatML(data: string): OpenAIChat[] | null {
 
     const starter = '<|im_start|>'
     const seperator = '<|im_sep|>'
     const ender = '<|im_end|>'
     const trimedData = data.trim()
-    if(!trimedData.startsWith(starter)){
+    if (!trimedData.startsWith(starter)) {
         return null
     }
 
     return trimedData.split(starter).filter((f) => f !== '').map((v) => {
-        let role:'system'|'user'|'assistant' = 'user'
+        let role: 'system' | 'user' | 'assistant' = 'user'
         //default separators
-        if(v.startsWith('user' + seperator)){
+        if (v.startsWith('user' + seperator)) {
             role = 'user'
             v = v.substring(4 + seperator.length)
         }
-        else if(v.startsWith('system' + seperator)){
+        else if (v.startsWith('system' + seperator)) {
             role = 'system'
             v = v.substring(6 + seperator.length)
         }
-        else if(v.startsWith('assistant' + seperator)){
+        else if (v.startsWith('assistant' + seperator)) {
             role = 'assistant'
             v = v.substring(9 + seperator.length)
         }
         //space/newline separators
-        else if(v.startsWith('user ') || v.startsWith('user\n')){
+        else if (v.startsWith('user ') || v.startsWith('user\n')) {
             role = 'user'
             v = v.substring(5)
         }
-        else if(v.startsWith('system ') || v.startsWith('system\n')){
+        else if (v.startsWith('system ') || v.startsWith('system\n')) {
             role = 'system'
             v = v.substring(7)
         }
-        else if(v.startsWith('assistant ') || v.startsWith('assistant\n')){
+        else if (v.startsWith('assistant ') || v.startsWith('assistant\n')) {
             role = 'assistant'
             v = v.substring(10)
         }
 
         v = v.trim()
 
-        if(v.endsWith(ender)){
+        if (v.endsWith(ender)) {
             v = v.substring(0, v.length - ender.length)
         }
 
 
-        let thoughts:string[] = []
+        let thoughts: string[] = []
         v = v.replace(/<Thoughts>(.+)<\/Thoughts>/gms, (match, p1) => {
             thoughts.push(p1)
             return ''

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -1666,7 +1666,7 @@ export function risuChatParser(da: string, arg: {
 
                         // If this block type initiated Pure Mode, exit it now.
                         if (blockType.type === 'ignore' || blockType.type === 'pure' ||
-                            blockType.type === 'each' ||
+                            blockType.type === 'each' ||  blockType.type === 'function' ||
                             blockType.type === 'pure-display' || blockType.type === 'escape'
                         ) {
                             log(`Exiting PURE MODE.`);
@@ -1775,7 +1775,7 @@ export function risuChatParser(da: string, arg: {
 
                         // If this block type requires it, enter Pure Mode.
                         if (matchResult.type === 'ignore' || matchResult.type === 'pure' ||
-                            matchResult.type === 'each' ||
+                            matchResult.type === 'each' ||  matchResult.type === 'function' ||
                             matchResult.type === 'pure-display' || matchResult.type === 'escape'
                         ) {
                             log(`Entering PURE MODE for block type '${matchResult.type}'.`);

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -1657,7 +1657,7 @@ export function risuChatParser(da: string, arg: {
 
                         // If this block type initiated Pure Mode, exit it now.
                         if (blockType.type === 'ignore' || blockType.type === 'pure' ||
-                            blockType.type === 'each' || blockType.type === 'function' ||
+                            blockType.type === 'each' ||
                             blockType.type === 'pure-display' || blockType.type === 'escape'
                         ) {
                             log(`Exiting PURE MODE.`);
@@ -1757,7 +1757,7 @@ export function risuChatParser(da: string, arg: {
 
                         // If this block type requires it, enter Pure Mode.
                         if (matchResult.type === 'ignore' || matchResult.type === 'pure' ||
-                            matchResult.type === 'each' || matchResult.type === 'function' ||
+                            matchResult.type === 'each' ||
                             matchResult.type === 'pure-display' || matchResult.type === 'escape'
                         ) {
                             log(`Entering PURE MODE for block type '${matchResult.type}'.`);


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
## The Problem
The previous implementation of the `{{call::...}}` syntax used a simple `string.split('::')` method to parse its arguments. This had a critical limitation: it could not correctly handle arguments that contained nested CBS (e.g., `{{getvar::...}}`, `{{slot::...}}`). This made it impossible to use powerful patterns, such as calling a function with a dynamic value from within an `{{#each}}` loop.

## The Solution
This PR replaces the simple split logic with a more robust, context-aware parser for `{{call}}` arguments. The new implementation iterates through the argument string while tracking the nesting level of curly braces (`{{...}}`). As a result, it now correctly identifies `::` as a top-level argument separator, while ignoring any `::` found inside nested syntaxes.

### Key Improvements
- **Nested CBS in Arguments:** `{{call}}` can now safely accept other CBS as arguments, enabling dynamic and modular script creation.
- **Enhanced Scripting Patterns:** This allows for advanced use cases, like using `{{#each}}` to loop through an array and call a function for each item, as demonstrated below.

## Demonstration

The following test case now works as intended.

**Test Code:**
```cbs
{{settempvar::my_fruits::{{array::Apple::Banana::Cherry}}}}

{{#func render_item}} 
  <div class="item">
    {{#when::{{arg::1}}::isnot::Banana}}
      - Fruit Name: {{arg::1}}
    {{:else}}
      - This one is a Banana!
    {{/when}}
  </div>
{{/func}}

<div class="fruit-list">
  {{#each {{gettempvar::my_fruits}} fruit}}
    {{call::render_item::{{slot::fruit}}}}
  {{/each}}
</div>
```

### Before:
The parser failed because it incorrectly split the nested `{{slot::fruit}}` and `{{when...}}` syntaxes, leading to broken output.
<img width="661" height="316" alt="msedge_46ZN0CKbbh" src="https://github.com/user-attachments/assets/25518286-e7bd-4922-86f2-252d6d7a6651" />

### After:
The function is called correctly for each item in the loop, producing the expected HTML structure.
<img width="490" height="242" alt="msedge_Vv4zglW0co" src="https://github.com/user-attachments/assets/a8660416-70a0-46a2-a94a-05e1883cb178" />
