### PR TITLE
fix: get all modules with namespace

### DIFF
--- a/src/ts/process/modules.ts
+++ b/src/ts/process/modules.ts
@@ -265,16 +265,12 @@ function getModuleById(id:string){
 }
 
 function getModuleByIds(ids:string[]){
-    let modules:RisuModule[] = []
     const db = getDatabase()
-    for(let i=0;i<ids.length;i++){
-        const module = db.modules.find((m) => m.id === ids[i] || (m.namespace === ids[i] && m.namespace))
-        if(module){
-            modules.push(module)
-        }
-    }
-    modules = deduplicateModuleById(modules)
-    return modules
+    const idSet = new Set(ids)
+    const modules = db.modules.filter(m => 
+        idSet.has(m.id) || (m.namespace && idSet.has(m.namespace))
+    )
+    return deduplicateModuleById(modules)
 }
 
 function deduplicateModuleById(modules:RisuModule[]){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Currently, when multiple modules use the same namespace in preset module integration, the UI shows them as simultaneously activated, but in reality only one is actually applied.

<img width="292" height="162" alt="image" src="https://github.com/user-attachments/assets/bd4f496a-d1e1-46a8-bd01-177cab675804" />
<br>
<img width="341" height="555" alt="image" src="https://github.com/user-attachments/assets/77584fe7-490e-4c84-a687-a1653deac047" />

This change ensures that:
- All modules with matching namespaces are included
- Performance is optimized using Set for O(1) lookups
- UI behavior now matches actual functionality