### PR TITLE
feat: add {{loreinject::name}} to use @@inject_at decorator

### DIFF
--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -328,7 +328,7 @@ export function registerCBS(arg:CBSRegisterArg) {
             }))
         },
         alias: ['worldinfo'],
-        description: 'Returns all active lorebook entries as a JSON array. Combines character lorebook, chat-specific lorebook, and module lorebooks. Each entry is JSON.stringify\'d.\n\nUsage:: {{lorebook}}',
+        description: 'Returns all lorebook entries as a JSON array. Combines character lorebook, chat-specific lorebook, and module lorebooks. Each entry is JSON.stringify\'d.\n\nUsage:: {{lorebook}}',
     });
 
     registerFunction({
@@ -2366,5 +2366,11 @@ Usage:: {{#when condition}}...{{/when}} or {{#when::not::condition}}...{{/when}}
         description: 'Defines the position which can be used in various features such as @@position <positionName> decorator.\n\nUsage:: {{position::positionName}}',
     })
 
+    registerFunction({
+        name: 'loreinject',
+        callback: 'doc_only',
+        alias: ['lore_inject'],
+        description: 'Injects content from lorebook entries that have @@inject_at decorators matching the specified target name. Searches through active lorebooks for entries with @@inject_at <targetName> decorator and returns their content. Only works with lorebooks that are currently active based on their keywords.\n\nUsage:: {{loreinject::targetName}}\n\nExample:\nLorebook entry with "@@inject_at myTarget" at the beginning will be injected when using {{loreinject::myTarget}}',
+    })
 
 }

--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -232,7 +232,7 @@ export async function loadLoreBookV3Prompt(){
         priority:number
         source:string
         inject:{
-            operation:'append'|'prepend'|'replace',
+            operation:'append'|'prepend'|'replace'|'insert',
             location:string,
             param:string
             lore:boolean
@@ -255,7 +255,7 @@ export async function loadLoreBookV3Prompt(){
             let activated = true
             let pos = ''
             let inject:{
-                operation:'append'|'prepend'|'replace',
+                operation:'append'|'prepend'|'replace'|'insert',
                 location:string,
                 param:string
                 lore:boolean
@@ -392,11 +392,12 @@ export async function loadLoreBookV3Prompt(){
                     }
                     case 'inject_at':{
                         inject??= {
-                            operation: 'append',
+                            operation: 'insert',
                             location: '',
                             param: '',
                             lore: false
                         }
+                        inject.operation = 'insert'
                         inject.location = arg.join(' ')
                         inject.lore = false
                         return


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
## Add features
- Add 'insert' operation to lorebook inject types in lorebook.svelte.ts
- Implement loreinjectParser using inject-based approach in index.svelte.ts
- Support both {{loreinject::name}} and {{lore_inject::name}} syntax
- Update CBS documentation for loreinject function

## Instructions
### How to use the new loreinject functionality:
1. **Create a lorebook entry with @@inject_at decorator:**
@@inject_at myTarget This content will be injected when {{loreinject::myTarget}} is used. You can include multiple lines and complex content here.

2. **Use loreinject in your prompts:**
{{loreinject::myTarget}} or {{lore_inject::myTarget}}

3. **How it works:**
- It works almost same as {{position}}
- The lorebook entry must start with `@@inject_at <targetName>`
- The lorebook must be active (keywords matched) to be available for injection
- Multiple lorebooks with the same target name will be combined

### Example use case:
- Create dynamic character descriptions that can be injected contextually
- Build modular world-building content that can be referenced anywhere
- Implement conditional lore injection based on active lorebooks