### PR TITLE
feat: add always HypaV3 toggle on option for character switching

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -875,6 +875,9 @@
                     <div class="mb-2">
                         <Check name="Use Experimental Implementation" bind:check={settings.useExperimentalImpl} />
                     </div>
+                    <div class="mb-2">
+                        <Check name="Always Toggle On" bind:check={settings.alwaysToggleOn} />
+                    </div>
                     {#if settings.useExperimentalImpl}
                         <span class="text-textcolor">Summarization Requests Per Minute</span>
                         <NumberInput marginBottom size="sm" min={1} bind:value={settings.summarizationRequestsPerMinute} />

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -42,6 +42,7 @@ export interface HypaV3Settings {
   summarizationMaxConcurrent: number;
   embeddingRequestsPerMinute: number;
   embeddingMaxConcurrent: number;
+  alwaysToggleOn: boolean;
 }
 
 interface HypaV3Data {
@@ -1760,6 +1761,7 @@ export function createHypaV3Preset(
     summarizationMaxConcurrent: 1,
     embeddingRequestsPerMinute: 100,
     embeddingMaxConcurrent: 1,
+    alwaysToggleOn: false,
   };
 
   if (

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -121,6 +121,12 @@ ReloadGUIPointer.subscribe(() => {
 $effect.root(() => {
     selectedCharID.subscribe((v) => {
         selIdState.selId = v
+
+        if (DBState?.db?.characters?.[selIdState.selId]) {
+            if (DBState.db.hypaV3 && DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.settings?.alwaysToggleOn) {
+                DBState.db.characters[selIdState.selId].supaMemory = true;
+            }
+        }
     })
     $effect(() => {
         $state.snapshot(DBState.db.modules)


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
## Why:
- Manual enabling of HypaV3 toggle required for each new character

## Changes:
- Check HypaV3 toggle automatically on character switch when option is enabled