### PR TITLE
fix: resolve Svelte console_log_state warning in Chats.svelte

### DIFF
--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -113,7 +113,7 @@
             `Hashes: ${hashes.size}`,
             `Current Hashes: ${currentHashes.size}`,
             `Removed: ${toRemove.size}`,
-            messages
+            $state.snapshot(messages)
         );
 
         hashes = currentHashes;


### PR DESCRIPTION
Use $state.snapshot() to properly log $state proxy values in console.log

# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
### Problem
The following Svelte warning was appearing in the console:

```
Chats.svelte:111 [svelte] console_log_state
Your `console.log` contained `$state` proxies. Consider using `$inspect(...)` or `$state.snapshot(...)` instead
https://svelte.dev/e/console_log_state
```

This warning occurs because `messages` (passed via `$props()`) is a `$state` proxy, and logging proxies directly doesn't show the actual values properly.

### Solution
Wrapped `messages` with `$state.snapshot()` to convert the proxy to a plain JavaScript object before logging.

```diff
- messages
+ $state.snapshot(messages)
```

### Why `$state.snapshot()` instead of `$inspect()`?
- `$inspect()`: Reactively logs every time the value changes (for continuous debugging)
- `$state.snapshot()`: One-time snapshot of the current value (for point-in-time logging)

Since this is inside an update function where we only want to log once per update cycle, `$state.snapshot()` is the appropriate choice.

## Files Changed
- `src/lib/ChatScreens/Chats.svelte`