### PR TITLE
feat: Support multiple file upload in chat screen

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.next.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.next.svelte
@@ -501,18 +501,20 @@
                                     reader.onload = async (e) => {
                                         const buf = e.target?.result as ArrayBuffer
                                         const uint8 = new Uint8Array(buf)
-                                        const res = await postChatFile({
+                                        const results = await postChatFile({
                                             name: file.name,
                                             data: uint8
                                         })
-                                        if(res?.type === 'asset'){
-                                            fileInput.push(res.data)
-                                            updateInputSizeAll()
+                                        if(!results) return
+                                        for(const res of results){
+                                            if(res?.type === 'asset'){
+                                                fileInput.push(res.data)
+                                            }
+                                            if(res?.type === 'text'){
+                                                messageInput += `{{file::${res.name}::${res.data}}}`
+                                            }
                                         }
-                                        if(res?.type === 'text'){
-                                            messageInput += `{{file::${res.name}::${res.data}}}`
-                                            updateInputSizeAll()
-                                        }
+                                        updateInputSizeAll()
                                     }
                                     reader.readAsArrayBuffer(file)
                                 }
@@ -872,15 +874,17 @@
                     </div>
 
                     <div class="flex items-center cursor-pointer hover:text-green-500 transition-colors" onclick={async () => {
-                        const res = await postChatFile(messageInput)
-                        if(res?.type === 'asset'){
-                            fileInput.push(res.data)
-                            updateInputSizeAll()
+                        const results = await postChatFile(messageInput)
+                        if(!results) return
+                        for(const res of results){
+                            if(res?.type === 'asset'){
+                                fileInput.push(res.data)
+                            }
+                            if(res?.type === 'text'){
+                                messageInput += `{{file::${res.name}::${res.data}}}`
+                            }
                         }
-                        if(res?.type === 'text'){
-                            messageInput += `{{file::${res.name}::${res.data}}}`
-                            updateInputSizeAll()
-                        }
+                        updateInputSizeAll()
                     }}>
 
                         <ImagePlusIcon />

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -489,18 +489,20 @@
                                     reader.onload = async (e) => {
                                         const buf = e.target?.result as ArrayBuffer
                                         const uint8 = new Uint8Array(buf)
-                                        const res = await postChatFile({
+                                        const results = await postChatFile({
                                             name: file.name,
                                             data: uint8
                                         })
-                                        if(res?.type === 'asset'){
-                                            fileInput.push(res.data)
-                                            updateInputSizeAll()
+                                        if(!results) return
+                                        for(const res of results){
+                                            if(res?.type === 'asset'){
+                                                fileInput.push(res.data)
+                                            }
+                                            if(res?.type === 'text'){
+                                                messageInput += `{{file::${res.name}::${res.data}}}`
+                                            }
                                         }
-                                        if(res?.type === 'text'){
-                                            messageInput += `{{file::${res.name}::${res.data}}}`
-                                            updateInputSizeAll()
-                                        }
+                                        updateInputSizeAll()
                                     }
                                     reader.readAsArrayBuffer(file)
                                 }
@@ -813,15 +815,17 @@
                     </div>
 
                     <div class="flex items-center cursor-pointer hover:text-green-500 transition-colors" onclick={async () => {
-                        const res = await postChatFile(messageInput)
-                        if(res?.type === 'asset'){
-                            fileInput.push(res.data)
-                            updateInputSizeAll()
+                        const results = await postChatFile(messageInput)
+                        if(!results) return
+                        for(const res of results){
+                            if(res?.type === 'asset'){
+                                fileInput.push(res.data)
+                            }
+                            if(res?.type === 'text'){
+                                messageInput += `{{file::${res.name}::${res.data}}}`
+                            }
                         }
-                        if(res?.type === 'text'){
-                            messageInput += `{{file::${res.name}::${res.data}}}`
-                            updateInputSizeAll()
-                        }
+                        updateInputSizeAll()
                     }}>
 
                         <ImagePlusIcon />

--- a/src/ts/process/files/multisend.ts
+++ b/src/ts/process/files/multisend.ts
@@ -4,7 +4,7 @@ import { get } from 'svelte/store';
 import { doingChat, sendChat } from '../index.svelte';
 import { downloadFile, isTauri } from 'src/ts/globalApi.svelte';
 import { HypaProcesser } from '../memory/hypamemory';
-import { BufferToText as BufferToText, selectSingleFile, sleep } from 'src/ts/util';
+import { BufferToText as BufferToText, selectMultipleFile, sleep } from 'src/ts/util';
 import { postInlayAsset } from './inlays';
 
 type sendFileArg = {
@@ -196,9 +196,9 @@ type postFileResultText = {
 }
 export async function postChatFile(query:string|{
     name:string,
-    data:Uint8Array<ArrayBufferLike>
-}):Promise<postFileResult>{
-    const file = typeof(query) === 'string' ? (await selectSingleFile([
+    data:Uint8Array
+}):Promise<postFileResult[]>{
+    const files = typeof(query) === 'string' ? (await selectMultipleFile([
         //image format
         'jpg',
         'jpeg',
@@ -223,86 +223,95 @@ export async function postChatFile(query:string|{
         'po',
         // 'pdf',
         'txt'
-    ])) : query
+    ])) : [query]
 
-    if(!file){
+    if(!files){
         return null
     }
 
     const xquery = typeof(query) === 'string' ? query : ''
-    const extention = file.name.split('.').at(-1)
-    console.log(extention)
+    const results: postFileResult[] = []
 
-    switch(extention){
-        case 'po':{
-            await sendPofile({
-                file: BufferToText(file.data),
-                query: xquery
-            })
-            return {
-                type: 'void'
-            }
-        }
-        case 'pdf':{
-            return {
-                type: 'text',
-                data: await sendPDFFile({
-                    file: BufferToText(file.data),
-                    query: xquery
-                }),
-                name: file.name
-            }
-        }
-        case 'xml':{
-            return {
-                type: 'text',
-                data: await sendXMLFile({
-                    file: BufferToText(file.data),
-                    query: xquery
-                }),
-                name: file.name
-            }
-        }
+    for(const file of files){
+        const extention = file.name.split('.').at(-1)
+        console.log(extention)
 
-        //image format
-        case 'jpg':
-        case 'jpeg':
-        case 'png':
-        case 'webp':
-        case 'gif':
-        case 'avif':
-            
-        //audio format
-        case 'wav':
-        case 'mp3':
-        case 'ogg':
-        case 'flac':
-            
-        //video format
-        case 'mp4':
-        case 'webm':
-        case 'mpeg':
-        case 'avi':{
-            const postData = await postInlayAsset(file)
-            if(!postData){
-                return null
-            }
-            return {
-                data: postData,
-                type: 'asset'
-            }
-        }
-        case 'txt':{
-            return {
-                type: 'text',
-                data: await sendTxtFile({
+        switch(extention){
+            case 'po':{
+                await sendPofile({
                     file: BufferToText(file.data),
                     query: xquery
-                }),
-                name: file.name
+                })
+                results.push({
+                    type: 'void'
+                })
+                break
+            }
+            case 'pdf':{
+                results.push({
+                    type: 'text',
+                    data: await sendPDFFile({
+                        file: BufferToText(file.data),
+                        query: xquery
+                    }),
+                    name: file.name
+                })
+                break
+            }
+            case 'xml':{
+                results.push({
+                    type: 'text',
+                    data: await sendXMLFile({
+                        file: BufferToText(file.data),
+                        query: xquery
+                    }),
+                    name: file.name
+                })
+                break
+            }
+
+            //image format
+            case 'jpg':
+            case 'jpeg':
+            case 'png':
+            case 'webp':
+            case 'gif':
+            case 'avif':
+
+            //audio format
+            case 'wav':
+            case 'mp3':
+            case 'ogg':
+            case 'flac':
+
+            //video format
+            case 'mp4':
+            case 'webm':
+            case 'mpeg':
+            case 'avi':{
+                const postData = await postInlayAsset(file)
+                if(!postData){
+                    continue
+                }
+                results.push({
+                    data: postData,
+                    type: 'asset'
+                })
+                break
+            }
+            case 'txt':{
+                results.push({
+                    type: 'text',
+                    data: await sendTxtFile({
+                        file: BufferToText(file.data),
+                        query: xquery
+                    }),
+                    name: file.name
+                })
+                break
             }
         }
     }
 
-    return 
+    return results
 }


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
This PR enables users to upload multiple files at once in the chat screen.

Previously, the file upload feature only supported selecting a single file. This PR modifies the `postChatFile` function to use `selectMultipleFile` instead of `selectSingleFile`, allowing users to select and upload multiple images, videos, or audio files simultaneously.

Changes:
- Modified `postChatFile` function to accept and process multiple files
- Changed return type from `postFileResult` to `postFileResult[]`
- Updated `DefaultChatScreen.svelte` and `DefaultChatScreen.next.svelte` to handle multiple file results with array iteration
- Users can now select multiple files at once from the file picker dialog