### PR TITLE
fix: add left padding to SliderInput checkbox for Tailwind v4 compatibility

### DIFF
--- a/src/lib/UI/GUI/SliderInput.svelte
+++ b/src/lib/UI/GUI/SliderInput.svelte
@@ -12,7 +12,7 @@
 <div class="w-full flex" class:mb-4={marginBottom}>
   {#if disableable}
 
-    <div class="relative h-8 border-darkborderc border rounded-full cursor-pointer rounded-r-none border-r-0 flex justify-center items-center">
+    <div class="relative h-8 border-darkborderc border rounded-full cursor-pointer rounded-r-none border-r-0 flex justify-center items-center pl-2">
       <CheckInput check={value !== -1000 && value !== undefined} margin={false} onChange={(c) => {
         onchange?.()
         if(c) {


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
### Problem
After the Tailwind v4 migration (#1118), the checkbox in `SliderInput` component appears misaligned, extending beyond the rounded border on the left side.

This is caused by a behavior change in Tailwind v4: In Tailwind v3, elements with `hidden` class were still included in gap calculations, but in v4 this was fixed so hidden elements no longer affect spacing.

Since `CheckInput` uses a hidden `<input>` element, the gap that previously existed between the hidden input and the visible checkbox span is now removed, causing the checkbox to touch the left border.

Related issue: https://github.com/kwaroran/Risuai/issues/1122

### Solution
Added `pl-2` (left padding) to the checkbox container div in `SliderInput.svelte`. This provides proper spacing from the rounded left border.

### Changes
- `src/lib/UI/GUI/SliderInput.svelte`: Added `pl-2` class to the checkbox container div