### PR TITLE
fix: correct Tailwind v4 opacity syntax from `bg-opacity/50` to `bg-color/50`

### DIFF
--- a/src/lib/ChatScreens/ResizeBox.svelte
+++ b/src/lib/ChatScreens/ResizeBox.svelte
@@ -83,7 +83,7 @@
     }
 </style>
 
-<div class="box bg-darkbg bg-opacity/70" bind:this="{box}" style="width: {$ViewBoxsize.width}px; height: {$ViewBoxsize.height}px;">
+<div class="box bg-darkbg/70" bind:this="{box}" style="width: {$ViewBoxsize.width}px; height: {$ViewBoxsize.height}px;">
     <!-- Your content here -->
     <TransitionImage classType='risu' src={getEmotion(DBState.db, $CharEmotion, 'plain')}/>
     <div role="button" tabindex="0"

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -113,7 +113,7 @@
 }}></svelte:window>
 
 {#if $alertStore.type !== 'none' &&  $alertStore.type !== 'toast' &&  $alertStore.type !== 'cardexport' && $alertStore.type !== 'branches' && $alertStore.type !== 'selectModule' && $alertStore.type !== 'pukmakkurit'}
-    <div class="absolute w-full h-full z-50 bg-black bg-opacity/50 flex justify-center items-center" class:vis={ $alertStore.type === 'wait2'}>
+    <div class="absolute w-full h-full z-50 bg-black/50 flex justify-center items-center" class:vis={ $alertStore.type === 'wait2'}>
         <div class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl  max-h-full overflow-y-auto">
             {#if $alertStore.type === 'error'}
                 <h2 class="text-red-700 mt-0 mb-2 w-40 max-w-full">Error</h2>
@@ -279,7 +279,7 @@
                     </datalist>
                 {/if}
             {:else if $alertStore.type === 'login'}
-                <div class="fixed top-0 left-0 bg-black bg-opacity/50 w-full h-full flex justify-center items-center">
+                <div class="fixed top-0 left-0 bg-black/50 w-full h-full flex justify-center items-center">
                     <iframe src={hubURL + '/hub/login'} title="login" class="w-full h-full">
                     </iframe>
                 </div>
@@ -626,7 +626,7 @@
 
 {:else if $alertStore.type === 'cardexport'}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div  class="fixed top-0 left-0 h-full w-full bg-black bg-opacity/50 flex flex-col z-50 items-center justify-center" role="button" tabindex="0" onclick={close}>
+    <div  class="fixed top-0 left-0 h-full w-full bg-black/50 flex flex-col z-50 items-center justify-center" role="button" tabindex="0" onclick={close}>
         <div class="bg-darkbg rounded-md p-4 max-w-full flex flex-col w-2xl" role="button" tabindex="0" onclick={(e) => {
             e.stopPropagation()
         }}>
@@ -726,14 +726,14 @@
     <!-- Log Generator by dootaang, GPL3 -->
     <!-- Svelte, Typescript version by Kwaroran -->
     
-    <div class="absolute w-full h-full z-50 bg-black bg-opacity/50 flex justify-center items-center">
+    <div class="absolute w-full h-full z-50 bg-black/50 flex justify-center items-center">
         <div class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl  max-h-full overflow-y-auto">
             <h2 class="text-green-700 mt-0 mb-2 w-40 max-w-full">{language.preview}</h2>
 
         </div>
     </div>
 {:else if $alertStore.type === 'branches'}
-    <div class="absolute w-full h-full z-50 bg-black bg-opacity/80 flex justify-center items-center overflow-x-auto overflow-y-auto">
+    <div class="absolute w-full h-full z-50 bg-black/80 flex justify-center items-center overflow-x-auto overflow-y-auto">
         {#if branchHover !== null}
             <div class="z-30 whitespace-pre-wrap p-4 text-textcolor bg-darkbg border-darkborderc border rounded-md absolute text-white" style="top: {branchHover.y * 80 + 24}px; left: {(branchHover.x + 1) * 80 + 24}px">
                 {branchHover.content}

--- a/src/lib/Others/BookmarkList.svelte
+++ b/src/lib/Others/BookmarkList.svelte
@@ -110,7 +110,7 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-    class="fixed top-0 left-0 w-full h-full z-30 bg-black bg-opacity/50 flex justify-center items-center"
+    class="fixed top-0 left-0 w-full h-full z-30 bg-black/50 flex justify-center items-center"
     onclick={(event) => {
         if (event.target === event.currentTarget) {
             close();

--- a/src/lib/Others/ChatList.svelte
+++ b/src/lib/Others/ChatList.svelte
@@ -14,7 +14,7 @@
     let { close = () => {} } = $props();
 </script>
 
-<div class="absolute w-full h-full z-40 bg-black bg-opacity/50 flex justify-center items-center">
+<div class="absolute w-full h-full z-40 bg-black/50 flex justify-center items-center">
     <div class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl w-72 max-h-full overflow-y-auto">
         <div class="flex items-center text-textcolor mb-4">
             <h2 class="mt-0 mb-0">{language.chatList}</h2>

--- a/src/lib/Others/PluginAlertModal.svelte
+++ b/src/lib/Others/PluginAlertModal.svelte
@@ -22,7 +22,7 @@
 </script>
 
 {#if pluginAlertModalStore.open}
-    <dialog open class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity/50">
+    <dialog open class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
         <div class="bg-orange-800 rounded-lg shadow-xl max-w-md w-full p-6">
             <h2 class="text-xl font-bold mb-4 text-gray-100">
                 {language.pluginRiskDetectedAlert}

--- a/src/lib/Setting/Pages/CustomGUISettingMenu.svelte
+++ b/src/lib/Setting/Pages/CustomGUISettingMenu.svelte
@@ -81,11 +81,11 @@
             const textElement = document.createElement('p')
             textElement.innerText = currentTree.type
             if(treeChain === selectedContatiner){
-                element.classList.add("bg-blue-200", "border-2", "border-blue-400", "relative", "bg-opacity/50", "p-4", "z-20")
+                element.classList.add("bg-blue-200/50", "border-2", "border-blue-400", "relative", "p-4", "z-20")
                 textElement.classList.add("absolute", "top-0", "left-0", "bg-blue-200", "p-1", "text-black")
             }
             else{
-                element.classList.add("bg-gray-200", "border-2", "border-gray-400", "relative", "bg-opacity/50", "p-4", "z-20")
+                element.classList.add("bg-gray-200/50", "border-2", "border-gray-400", "relative", "p-4", "z-20")
                 textElement.classList.add("absolute", "top-0", "left-0", "bg-white", "p-1", "text-black")
             }
             element.appendChild(textElement)

--- a/src/lib/Setting/Pages/Module/ModuleChatMenu.svelte
+++ b/src/lib/Setting/Pages/Module/ModuleChatMenu.svelte
@@ -32,7 +32,7 @@
 </script>
 
 
-<div class="absolute w-full h-full z-40 bg-black bg-opacity/50 flex justify-center items-center">
+<div class="absolute w-full h-full z-40 bg-black/50 flex justify-center items-center">
     <div class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl w-full max-h-full overflow-y-auto">
         <div class="flex items-center text-textcolor">
             <h2 class="mt-0 mb-0 text-lg">{language.modules}</h2>

--- a/src/lib/Setting/Pages/PluginSettings.svelte
+++ b/src/lib/Setting/Pages/PluginSettings.svelte
@@ -115,7 +115,7 @@
             </span>
             <!--List up args-->
         {:else if Object.keys(plugin.arguments).filter((i) => !i.startsWith("hidden_")).length > 0 && showParams.includes(i)}
-            <div class="flex flex-col mt-2 bg-dark-900 bg-opacity/50 p-3">
+            <div class="flex flex-col mt-2 bg-dark-900/50 p-3">
                 {#each Object.keys(plugin.arguments) as arg}
                     {#if !arg.startsWith("hidden_")}
                         {#if typeof(plugin?.argMeta?.[arg]?.divider) === 'string'}

--- a/src/lib/Setting/Pages/UserSettings.svelte
+++ b/src/lib/Setting/Pages/UserSettings.svelte
@@ -168,7 +168,7 @@
 
 </div>
 {#if openIframe}
-    <div class="fixed top-0 left-0 bg-black bg-opacity/50 w-full h-full flex justify-center items-center">
+    <div class="fixed top-0 left-0 bg-black/50 w-full h-full flex justify-center items-center">
         <iframe src={openIframeURL} title="login" class="w-full h-full">
         </iframe>
     </div>

--- a/src/lib/Setting/botpreset.svelte
+++ b/src/lib/Setting/botpreset.svelte
@@ -334,7 +334,7 @@
 
 </script>
 
-<div class="absolute w-full h-full z-40 bg-black bg-opacity/50 flex justify-center items-center">
+<div class="absolute w-full h-full z-40 bg-black/50 flex justify-center items-center">
     <div class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl w-124 max-h-full overflow-y-auto">
         <div class="flex items-center text-textcolor mb-4">
             <h2 class="mt-0 mb-0">{language.presets}</h2>

--- a/src/lib/Setting/listedPersona.svelte
+++ b/src/lib/Setting/listedPersona.svelte
@@ -14,7 +14,7 @@
 
 </script>
 
-<div class="absolute w-full h-full z-40 bg-black bg-opacity/50 flex justify-center items-center">
+<div class="absolute w-full h-full z-40 bg-black/50 flex justify-center items-center">
     <div class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl w-96 max-h-full overflow-y-auto">
         <div class="flex items-center text-textcolor mb-4">
             <h2 class="mt-0 mb-0 font-bold">{language.persona}</h2>

--- a/src/lib/Setting/lorepreset.svelte
+++ b/src/lib/Setting/lorepreset.svelte
@@ -10,7 +10,7 @@
     let { close = () => {} } = $props();
 </script>
 
-<div class="absolute w-full h-full z-40 bg-black bg-opacity/50 flex justify-center items-center">
+<div class="absolute w-full h-full z-40 bg-black/50 flex justify-center items-center">
     <div class="bg-darkbg p-4 break-any rounded-md flex flex-col max-w-3xl w-96 max-h-full overflow-y-auto">
         <div class="flex items-center text-textcolor mb-4">
             <h2 class="mt-0 mb-0">{language.loreBook}</h2>

--- a/src/lib/SideBars/Scripts/TriggerList2.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList2.svelte
@@ -2245,7 +2245,7 @@
 <Portal>
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="text-textcolor absolute top-0 bottom-0 bg-black bg-opacity/50 max-w-full w-full h-full z-40 flex justify-center items-center" 
+    <div class="text-textcolor absolute top-0 bottom-0 bg-black/50 max-w-full w-full h-full z-40 flex justify-center items-center" 
          onclick={(e) => {
              if (e.target === e.currentTarget) {
                  contextMenu = false

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -569,15 +569,16 @@
       {#if char.type === 'folder' && openFolders.includes(char.id)}
         {#key char.color}
         <div class="p-1 flex flex-col items-center py-1 mt-1 rounded-lg relative">
-          <div class="absolute top-0 left-1  border border-selected w-full h-full rounded-lg z-0 bg-opacity/20"
-          class:bg-darkbg={char.color === 'default' || char.color === ''}
-          class:bg-red-700={char.color === 'red'}
-          class:bg-yellow-700={char.color === 'yellow'}
-          class:bg-green-700={char.color === 'green'}
-          class:bg-blue-700={char.color === 'blue'}
-          class:bg-indigo-700={char.color === 'indigo'}
-          class:bg-purple-700={char.color === 'purple'}
-          class:bg-pink-700={char.color === 'pink'}></div>
+          <div class="absolute top-0 left-1 border border-selected w-full h-full rounded-lg z-0 {
+            char.color === 'red' ? 'bg-red-700/20' :
+            char.color === 'yellow' ? 'bg-yellow-700/20' :
+            char.color === 'green' ? 'bg-green-700/20' :
+            char.color === 'blue' ? 'bg-blue-700/20' :
+            char.color === 'indigo' ? 'bg-indigo-700/20' :
+            char.color === 'purple' ? 'bg-purple-700/20' :
+            char.color === 'pink' ? 'bg-pink-700/20' :
+            'bg-darkbg/20'
+          }"></div>
           <div class="h-4 min-h-4 w-14 relative z-10" role="listitem" ondragover={(e) => {
             e.preventDefault()
             e.dataTransfer.dropEffect = 'move'

--- a/src/lib/SideBars/SidebarAvatar.svelte
+++ b/src/lib/SideBars/SidebarAvatar.svelte
@@ -44,42 +44,40 @@
     {#if src === "slot"}
       {#await backgroundimg}
       <div
-        class="bg-skin-border sidebar-avatar rounded-md bg-top flex items-center justify-center bg-opacity/50"
-        class:bg-darkbg={color === 'default' || color === ''}
-        class:bg-red-700={color === 'red'}
-        class:bg-yellow-700={color === 'yellow'}
-        class:bg-green-700={color === 'green'}
-        class:bg-blue-700={color === 'blue'}
-        class:bg-indigo-700={color === 'indigo'}
-        class:bg-purple-700={color === 'purple'}
-        class:bg-pink-700={color === 'pink'}
-
-
+        class="bg-skin-border sidebar-avatar rounded-md bg-top flex items-center justify-center {
+          color === 'red' ? 'bg-red-700/50' :
+          color === 'yellow' ? 'bg-yellow-700/50' :
+          color === 'green' ? 'bg-green-700/50' :
+          color === 'blue' ? 'bg-blue-700/50' :
+          color === 'indigo' ? 'bg-indigo-700/50' :
+          color === 'purple' ? 'bg-purple-700/50' :
+          color === 'pink' ? 'bg-pink-700/50' :
+          'bg-darkbg/50'
+        }"
         style:width={size + "px"}
         style:height={size + "px"}
         style:minWidth={size + "px"}
-        class:rounded-md={!rounded} class:rounded-full={rounded} 
+        class:rounded-md={!rounded} class:rounded-full={rounded}
       ></div>
       {:then resolvedBgImg}
       <div
-        class="bg-skin-border sidebar-avatar rounded-md bg-top flex items-center justify-center bg-opacity/50"
-        class:bg-darkbg={color === 'default' || color === ''}
-        class:bg-red-700={color === 'red'}
-        class:bg-yellow-700={color === 'yellow'}
-        class:bg-green-700={color === 'green'}
-        class:bg-blue-700={color === 'blue'}
-        class:bg-indigo-700={color === 'indigo'}
-        class:bg-purple-700={color === 'purple'}
-        class:bg-pink-700={color === 'pink'}
-
-
+        class="bg-skin-border sidebar-avatar rounded-md bg-top flex items-center justify-center {
+          color === 'red' ? 'bg-red-700/50' :
+          color === 'yellow' ? 'bg-yellow-700/50' :
+          color === 'green' ? 'bg-green-700/50' :
+          color === 'blue' ? 'bg-blue-700/50' :
+          color === 'indigo' ? 'bg-indigo-700/50' :
+          color === 'purple' ? 'bg-purple-700/50' :
+          color === 'pink' ? 'bg-pink-700/50' :
+          'bg-darkbg/50'
+        }"
         style:width={size + "px"}
         style:height={size + "px"}
         style:minWidth={size + "px"}
         style:background-image={resolvedBgImg ? `url('${resolvedBgImg}')` : undefined}
         style:background-size={resolvedBgImg ? "cover" : undefined}
         style:background-position={resolvedBgImg ? "center" : undefined}
-        class:rounded-md={!rounded} class:rounded-full={rounded} 
+        class:rounded-md={!rounded} class:rounded-full={rounded}
       >
       {#if !resolvedBgImg}
         {@render children?.()}

--- a/src/lib/UI/ModelList.svelte
+++ b/src/lib/UI/ModelList.svelte
@@ -34,7 +34,7 @@
 
 {#if openOptions}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div class="fixed top-0 w-full h-full left-0 bg-black bg-opacity/50 z-50 flex justify-center items-center" role="button" tabindex="0" onclick={() => {
+    <div class="fixed top-0 w-full h-full left-0 bg-black/50 z-50 flex justify-center items-center" role="button" tabindex="0" onclick={() => {
         openOptions = false
     }}>
         <div class="w-96 max-w-full max-h-full overflow-y-auto overflow-x-hidden bg-bgcolor p-4 flex flex-col" role="button" tabindex="0" onclick={(e)=>{

--- a/src/lib/UI/OpenrouterProviderList.svelte
+++ b/src/lib/UI/OpenrouterProviderList.svelte
@@ -27,7 +27,7 @@
 
 {#if openOptions}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div class="fixed top-0 w-full h-full left-0 bg-black bg-opacity/50 z-50 flex justify-center items-center" role="button" tabindex="0" onclick={() => {
+    <div class="fixed top-0 w-full h-full left-0 bg-black/50 z-50 flex justify-center items-center" role="button" tabindex="0" onclick={() => {
         openOptions = false
     }}>
         <div class="w-96 max-w-full max-h-full overflow-y-auto overflow-x-hidden bg-bgcolor p-4 flex flex-col" role="button" tabindex="0" onclick={(e)=>{

--- a/src/lib/UI/Realm/RealmMain.svelte
+++ b/src/lib/UI/Realm/RealmMain.svelte
@@ -180,7 +180,7 @@
 
 {#if menuOpen}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div class="top-0 left-0 z-50 fixed w-full h-full bg-black bg-opacity/50 flex justify-center items-center" role="button" tabindex="0" onclick={() => {
+    <div class="top-0 left-0 z-50 fixed w-full h-full bg-black/50 flex justify-center items-center" role="button" tabindex="0" onclick={() => {
         menuOpen = false
     }}>
         <div class="max-w-full bg-darkbg rounded-md flex flex-col gap-4 overflow-y-auto p-4">

--- a/src/lib/UI/Realm/RealmPopUp.svelte
+++ b/src/lib/UI/Realm/RealmPopUp.svelte
@@ -19,7 +19,7 @@
 
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
-<div class="top-0 left-0 z-50 fixed w-full h-full bg-black bg-opacity/50 flex justify-center items-center text-textcolor" role="button" tabindex="0" onclick={() => {
+<div class="top-0 left-0 z-50 fixed w-full h-full bg-black/50 flex justify-center items-center text-textcolor" role="button" tabindex="0" onclick={() => {
     openedData = null
 }}>
     <div class="p-6 max-w-full bg-darkbg rounded-md flex flex-col gap-4 w-2xl overflow-y-auto max-h-full">

--- a/src/lib/UI/Realm/RealmUpload.svelte
+++ b/src/lib/UI/Realm/RealmUpload.svelte
@@ -1,5 +1,5 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
-<div  class="fixed top-0 left-0 h-full w-full bg-black bg-opacity/50 flex flex-col z-50 items-center justify-center" role="button" tabindex="0" onclick={close}>
+<div  class="fixed top-0 left-0 h-full w-full bg-black/50 flex flex-col z-50 items-center justify-center" role="button" tabindex="0" onclick={close}>
     <div class="bg-darkbg rounded-md p-4 max-w-full flex flex-col w-2xl max-h-full overflow-y-auto" role="button" tabindex="0" onclick={(e)=>{
         e.stopPropagation()
         onclick?.(e)

--- a/src/lib/VisualNovel/VisualNovelChat.svelte
+++ b/src/lib/VisualNovel/VisualNovelChat.svelte
@@ -53,10 +53,10 @@
     <div class="w-full flex justify-center absolute bottom-5">
         <div class="w-3xl max-w-full flex flex-col">
 
-            <div class="bg-slate-700 h-12 rounded-lg border-slate-500 border-1 w-40 mb-2 bg-opacity/90 text-center flex items-center justify-center">
+            <div class="bg-slate-700/90 h-12 rounded-lg border-slate-500 border-1 w-40 mb-2 text-center flex items-center justify-center">
                 <span class="font-bold p-2">{DBState.db.characters[$selectedCharID].name}</span>
             </div>
-            <div class="bg-slate-700 h-40 rounded-lg border-slate-500 border-1 w-full bg-opacity/90 text-justify p-4">
+            <div class="bg-slate-700/90 h-40 rounded-lg border-slate-500 border-1 w-full text-justify p-4">
                 Test
             </div>
         </div>


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
### Problem
During the Tailwind CSS v4 migration (#1118), the background opacity syntax was incorrectly converted. The old `bg-opacity-50` utility was changed to `bg-opacity/50`, which is invalid in Tailwind v4.

This caused modal overlays and semi-transparent backgrounds to appear as **solid black** instead of semi-transparent.

### Solution
Fixed the opacity syntax across 21 files to use the correct Tailwind v4 format.

**Before (incorrect):**
```svelte
<div class="bg-black bg-opacity/50">
```

**After (correct):**
```svelte
<div class="bg-black/50">
```

### Svelte Class Directive Limitation
Tailwind v4's new slash syntax (`bg-color/50`) is not compatible with Svelte's `class:` directive because slashes are not supported in class names within the directive.

This is a known issue discussed in the Tailwind CSS repository:
- [tailwindlabs/tailwindcss#15310](https://github.com/tailwindlabs/tailwindcss/discussions/15310) - *[v4] New color opacity syntax not working with Svelte class directives*

**Does not work:**
```svelte
<div class:bg-red-700/20={condition}>
```

**Workaround - use string interpolation:**
```svelte
<div class="base-classes {
  condition === 'red' ? 'bg-red-700/20' :
  condition === 'blue' ? 'bg-blue-700/20' :
  'bg-darkbg/20'
}">
```

### Files Changed (21 files)
- `AlertComp.svelte` - Main modal overlay for character creation menu
- `PluginAlertModal.svelte`
- `ChatList.svelte`
- `BookmarkList.svelte`
- `RealmUpload.svelte`, `RealmPopUp.svelte`, `RealmMain.svelte`
- `OpenrouterProviderList.svelte`, `ModelList.svelte`
- `TriggerList2.svelte`
- `UserSettings.svelte`, `PluginSettings.svelte`, `CustomGUISettingMenu.svelte`
- `lorepreset.svelte`, `listedPersona.svelte`, `botpreset.svelte`
- `ModuleChatMenu.svelte`
- `ResizeBox.svelte`, `VisualNovelChat.svelte`
- `SidebarAvatar.svelte`, `Sidebar.svelte`