### PR TITLE
feat: Add tooltip explanation for Additional Prompt in all languages

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -177,6 +177,8 @@ export const languageChinese = {
         openrouterProviderOnly:
             "仅使用此列表中的提供商，若所有提供商都不可用，请求将会失败。详见 https://openrouter.ai/docs/guides/routing/provider-selection#allowing-only-specific-providers",
         openrouterProviderIgnore: "忽略此列表中的提供商，若所有提供商都被忽略，请求将会失败。详见 https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
+        additionalPrompt:
+            "启用提示词预处理时，这段文本会添加到主提示词的末尾。默认值是 'The assistant must act as {{char}}. user is {{user}}.'，用于设置基本的角色扮演背景。",
     },
     setup: {
         chooseProvider: "选择 AI 提供者",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -212,6 +212,8 @@ export const languageGerman = {
             "Verwenden Sie nur die Anbieter in dieser Liste. Wenn alle Anbieter nicht verfügbar sind, schlägt die Anfrage fehl. Siehe Details unter https://openrouter.ai/docs/guides/routing/provider-selection#allowing-only-specific-providers",
         openrouterProviderIgnore:
             "Ignorieren Sie die Anbieter in dieser Liste. Wenn alle Anbieter ignoriert werden, schlägt die Anfrage fehl. Siehe Details unter https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
+        additionalPrompt:
+            "Text, der am Ende der Haupt-Anweisung angehängt wird, wenn die Anweisungsvorverarbeitung aktiviert ist. Der Standardwert ist 'The assistant must act as {{char}}. user is {{user}}.' Dies hilft, den grundlegenden Rollenspielkontext einzurichten.",
     },
     setup: {
         chooseProvider: "Wählen Sie Ihren AI-Anbieter aus",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -235,6 +235,8 @@ export const languageEnglish = {
             "Only use the providers in this list, if all the provider is not available, the request will failed. See detail on https://openrouter.ai/docs/guides/routing/provider-selection#allowing-only-specific-providers",
         openrouterProviderIgnore:
             "Ignore the providers in this list, if all the provider is ingored, the request will failed. See detail on https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
+        additionalPrompt:
+            "Text that gets appended to the Main Prompt when Prompt Preprocess is enabled. Default is 'The assistant must act as {{char}}. user is {{user}}.' This helps set up basic roleplay context.",
     },
     setup: {
         chooseProvider: "Choose AI Provider",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -204,6 +204,8 @@ export const languageSpanish = {
             "Solo usar los proveedores en esta lista, si todos los proveedores no están disponibles, la solicitud fallará. Ver detalles en https://openrouter.ai/docs/guides/routing/provider-selection#allowing-only-specific-providers",
         openrouterProviderIgnore:
             "Ignorar los proveedores en esta lista, si todos los proveedores son ignorados, la solicitud fallará. Ver detalles en https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
+        additionalPrompt:
+            "Texto que se agrega al final del Prompt Principal cuando el Preprocesamiento de Prompt está habilitado. El valor predeterminado es 'The assistant must act as {{char}}. user is {{user}}.' Esto ayuda a establecer el contexto básico del juego de roles.",
     },
     setup: {
         chooseProvider: "Elige Proveedor de IA",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -188,6 +188,8 @@ export const languageKorean = {
             "이 목록의 제공자만 사용합니다. 모든 제공자를 사용할 수 없는 경우 요청이 실패합니다. 자세한 내용은 https://openrouter.ai/docs/guides/routing/provider-selection#allowing-only-specific-providers 를 참조하세요",
         openrouterProviderIgnore:
             "이 목록의 제공자를 무시합니다. 모든 제공자가 무시되면 요청이 실패합니다. 자세한 내용은 https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers 를 참조하세요",
+        additionalPrompt:
+            "프롬프트 선보정이 활성화되어 있을 때 메인 프롬프트 끝에 추가되는 텍스트입니다. 기본값은 'The assistant must act as {{char}}. user is {{user}}.'이며, 이를 통해 기본적인 롤플레이 맥락을 설정합니다.",
     },
     setup: {
         chooseProvider: "AI 제공자를 선택해 주세요",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -197,6 +197,8 @@ export const LanguageVietnamese = {
             "Chỉ sử dụng các nhà cung cấp trong danh sách này, nếu tất cả các nhà cung cấp không có sẵn, yêu cầu sẽ thất bại. Xem chi tiết tại https://openrouter.ai/docs/guides/routing/provider-selection#allowing-only-specific-providers",
         openrouterProviderIgnore:
             "Bỏ qua các nhà cung cấp trong danh sách này, nếu tất cả các nhà cung cấp bị bỏ qua, yêu cầu sẽ thất bại. Xem chi tiết tại https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
+        additionalPrompt:
+            "Văn bản được thêm vào cuối Lời nhắc chính khi Tiền xử lý lời nhắc được bật. Mặc định là 'The assistant must act as {{char}}. user is {{user}}.' Điều này giúp thiết lập ngữ cảnh nhập vai cơ bản.",
     },
     setup: {
         chooseProvider: "Chọn nhà cung cấp AI",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -178,6 +178,8 @@ export const languageChineseTraditional = {
             "僅使用此列表中的提供商，若所有提供商均不可用，請求將失敗。詳情請參閱 https://openrouter.ai/docs/guides/routing/provider-selection#allowing-only-specific-providers",
         openrouterProviderIgnore:
             "忽略此列表中的提供商,若所有提供商均被忽略,請求將失敗。詳情請參閱 https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
+        additionalPrompt:
+            "啟用提示詞預處理時，這段文字會加在主要提示詞的末尾。預設值是 'The assistant must act as {{char}}. user is {{user}}.'，用於設定基本的角色扮演情境。",
     },
     setup: {
         chooseProvider: "選擇 AI 提供者",

--- a/src/lib/Setting/Pages/AdvancedSettings.svelte
+++ b/src/lib/Setting/Pages/AdvancedSettings.svelte
@@ -76,7 +76,7 @@
 <span class="text-textcolor">{language.autoContinueMinTokens}</span>
 <NumberInput marginBottom={true} size={"sm"} min={0} bind:value={DBState.db.autoContinueMinTokens}/>
 
-<span class="text-textcolor">{language.additionalPrompt}</span>
+<span class="text-textcolor">{language.additionalPrompt} <Help key="additionalPrompt"/></span>
 <TextInput marginBottom={true} size={"sm"} bind:value={DBState.db.additionalPrompt}/>
 
 <span class="text-textcolor">{language.descriptionPrefix}</span>


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

Added a tooltip explanation for the "Additional Prompt" setting in Advanced Settings.

## Changes
- Added `<Help key="additionalPrompt"/>` component next to the Additional Prompt label in AdvancedSettings.svelte
- Added help text for `additionalPrompt` in all language files