### PR TITLE
Fix: local lorebook update

### DIFF
--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -720,9 +720,8 @@ export async function runScripted(code:string, arg:{
                     secondKey = '',
                 } = options
 
-                const currentChat = char.chats[char.chatPage]
-
-                const newLocalLoreBooks = currentChat.localLore.filter((book) => book.comment !== name)
+                const targetChat = ScriptingEngineState.chat
+                const newLocalLoreBooks = targetChat.localLore.filter((book) => book.comment !== name)
                 newLocalLoreBooks.push({
                     alwaysActive,
                     comment: name,
@@ -734,7 +733,7 @@ export async function runScripted(code:string, arg:{
                     selective: !!secondKey,
                     useRegex: regex,
                 })
-                currentChat.localLore = newLocalLoreBooks
+                targetChat.localLore = newLocalLoreBooks
             })
 
             declareAPI('loadLoreBooksMain', async (id:string, reserve:number) => {


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions? 
- [x] Have you added type definitions?


# Description
Fixes the issue where `upsertLocalLoreBook` function doesn't persist changes when called from `onStart`, `onInput` and `onOutput` events.

## Changes Made
- Modified `upsertLocalLoreBook` in `scriptings.ts` to use `ScriptingEngineState.chat` instead of `char.chats[char.chatPage]`
- This ensures consistent behavior across all event types

## Cause
The function was modifying a different chat object reference than the one being returned by the scripting engine, causing changes to be lost in `onStart`/`onOutput` contexts.

## Testing
- ✅ Verified `upsertLocalLoreBook` now works in `onStart` events
- ✅ Verified `upsertLocalLoreBook` now works in `onOutput` events  
- ✅ Confirmed existing `onButtonClick` functionality remains intact
- ✅ No breaking changes to other API functions
- The only environment tested was Docker.

## Files Changed
- `src/ts/process/scriptings.ts`

Fixes #1041 


--- 


# (KR) 설명
`onStart`와 `onInput`, `onOutput` 이벤트에서 `upsertLocalLoreBook` 함수가 변경사항을 저장하지 않는 문제를 수정했습니다.

## 변경사항
- `scriptings.ts`의 `upsertLocalLoreBook`을 `char.chats[char.chatPage]` 대신 `ScriptingEngineState.chat`을 사용하도록 수정
- 모든 이벤트 타입에서 일관된 동작을 보장

## 원인
함수가 스크립팅 엔진에서 반환하는 채팅 객체와 다른 채팅 객체 참조를 수정하고 있어서, `onStart`/`onOutput` 컨텍스트에서 변경사항이 손실되었음.

## 테스트
- ✅ `upsertLocalLoreBook`이 이제 `onStart` 이벤트에서 정상 작동하는 것을 확인
- ✅ `upsertLocalLoreBook`이 이제 `onOutput` 이벤트에서 정상 작동하는 것을 확인  
- ✅ 기존 `onButtonClick` 기능이 그대로 유지되는 것을 확인
- ✅ 다른 API 함수들에 대한 호환성 문제 없음
- 노드리스 - 도커 환경에서만 테스트함

## 변경된 파일
- `src/ts/process/scriptings.ts`

Fixes #1041 