### PR TITLE
fix: Use max_completion_tokens instead of max_output_tokens for OpenAI Completion API

### DIFF
--- a/src/ts/process/request/openAI.ts
+++ b/src/ts/process/request/openAI.ts
@@ -409,8 +409,8 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         delete body.logit_bias
     }
 
-    if(aiModel.startsWith('gpt4o1') || arg.modelInfo.flags.includes(LLMFlags.OAICompletionTokens)){
-        body.max_output_tokens = body.max_tokens
+    if(arg.modelInfo.flags.includes(LLMFlags.OAICompletionTokens)){
+        body.max_completion_tokens = body.max_tokens
         delete body.max_tokens
     }
 


### PR DESCRIPTION
# PR Checklist
- [O] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
  - Fixes `Unknown parameter: 'max_output_tokens'.` error when using OpenAI completion API
  - Uses `max_completion_tokens` which is the correct parameter name for the OpenAI API

  ### Changes
  - Replaced `max_output_tokens` with `max_completion_tokens` in openAI.ts
  - Simplified condition to only check `LLMFlags.OAICompletionTokens` flag