### PR TITLE
fix: Fix error messages not being captured due to variable shadowing

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -2083,8 +2083,8 @@ export async function fetchNative(url: string, arg: {
                         error = parsedRes.body
                         resolved = true
                     }
-                } catch (error) {
-                    error = JSON.stringify(error)
+                } catch (e) {
+                    error = JSON.stringify(e)
                     resolved = true
                 }
             })

--- a/src/ts/process/models/nai.ts
+++ b/src/ts/process/models/nai.ts
@@ -115,8 +115,8 @@ export const novelLogin = async () => {
                 setDatabase(db)
                 return
             }
-            catch (error) {
-                error = (`Failed to authenticate with NovelAI: ${error}`)
+            catch (e) {
+                error = `Failed to authenticate with NovelAI: ${e}`
                 tries++
             }
         }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Fixed a bug where catch parameter shadowing caused error messages to be silently lost, resulting in empty or missing error displays to users.

## Problem

Both files declared an outer `error` variable, then used `catch (error)` which shadows it:

```typescript
let error = ''
// ...
catch (error) {              // shadows outer 'error'
    error = `message: ${error}`  // assigns to catch param, not outer variable
}
alertError(error)            // always '' - outer variable was never updated
```

## Affected Features

**globalApi.svelte.ts (streamed fetch)**
- When `JSON.parse()` failed during Tauri streamed fetch, the error was lost
- Users would see no error message when fetch parsing failed

**nai.ts (NovelAI login)**
- After 3 failed login attempts, `alertError(error)` showed empty string
- Users saw a blank error popup instead of the actual failure reason

## Fix

Renamed catch parameter from `error` to `e` so assignments properly update the outer variable:

```typescript
catch (e) {
    error = `message: ${e}`  // now correctly assigns to outer 'error'
}
```

## Files Changed

- `src/ts/globalApi.svelte.ts` (1 line)
- `src/ts/process/models/nai.ts` (2 lines)
