### PR TITLE
Fix: Resolve prebuilt asset exclude toggle malfunction

### DIFF
--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -637,10 +637,10 @@
                                         <TrashIcon />
                                     </button>
                                     {#if DBState.db.useAdditionalAssetsPreview}
-                                        <button class="hover:text-blue-500" class:text-textcolor2={DBState.db.characters[$selectedCharID].prebuiltAssetExclude?.includes?.(assetFilePath[i])} onclick={() => {
+                                        <button class="hover:text-blue-500" class:text-textcolor2={DBState.db.characters[$selectedCharID].prebuiltAssetExclude?.includes?.(assets[1])} onclick={() => {
                                             DBState.db.characters[$selectedCharID].prebuiltAssetExclude ??= []
                                             if(DBState.db.characters[$selectedCharID].prebuiltAssetExclude.includes(assets[1])){
-                                                DBState.db.characters[$selectedCharID].prebuiltAssetExclude = DBState.db.characters[$selectedCharID].prebuiltAssetExclude.filter((e) => e !== assetFilePath[i])
+                                                DBState.db.characters[$selectedCharID].prebuiltAssetExclude = DBState.db.characters[$selectedCharID].prebuiltAssetExclude.filter((e) => e !== assets[1])
                                             }
                                             else {
                                                 DBState.db.characters[$selectedCharID].prebuiltAssetExclude.push(assets[1])


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

## Overview

Fixed a variable mismatch bug in the prebuilt asset exclude toggle functionality that prevented assets from being re-included after exclusion.

## Problem

In CharConfig.svelte, the asset exclude toggle button used inconsistent variable references:
- Used `assetFilePath[i]` (temporary blob URL) for CSS class condition and removal filter
- Used `assets[1]` (permanent asset ID) for adding to exclude array and icon display

Since `assetFilePath[i]` and `assets[1]` contain different values, the filter operation never matched any items, preventing excluded assets from being re-included.

## Solution

Changed lines 640 and 643 to consistently use `assets[1]` (the permanent asset ID) across all operations:
- CSS class condition
- Removal filter
- Add operation
- Icon display condition

## Changes

- Line 640: Changed CSS class condition from `assetFilePath[i]` to `assets[1]`
- Line 643: Changed filter comparison from `assetFilePath[i]` to `assets[1]`

## Testing

The toggle button now works correctly:
- Clicking on included asset adds it to exclude list
- Clicking on excluded asset removes it from exclude list and restores inclusion