### PR TITLE
feat: Add external iframe warning to plugin import confirmation

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -303,6 +303,7 @@ export const languageChinese = {
     "emphasizedView": "双角色模式",
     "pluginWarn": "但安装恶意插件可能导致问题。",
     "pluginConfirm": "你真的要导入这个插件吗？只从可信的来源导入插件。",
+    "pluginContainsExternalIframe": "警告：此插件使用外部 iframe，这可能存在安全风险。",
     "pluginContainsExternalMedia": "此插件包含外部媒体。",
     "pluginContainsExternalJS": "此插件包含外部 Javascript。",
     "createGroupImg": "产生群组头像",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -215,6 +215,7 @@ export const languageGerman = {
     emphasizedView: "Doppelte Charakteransicht",
     pluginWarn: "Installieren von Plugins unbekannter Herkunft könnte Probleme verursachen oder sogar schädlichen Code enthalten",
     pluginConfirm: "Möchten Sie dieses Plugin wirklich importieren? Importieren Sie nur Plugins aus vertrauenswürdigen Quellen.",
+    pluginContainsExternalIframe: "Warnung: Dieses Plugin verwendet einen externen Iframe, was ein Sicherheitsrisiko darstellen kann.",
     pluginContainsExternalMedia: "Dieses Plugin enthält externe Medien.",
     pluginContainsExternalJS: "Dieses Plugin enthält externes Javascript.",
     createGroupImg: "Gruppenicon generieren",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -662,6 +662,7 @@ export const languageEnglish = {
     emphasizedView: "Double Character View",
     pluginWarn: "Installing malicious plugins can cause problems.",
     pluginConfirm: "Do you really want to import this plugin? Only import plugins from trusted sources.",
+    pluginContainsExternalIframe: "Warning: This plugin uses an external iframe, which can be a security risk.",
     pluginContainsExternalMedia: "This plugin contains external media.",
     pluginContainsExternalJS: "This plugin contains external Javascript.",
     createGroupImg: "Generate group icon",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -265,6 +265,7 @@ export const languageSpanish = {
     emphasizedView: "Vista de Personajes Doble",
     pluginWarn: "Instalar plugins maliciosos puede causar problemas.",
     pluginConfirm: "¿Realmente quieres importar este plugin? Solo importa plugins de fuentes confiables.",
+    pluginContainsExternalIframe: "Advertencia: Este plugin utiliza un iframe externo, lo que puede suponer un riesgo de seguridad.",
     pluginContainsExternalMedia: "Este plugin contiene medios externos.",
     pluginContainsExternalJS: "Este complemento contiene Javascript externo.",
     createGroupImg: "Generar icono de grupo",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -606,6 +606,7 @@ export const languageKorean = {
     "emphasizedView": "더블",
     "pluginWarn": "악성 플러그인 설치 시 문제가 생길 수 있습니다.",
     "pluginConfirm": "이 플러그인을 정말로 가져오시겠습니까? 신뢰할 수 있는 출처의 플러그인만 가져오세요.",
+    "pluginContainsExternalIframe": "경고: 이 플러그인은 외부 iframe을 사용하며, 이는 보안 위험을 초래할 수 있습니다.",
     "pluginContainsExternalMedia": "이 플러그인에는 외부 미디어가 포함되어 있습니다.",
     "pluginContainsExternalJS": "이 플러그인에는 외부 자바스크립트가 포함되어 있습니다.",
     "createGroupImg": "그룹 아이콘 자동생성",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -186,6 +186,7 @@ export const LanguageVietnamese = {
     "emphasizedView": "Chế độ xem nhân vật đôi",
     "pluginWarn": "Các plugin có thể gây ra sự cố khi cài đặt các plugin độc hại.",
     "pluginConfirm": "Bạn có thực sự muốn nhập plugin này không? Chỉ nhập plugin từ các nguồn đáng tin cậy.",
+    "pluginContainsExternalIframe": "Cảnh báo: Plugin này sử dụng iframe bên ngoài, có thể gây rủi ro bảo mật.",
     "pluginContainsExternalMedia": "Plugin này chứa phương tiện bên ngoài.",
     "pluginContainsExternalJS": "Plugin này chứa Javascript bên ngoài.",
     "createGroupImg": "Tạo biểu tượng nhóm",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -308,6 +308,7 @@ export const languageChineseTraditional = {
     "emphasizedView": "雙角色模式",
     "pluginWarn": "但安裝惡意外掛可能導致問題。",
     "pluginConfirm": "您真的要導入這個插件嗎？只從可信的來源導入插件。",
+    "pluginContainsExternalIframe": "警告：此插件使用外部 iframe，這可能存在安全風險。",
     "pluginContainsExternalMedia": "此插件包含外部媒體。",
     "pluginContainsExternalJS": "此插件包含外部 Javascript。",
     "createGroupImg": "產生群組頭像",

--- a/src/ts/plugins/plugins.ts
+++ b/src/ts/plugins/plugins.ts
@@ -49,6 +49,8 @@ export async function importPlugin() {
         const hasExternalMedia = mediaRegex.test(jsFile);
         const jsRegex = /(https?):\/\/[^\s\'\"]+\.js/gi;
         const hasExternalJS = jsRegex.test(jsFile);
+        const iframeRegex = /<iframe|createElement\s*\(\s*['"]iframe['"]\s*\)/gi;
+        const hasExternalIframe = iframeRegex.test(jsFile);
 
         let confirmMessage = `${name}`;
         if (hasExternalMedia) {
@@ -56,6 +58,9 @@ export async function importPlugin() {
         }
         if (hasExternalJS) {
             confirmMessage += `\n${language.pluginContainsExternalJS}`;
+        }
+        if (hasExternalIframe) {
+            confirmMessage += `\n${language.pluginContainsExternalIframe}`;
         }
         confirmMessage += `\n\n${language.pluginConfirm}`;
 


### PR DESCRIPTION
A follow-up to #1055.

# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

### Problem
The initial implementation of the plugin security warning in #1055 did not account for `iframes` created dynamically via JavaScript. This allowed certain plugins to bypass the security check.

### Solution
This pull request enhances the detection mechanism to identify `iframes` created programmatically. This ensures that users are properly warned about all plugins that utilize external iframes, strengthening the security of the plugin system.

# Key Changes
*   **Enhanced Iframe Detection:** Updated the detection logic to recognize dynamically created iframes.
*   **Localization:** The new warning for external iframes has been added to all supported languages.

# UI example
| external iframe warn |
| -------------------- |
| <img width="400" alt="risuai-plugin-external-iframe-warn" src="https://github.com/user-attachments/assets/7ad8abf8-b8b5-48c7-8f05-4fe0448aad72" /> |
