### PR TITLE
feat: add support for reasoning parsing in OpenRouter responses

### DIFF
--- a/src/ts/process/request/openAI.ts
+++ b/src/ts/process/request/openAI.ts
@@ -743,6 +743,10 @@ export async function requestHTTPOpenAI(replacerURL:string,body:any, headers:Rec
         if(dat?.choices[0]?.reasoning_content){
             result = `<Thoughts>\n${dat.choices[0].reasoning_content}\n</Thoughts>\n${result}`
         }
+        // For openrouter, https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#response.body.choices.message.reasoning
+        if(dat?.choices?.[0]?.message?.reasoning){
+            result = `<Thoughts>\n${dat.choices[0].message.reasoning}\n</Thoughts>\n${result}`
+        }
 
         return result
     }


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
This pull request adds support for parsing reasoning content from OpenRouter API responses. It ensures the `reasoning` field is properly extracted and included in the output.

* Added logic to check for and extract the `reasoning` field from `dat.choices[0].message` in the `requestHTTPOpenAI` function, wrapping it in `<Thoughts>` tags for consistency with existing reasoning extraction.

## Tested Models
The following models have been verified to return COT content:
* Gemini 3.x
* DeepSeek V3.x / R1.x
* Grok 4.x
* GLM 4.x
* gpt-oss


Some models do not yet support reasoning parsing:
* GPT 5.x: use encrypted reasoning in `dat.choices[0].message.reasoning_details`, which cannot be parsed at this time.

## Ref
https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#response.body.choices.message.reasoning

