### PR TITLE
fix: enable noFallthroughCasesInSwitch and fix fallthrough bugs

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -746,15 +746,27 @@ export function addMetadataToElement(data:string, modelShortName:string){
             switch(byte.charAt(j)){
                 case '0':{
                     encodedMetaCode += metaCodes[0]
+                    break
                 }
                 case '1':{
                     encodedMetaCode += metaCodes[1]
+                    break
                 }
                 case '2':{
                     encodedMetaCode += metaCodes[2]
+                    break
                 }
                 case '3':{
                     encodedMetaCode += metaCodes[3]
+                    break
+                }
+                case '4':{
+                    encodedMetaCode += metaCodes[4]
+                    break
+                }
+                case '5':{
+                    encodedMetaCode += metaCodes[5]
+                    break
                 }
             }
         }
@@ -1327,6 +1339,7 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
                         else{
                             statement.push('0')
                         }
+                        break
                     }
                     case 'tis':{ //tis = toggle is
                         const variable = getGlobalChatVar('toggle_' + statement.pop())

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "strict": false,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
 
     /* Debugging */
     "sourceMap": true


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
1. Enable `noFallthroughCasesInSwitch` in tsconfig.json to catch unintentional switch fallthrough at compile time
2. Fix existing fallthrough bugs in parser.svelte.ts discovered by the new compiler check

## Why
With this option enabled, `pnpm check` (svelte-check) will automatically catch accidentally missing `break` statements in switch cases. This prevents bugs like those fixed in previous PRs:
- https://github.com/kwaroran/RisuAI/pull/271
- https://github.com/kwaroran/RisuAI/pull/1081

### Note
Fortunately, unlike ESLint's `no-fallthrough` rule, TypeScript's `noFallthroughCasesInSwitch` allows empty cases (intentional fallthrough pattern):
```typescript
// This is still allowed - empty cases are fine
case 'a':
case 'b':
case 'c':
    doSomething()
    break
```

If other intentional fallthrough with code is needed, you can disable it per-line:
```typescript
// @ts-expect-error intentional fallthrough
```

## Changes

### tsconfig.json
Added `noFallthroughCasesInSwitch: true` to enforce explicit break statements in switch cases.

### parser.svelte.ts
Fixed fallthrough bugs caught by the compiler:
- **`addMetadataToElement`**: Added missing `break` statements for cases '0'-'3', and added missing cases '4' and '5' for complete base-6 encoding
- **`blockStartMatcher`**: Added missing `break` in `visnot` case

#### Example: `blockStartMatcher` (before)
```typescript
case 'visnot':{ // variable is not
    const variable = getChatVar(statement.pop())
    if(variable !== condition){
        statement.push('1')
    } else {
        statement.push('0')
    }
} // missing break - falls through to 'tis' case
case 'tis':{ // toggle is
    const variable = getGlobalChatVar('toggle_' + statement.pop())
    // ...
}
```

#### Example: `blockStartMatcher` (after)
```typescript
case 'visnot':{ // variable is not
    const variable = getChatVar(statement.pop())
    if(variable !== condition){
        statement.push('1')
    } else {
        statement.push('0')
    }
    break
}
case 'tis':{ // toggle is
    const variable = getGlobalChatVar('toggle_' + statement.pop())
    // ...
}
```
