### PR TITLE
feat: Prevent form submission, allow listening to it with Lua

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -4,7 +4,7 @@
     import { ColorSchemeTypeStore } from "src/ts/gui/colorscheme"
     import { longpress } from "src/ts/gui/longtouch"
     import { getModelInfo } from "src/ts/model/modellist"
-    import { runLuaButtonTrigger } from 'src/ts/process/scriptings'
+    import { runLuaButtonTrigger, runLuaFormTrigger } from 'src/ts/process/scriptings'
     import { risuChatParser } from "src/ts/process/scripts"
     import { runTrigger } from 'src/ts/process/triggers'
     import { sayTTS } from "src/ts/process/tts"
@@ -342,6 +342,46 @@
             setTimeout(() => {
                 CurrentTriggerIdStore.set(null)
             }, 100) // Small delay to allow display mode to complete
+        }
+    }
+
+    async function handleFormTriggerWithin(event: SubmitEvent) {
+        // Regardless of attribute presence, prevent undesirable site exits via form submission
+        event.preventDefault()
+
+        const currentChar = getCurrentCharacter()
+        if (currentChar.type === 'group') {
+            return
+        }
+
+        const target = event.target as HTMLFormElement
+        const formEvent = target.getAttribute('risu-form')
+
+        if (!formEvent) {
+            return
+        }
+
+        const obj = {}
+        for (const [k, v] of new FormData(target)) {
+            if (obj[k]) {
+                if (Array.isArray(obj[k])) {
+                    (obj[k] as any[]).push(v)
+                } else {
+                    obj[k] = [obj[k], v]
+                }
+            } else {
+                obj[k] = v
+            }
+        }
+
+        const triggerResult =  formEvent ? await runLuaFormTrigger(currentChar, formEvent, { data: obj }) : null
+
+        if(triggerResult) {
+            setCurrentChat(triggerResult.chat)
+            ReloadChatPointer.update((v) => {
+                v[idx] = (v[idx] ?? 0) + 1
+                return v
+            })
         }
     }
 
@@ -1141,7 +1181,8 @@
      data-chat-index={idx}
      data-chat-id={DBState.db.characters?.[selIdState.selId]?.chats?.[DBState.db.characters?.[selIdState.selId]?.chatPage]?.message?.[idx]?.chatId ?? ''}
      style={isLastMemory ? `border-top:${DBState.db.memoryLimitThickness}px solid rgba(98, 114, 164, 0.7);` : ''}
-     onclickcapture={handleButtonTriggerWithin}>
+     onclickcapture={handleButtonTriggerWithin}
+     onsubmitcapture={handleFormTriggerWithin}>
     <div class="text-textcolor mt-1 ml-4 mr-4 mb-1 p-2 bg-transparent grow border-t-gray-900 border-opacity/30 border-transparent flexium items-start max-w-full" >
         {#if DBState.db.theme === 'mobilechat' && !blankMessage}
             <div class={role === 'user' ? "flex items-start w-full justify-end" : "flex items-start"}>

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -4,7 +4,7 @@
     import { ColorSchemeTypeStore } from "src/ts/gui/colorscheme"
     import { longpress } from "src/ts/gui/longtouch"
     import { getModelInfo } from "src/ts/model/modellist"
-    import { runLuaButtonTrigger, runLuaFormTrigger } from 'src/ts/process/scriptings'
+    import { runLuaInteractionTrigger } from 'src/ts/process/scriptings'
     import { risuChatParser } from "src/ts/process/scripts"
     import { runTrigger } from 'src/ts/process/triggers'
     import { sayTTS } from "src/ts/process/tts"
@@ -327,7 +327,7 @@
                     triggerId: triggerId || undefined,
                 }) :
             btnEvent ?
-                await runLuaButtonTrigger(currentChar, btnEvent) :
+                await runLuaInteractionTrigger('button', currentChar, btnEvent) :
             null
 
         if(triggerResult) {
@@ -374,7 +374,7 @@
             }
         }
 
