### PR TITLE
Fix: Assign New chatId when chat doesn't have chatId in toggleBookmark

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -13,6 +13,7 @@
     import { capitalize, getUserIcon, getUserName } from "src/ts/util"
     import { onDestroy, onMount } from "svelte"
     import { type Unsubscriber } from "svelte/store"
+    import { v4 as uuidv4 } from 'uuid'
     import { language } from "../../lang"
     import { alertClear, alertConfirm, alertInput, alertNormal, alertRequestData, alertWait } from "../../ts/alert"
     import { ParseMarkdown, type CbsConditions, type simpleCharacterArgument } from "../../ts/parser.svelte"
@@ -214,10 +215,16 @@
 
     async function toggleBookmark() {
         const chat = DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage];
-        const messageId = chat.message[idx]?.chatId;
+        
+        if(!chat.message[idx]) return;
+
+        let messageId = chat.message[idx]?.chatId;
         const messageContent = chat.message[idx]?.data;
 
-        if (!messageId) return;
+        if (!messageId) {
+            messageId = uuidv4();
+            chat.message[idx].chatId = messageId;
+        }
 
         chat.bookmarks ??= [];
         chat.bookmarkNames ??= {};


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
The bookmark feature uses chatId as an identifier, but this is currently optional in the Message interface.
Therefore, chats without a chatId cannot be bookmarked.

This PR enables bookmarking by assigning a new chatId to chats where the chatId is undefined when a user attempts to bookmark them.

And thank you so much for merge the bookmark feature last time.
For someone who's been waiting for this, it's practically a Christmas present.
I didn't even know it might get merged this year lol

Christmas is almost over, but Merry Christmas!