### PR TITLE
fix: Fix character image 'contain' style not being applied

### DIFF
--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -67,7 +67,7 @@ export async function getCharImage(loc:string, type:'plain'|'css'|'contain'|'lgc
     else if(type ==='css'){
         return `background: url("${filesrc}");background-size: cover;`
     }
-    else if(type ='lgcss'){
+    else if(type === 'lgcss'){
         return `background: url("${filesrc}");background-size: cover;height: 10.66rem;`
 
     }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Fixed a bug where the `contain` image style was never applied to character images, always falling through to the `lgcss` style instead.

## Problem

In `getCharImage()`, the condition for `lgcss` type used an assignment operator (`=`) instead of an equality operator (`===`):

```typescript
// Before (bug)
else if(type ='lgcss'){

// After (fix)
else if(type === 'lgcss'){
```

Since assignment returns the assigned value (`'lgcss'` is truthy), this condition always evaluated to true, preventing the `contain` branch from ever executing.

## Impact

When calling `getCharImage(loc, 'contain')`:
- **Expected**: `background-size: contain; background-repeat: no-repeat; background-position: center;`
- **Actual**: `background-size: cover; height: 10.66rem;` (lgcss style)

## Files Changed

- `src/ts/characters.ts` (1 line)