### PR TITLE
Fix:display valid languages in creator's comment

### DIFF
--- a/src/lib/UI/GUI/MultiLangInput.svelte
+++ b/src/lib/UI/GUI/MultiLangInput.svelte
@@ -51,7 +51,7 @@
 {#if addingLang}
     <div class="m-1 p-1 g-2 flex max-w-fit rounded-md border-t-bgcolor flex-wrap gap-1">
         {#each languageCodes as lang}
-            {#if toLangName(lang).length !== 2}
+            {#if toLangName(lang) !== lang}
                 <button class="bg-bgcolor py-2 rounded-lg px-4 text-nowrap" onclick={() => {
                     valueObject[lang] = ""
                     selectedLang = lang


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fixes issue where valid 2-character language names (like Chinese '中文') were filtered out