### PR TITLE
fix: Handle null response body in hubProxyFunc to prevent crash

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -228,11 +228,19 @@ async function hubProxyFunc(req, res) {
                 res.setHeader(key, value);
             }
             res.status(redirectResponse.status);
-            await pipeline(redirectResponse.body, res);
+            if (redirectResponse.body) {
+                await pipeline(redirectResponse.body, res);
+            } else {
+                res.end();
+            }
             return;
         }
         
-        await pipeline(response.body, res);
+        if (response.body) {
+            await pipeline(response.body, res);
+        } else {
+            res.end();
+        }
         
     } catch (error) {
         console.error("[Hub Proxy] Error:", error);


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR fixes a crash in the `hubProxyFunc` function located in `server/node/server.cjs`. #1063 

Previously, the `pipeline` function was called with `redirectResponse.body` or `response.body` without checking if they were null. This could lead to a crash if the response body was empty.

This change adds a null check before calling `pipeline`. If the body is null, `res.end()` is called instead, preventing the crash and ensuring the server continues to run smoothly.