### PR TITLE
feat: css class & button trigger support on background DOM

### DIFF
--- a/src/lib/ChatScreens/BackgroundDom.svelte
+++ b/src/lib/ChatScreens/BackgroundDom.svelte
@@ -1,19 +1,58 @@
 <script lang="ts">
     import { ParseMarkdown, risuChatParser } from "src/ts/parser.svelte";
-    import { type character, type groupChat } from "src/ts/storage/database.svelte";
-    import { DBState } from 'src/ts/stores.svelte';
+    import { type character, type groupChat, getCurrentCharacter, getCurrentChat, setCurrentChat } from "src/ts/storage/database.svelte";
+    import { DBState, CurrentTriggerIdStore } from 'src/ts/stores.svelte';
     import { moduleBackgroundEmbedding, ReloadGUIPointer, selIdState } from "src/ts/stores.svelte";
+    import { runTrigger } from 'src/ts/process/triggers';
+    import { runLuaButtonTrigger } from 'src/ts/process/scriptings';
 
     let backgroundHTML = $derived(DBState.db?.characters?.[selIdState.selId]?.backgroundHTML)
     let currentChar:character|groupChat = $derived(DBState.db?.characters?.[selIdState.selId])
 
-</script>
+    async function handleBackgroundButtonTrigger(event: UIEvent) {
+        const currentChar = getCurrentCharacter()
+        if(currentChar.type === 'group'){
+            return
+        }
 
+        const target = event.target as HTMLElement
+        const origin = target.closest('[risu-trigger], [risu-btn]')
+        if (!origin) {
+            return
+        }
+
+        const triggerName = origin.getAttribute('risu-trigger')
+        const triggerId = origin.getAttribute('risu-id')
+        const btnEvent = origin.getAttribute('risu-btn')
+
+        const triggerResult =
+            triggerName ?
+                await runTrigger(currentChar, 'manual', {
+                    chat: getCurrentChat(),
+                    manualName: triggerName,
+                    triggerId: triggerId || undefined,
+                }) :
+            btnEvent ?
+                await runLuaButtonTrigger(currentChar, btnEvent) :
+            null
+
+        if(triggerResult) {
+            setCurrentChat(triggerResult.chat)
+        }
+        
+        if(triggerName && triggerId) {
+            setTimeout(() => {
+                CurrentTriggerIdStore.set(null)
+            }, 100)
+        }
+    }
+</script>
 
 {#if backgroundHTML || $moduleBackgroundEmbedding}
     {#if selIdState.selId > -1}
         {#key $ReloadGUIPointer}
-            <div class="absolute top-0 left-0 w-full h-full chattext">
+            <div class="absolute top-0 left-0 w-full h-full chattext" 
+                 onclickcapture={handleBackgroundButtonTrigger}>
                 {#await ParseMarkdown(risuChatParser((backgroundHTML || '') + '\n' + ($moduleBackgroundEmbedding || ''), {chara:currentChar}), currentChar, 'back') then md} 
                     {@html md}
                 {/await}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Currently, when using HTML elements in background embedding slots, inline styles can be used, but direct CSS classes(ie. x-risu-something) cannot be specified. This change resolves this issue, but if you don't want this or have other ideas, please let me know.

(+@)
Thanks to comments, I noticed button triggers are not available in background embedding, so I added capturing of button triggers here as well. For performance reasons, chat reload is left at the trigger's discretion.