### PR TITLE
Add support for custom OpenAI Response API endpoints

### DIFF
--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -174,6 +174,9 @@
             <OptionInput value={LLMFormat.OpenAICompatible.toString()}>
                 OpenAI Compatible
             </OptionInput>
+            <OptionInput value={LLMFormat.OpenAIResponseAPI.toString()}>
+                OpenAI Response API
+            </OptionInput>
             <OptionInput value={LLMFormat.Anthropic.toString()}>
                 Anthropic Claude
             </OptionInput>

--- a/src/ts/process/request/openAI.ts
+++ b/src/ts/process/request/openAI.ts
@@ -410,7 +410,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
     }
 
     if(aiModel.startsWith('gpt4o1') || arg.modelInfo.flags.includes(LLMFlags.OAICompletionTokens)){
-        body.max_completion_tokens = body.max_tokens
+        body.max_output_tokens = body.max_tokens
         delete body.max_tokens
     }
 
@@ -1060,16 +1060,78 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         store: false
     }, ['temperature', 'top_p'], {}, arg.mode)
 
+    let requestURL = arg.customURL ?? "https://api.openai.com/v1/responses"
+    if(arg.modelInfo?.endpoint){
+        requestURL = arg.modelInfo.endpoint
+    }
+
+    let risuIdentify = false
+    if(requestURL.startsWith("risu::")){
+        risuIdentify = true
+        requestURL = requestURL.replace("risu::", '')
+    }
+
+    if(aiModel === 'reverse_proxy' && db.autofillRequestUrl){
+        try{
+            const url = new URL(requestURL)
+            const pathSegments = url.pathname.split('/').filter(Boolean)
+            const lastSegment = pathSegments[pathSegments.length - 1] ?? ''
+
+            if(url.searchParams.has('api-version') && url.pathname.includes('/responses')){
+                // Azure-style Responses API URL already includes the endpoint
+            }
+            else if(lastSegment === 'responses'){
+                // keep as-is
+            }
+            else if(lastSegment === 'v1'){
+                url.pathname = url.pathname.replace(/\/?$/, '/responses')
+            }
+            else{
+                url.pathname = url.pathname.replace(/\/?$/, '/v1/responses')
+            }
+
+            requestURL = url.toString()
+        }
+        catch{
+            const [baseURL, query] = requestURL.split('?', 2)
+            let nextURL = baseURL
+            const pathSegments = nextURL.split('/').filter(Boolean)
+            const lastSegment = pathSegments[pathSegments.length - 1] ?? ''
+            const hasApiVersion = query?.includes('api-version=')
+
+            if(hasApiVersion && nextURL.includes('/responses')){
+                // Azure-style Responses API URL already includes the endpoint
+            }
+            else if(lastSegment === 'responses'){
+                // keep as-is
+            }
+            else if(lastSegment === 'v1'){
+                nextURL += nextURL.endsWith('/') ? 'responses' : '/responses'
+            }
+            else{
+                nextURL += nextURL.endsWith('/') ? 'v1/responses' : '/v1/responses'
+            }
+
+            requestURL = query ? `${nextURL}?${query}` : nextURL
+        }
+    }
+
+    const headers = {
+        "Authorization": "Bearer " + (arg.key ?? db.openAIKey),
+        "Content-Type": "application/json"
+    }
+
+    if(risuIdentify){
+        headers["X-Proxy-Risu"] = 'RisuAI'
+    }
+
     if(arg.previewBody){
         return {
             type: 'success',
             result: JSON.stringify({
-                url: "https://api.openai.com/v1/responses",
+                url: requestURL,
                 body: body,
-                headers: {
-                    "Authorization": "Bearer " + (arg.key ?? db.openAIKey),
-                    "Content-Type": "application/json"
-                }
+                headers: headers
             })
         }
     }
@@ -1078,12 +1140,9 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         body.tools.push('web_search_preview')
     }
 
-    const response = await globalFetch("https://api.openai.com/v1/responses", {
+    const response = await globalFetch(requestURL, {
         body: body,
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + (arg.key ?? db.openAIKey),
-        },
+        headers: headers,
         chatId: arg.chatId,
         abortSignal: arg.abortSignal
     });


### PR DESCRIPTION
# PR Checklist
- [No, only for response API] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [No, only checked in web] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [No] Have you added type definitions?

# Description
BotSettings now includes an option for 'OpenAI Response API'. The requestOpenAIResponseAPI function supports custom endpoints, dynamic URL construction, and a special 'risu' identifier for proxying, with headers adjusted accordingly.

Update OpenAI API request parameters and URL handling
Replaces 'max_completion_tokens' with 'max_output_tokens' in request bodies for compatibility with updated OpenAI API. Improves logic for constructing the /responses endpoint URL, handling Azure-style URLs and various path formats more robustly.