### PR TITLE
Fix: Update tooltip content when prop changes

### DIFF
--- a/src/ts/gui/tooltip.ts
+++ b/src/ts/gui/tooltip.ts
@@ -10,6 +10,9 @@ export function tooltip(node:HTMLElement, tip:string) {
         theme: 'translucent',
     })
     return {
+        update(newTip: string) {
+            instance.setContent(newTip)
+        },
         destroy() {
             instance.destroy()
         }
@@ -25,6 +28,9 @@ export function tooltipRight(node:HTMLElement, tip:string) {
         theme: 'translucent',
     })
     return {
+        update(newTip: string) {
+            instance.setContent(newTip)
+        },
         destroy() {
             instance.destroy()
         }


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

## Issue
Sidebar avatar tooltips were not updating when characters were deleted, showing outdated names from previously selected characters.

## Changes
Added `update` method to both `tooltip` and `tooltipRight` directives in `src/ts/gui/tooltip.ts` to dynamically update tooltip content when the tip parameter changes.

## Technical Details
- Implemented Svelte action `update` lifecycle method
- Calls `instance.setContent()` to update Tippy.js tooltip content
- Existing usages with static values are unaffected since `update` is only called when parameters change

## Implementation
The update method is now called automatically by Svelte whenever the tip parameter changes, ensuring tooltips always display current information for dynamically updating components like SidebarAvatar.