### PR TITLE
fix: Add nullish coalescing for largePortrait in Chats.svelte

### DIFF
--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -53,7 +53,7 @@
         for(let i=messages.length - 1 ; i >= messages.length - loadPages; i--){
             if(i < 0) break; // Prevent out of bounds
             const message = messages[i];
-            const messageLargePortrait = message.role === 'user' ? (userIconPortrait ?? false) : (currentCharacter as character).largePortrait;
+            const messageLargePortrait = message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false);
             let hashd = message.data + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString()
             const currentHash = hashCode(hashd);
             currentHashes.add(currentHash);
@@ -73,7 +73,7 @@
                         unReroll: unReroll,
                         rerollIcon: 'dynamic',
                         character: simpleChar,
-                        largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : (currentCharacter as character).largePortrait,
+                        largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false),
                         messageGenerationInfo: message.generationInfo,
                         role: message.role,
                         name: message.role === 'user' ? currentUsername : currentCharacter.name


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
## Summary
- Fixes `TypeError: Cannot read properties of undefined (reading 'toString')` in `updateChatBody`
- Adds `?? false` fallback for `largePortrait` which can be undefined

## Cause
Introduced in PR #938, `(currentCharacter as character).largePortrait` can be `undefined` when:
- `currentCharacter` is a `groupChat` (no `largePortrait` property)
- `character.largePortrait` is not set (optional property)

This was not caught at compile time because `tsconfig.json` has `strict: false`.

## Changes
```diff
- const messageLargePortrait = ... : (currentCharacter as character).largePortrait;
+ const messageLargePortrait = ... : ((currentCharacter as character).largePortrait ?? false);
```