-        const triggerResult =  formEvent ? await runLuaFormTrigger(currentChar, formEvent, { data: obj }) : null
+        const triggerResult =  formEvent ? await runLuaInteractionTrigger('form', currentChar, formEvent, { data: obj }) : null
 
         if(triggerResult) {
             setCurrentChat(triggerResult.chat)

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -361,20 +361,20 @@
             return
         }
 
-        const obj = {}
-        for (const [k, v] of new FormData(target)) {
-            if (obj[k]) {
-                if (Array.isArray(obj[k])) {
-                    (obj[k] as any[]).push(v)
+        const data: Record<string, FormDataEntryValue | FormDataEntryValue[]> = Object.create(null)
+        for (const [key, value] of new FormData(target, event.submitter)) {
+            if (Object.hasOwn(data, key)) {
+                if (Array.isArray(data[key])) {
+                    data[key].push(value)
                 } else {
-                    obj[k] = [obj[k], v]
+                    data[key] = [data[key], value]
                 }
             } else {
-                obj[k] = v
+                data[key] = value
             }
         }
 
-        const triggerResult =  formEvent ? await runLuaInteractionTrigger('form', currentChar, formEvent, { data: obj }) : null
+        const triggerResult = await runLuaInteractionTrigger('form', currentChar, formEvent, { data })
 
         if(triggerResult) {
             setCurrentChat(triggerResult.chat)

--- a/src/ts/parser/parser.svelte.ts
+++ b/src/ts/parser/parser.svelte.ts
@@ -778,7 +778,7 @@ export async function ParseMarkdown(
 
 const trimPurifyConfig = {
     ADD_TAGS: ["iframe", "style", "risu-style", "x-em", 'annotation', 'semantics', 'mrow', 'mi', 'mo', 'mn', 'msup', 'msub', 'mfrac', 'msqrt'],
-    ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "risu-ctrl" ,"risu-btn", 'risu-trigger', 'risu-mark', 'risu-id', 'x-hl-lang', 'x-hl-text'],
+    ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "risu-btn", "risu-ctrl", 'risu-form', 'risu-trigger', 'risu-mark', 'risu-id', 'x-hl-lang', 'x-hl-text'],
 }
 
 export function trimMarkdown(data:string){

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -76,7 +76,7 @@ export async function runScripted(code:string, arg:{
         await ensureLuaFactory()
     }
     let ScriptingEngineState = await getOrCreateEngineState(mode, type);
-    
+
     return await ScriptingEngineState.mutex.runExclusive(async () => {
         ScriptingEngineState.chat = chat
         ScriptingEngineState.setVar = setVar
@@ -1456,7 +1456,9 @@ export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:char
     }
 }
 
-export async function runLuaButtonTrigger(char:character|simpleCharacterArgument, triggerKey:string):Promise<any>{
+export async function runLuaInteractionTrigger(type: 'button'|'form', char: character|simpleCharacterArgument, triggerKey: string, meta?: object): Promise<any> {
+    const mode = type === 'button' ? 'onButtonClick' : 'onFormSubmit'
+
     let runResult
     try {
         const triggers = char.triggerscript.map<triggerscript>((v) => ({
@@ -1467,35 +1469,11 @@ export async function runLuaButtonTrigger(char:character|simpleCharacterArgument
         for(let trigger of triggers){
             if(trigger?.effect?.[0]?.type === 'triggerlua'){
                 runResult = await runScripted(trigger.effect[0].code, {
-                    char: char,
-                    data: triggerKey,
-                    lowLevelAccess: trigger.lowLevelAccess,
-                    mode: 'onButtonClick',
-                })
-            }
-        }
-    } catch (error) {
-        throw(error)
-    }
-    return runResult   
-}
-
-export async function runLuaFormTrigger(char:character|simpleCharacterArgument, triggerKey:string, meta?:object):Promise<any>{
-    let runResult
-    try {
-        const triggers = char.triggerscript.map<triggerscript>((v) => ({
-            ...v,
-            lowLevelAccess: char.type !== 'simple' ? char.lowLevelAccess ?? false : false
-        })).concat(getModuleTriggers())
-
-        for(let trigger of triggers){
-            if(trigger?.effect?.[0]?.type === 'triggerlua'){
-                runResult = await runScripted(trigger.effect[0].code, {
-                    char: char,
+                    char,
                     data: triggerKey,
                     lowLevelAccess: trigger.lowLevelAccess,
                     meta,
-                    mode: 'onFormSubmit',
+                    mode,
                 })
             }
         }

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -1105,6 +1105,13 @@ export async function runScripted(code:string, arg:{
                         }
                         break
                     }
+                    case 'onFormSubmit':{
+                        const func = luaEngine.global.get('onFormSubmit')
+                        if(func){
+                            res = await func(accessKey, data, JSON.stringify(meta))
+                        }
+                        break
+                    }
                     case 'editRequest':
                     case 'editDisplay':
                     case 'editInput':
@@ -1449,10 +1456,10 @@ export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:char
     }
 }
 
-export async function runLuaButtonTrigger(char:character|groupChat|simpleCharacterArgument, data:string):Promise<any>{
+export async function runLuaButtonTrigger(char:character|simpleCharacterArgument, triggerKey:string):Promise<any>{
     let runResult
     try {
-        const triggers = char.type === 'group' ? getModuleTriggers() : char.triggerscript.map<triggerscript>((v) => ({
+        const triggers = char.triggerscript.map<triggerscript>((v) => ({
             ...v,
             lowLevelAccess: char.type !== 'simple' ? char.lowLevelAccess ?? false : false
         })).concat(getModuleTriggers())
@@ -1461,9 +1468,34 @@ export async function runLuaButtonTrigger(char:character|groupChat|simpleCharact
             if(trigger?.effect?.[0]?.type === 'triggerlua'){
                 runResult = await runScripted(trigger.effect[0].code, {
                     char: char,
+                    data: triggerKey,
                     lowLevelAccess: trigger.lowLevelAccess,
                     mode: 'onButtonClick',
-                    data: data
+                })
+            }
+        }
+    } catch (error) {
+        throw(error)
+    }
+    return runResult   
+}
+
+export async function runLuaFormTrigger(char:character|simpleCharacterArgument, triggerKey:string, meta?:object):Promise<any>{
+    let runResult
+    try {
+        const triggers = char.triggerscript.map<triggerscript>((v) => ({
+            ...v,
+            lowLevelAccess: char.type !== 'simple' ? char.lowLevelAccess ?? false : false
+        })).concat(getModuleTriggers())
+
+        for(let trigger of triggers){
+            if(trigger?.effect?.[0]?.type === 'triggerlua'){
+                runResult = await runScripted(trigger.effect[0].code, {
+                    char: char,
+                    data: triggerKey,
+                    lowLevelAccess: trigger.lowLevelAccess,
+                    meta,
+                    mode: 'onFormSubmit',
                 })
             }
         }


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

This MR allows form submission handling with Lua scripts.

## Problem

Currently, form-like interaction *can* be done with a combination of `risu-btn`/`risu-trigger` and chat variables. But each button press requires separate Lua calls and a full or partial chat update, which moves scroll position and gets more and more slower as the chat session gets longer.

With form submission, creators can implement a "batch" variable update with faster, more reactive UX, while also utilizing browser built-in form controls.

> [!NOTE]
> This MR also cancels `submit` events dispatched from inside the chat body which should help mitigate some form of attacks, such as a button that submits to an advertisement link.

## Usage

Similar to the `risu-btn` attribute, creators can add a `risu-form="key"` attribute to their `<form>`s:

```html
<form risu-form="submit-controlpanel">
  <input name="boolean" type="checkbox">
  <input name="foo" type="text">
  <button>submit</button>
</form>
```

On Lua side, they can define `onFormSubmit` like so:

```lua
onFormSubmit = function (triggerId, key, meta)
  print(key) -- 'submit-controlpanel'

  local data = json.decode(meta).data
  print('data.boolean', data.boolean) -- 'on' or nil
  print('data.foo', data.foo) -- whatever text the user has typed
end
```

## Implementation

- Added `risu-form` to sanitizer allowlist
- Renamed `runLuaButtonTrigger()` to `runLuaInteractionTrigger()`
  - `runLuaButtonTrigger(char, value)` => `runLuaInteractionTrigger('button', char, value)`
  - Used for form submissions as well: `runLuaInteractionTrigger('form', char, value, formData)`