### PR TITLE
fix: improve type conversion for Additional Parameters values

### DIFF
--- a/src/ts/process/request/openAI.ts
+++ b/src/ts/process/request/openAI.ts
@@ -673,6 +673,9 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
                     body[key] = JSON.parse(value)                            
                 } catch (error) {}
             }
+            else if((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))){
+                body = setObjectValue(body, key, value.slice(1, -1))
+            }
             else if(value === 'true' || value === 'false'){
                 body = setObjectValue(body, key, value === 'true')
             }


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR improves the type conversion logic for Additional Parameters in Custom API settings.

Fixes: https://discord.com/channels/1108412316619391006/1449359909442424862 (Risuai community)

### Changes

1. **Added boolean support (`true`/`false`)**
   - Values `true` and `false` are now converted to boolean instead of remaining as strings

2. **Added null support**
   - Value `null` is now converted to actual `null` instead of string `"null"`

3. **Fixed parseFloat issue by replacing with Number()**
   - The previous implementation used `parseFloat()` which has an issue with partial number parsing

### Problem with parseFloat

`parseFloat()` parses the beginning of a string and ignores trailing non-numeric characters:

```javascript
// Previous behavior (parseFloat)
parseFloat("123")     // 123 ✓
parseFloat("3.14")    // 3.14 ✓
parseFloat("123abc")  // 123 ⚠️ Wrong! Should be treated as string
parseFloat("abc123")  // NaN

// New behavior (Number)
Number("123")         // 123 ✓
Number("3.14")        // 3.14 ✓
Number("123abc")      // NaN ✓ Correctly treated as string
Number("abc123")      // NaN ✓
```

### Type conversion summary

| Input | Result |
|-------|--------|
| `{{none}}` | Delete key |
| `header::X-Key` | Set header |
| `json::[1,2,3]` | JSON parse |
| `true` / `false` | boolean |
| `null` | null |
| `123`, `3.14` | number |
| Other | string |
