### PR TITLE
fix: Use primitive 'number' instead of wrapper 'Number' type

### DIFF
--- a/src/ts/horde/getModels.ts
+++ b/src/ts/horde/getModels.ts
@@ -4,7 +4,7 @@ interface HordeModel {
     "performance": number,
     "queued": number,
     "jobs": number,
-    "eta": Number,
+    "eta": number,
     "type": "text",
     "name": "aphrodite\/Undi95\/Toppy-M-7B",
     "count": number


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

TypeScript's 'Number' is a wrapper object type that should not be used for type annotations. Use the primitive 'number' type instead.