### PR TITLE
Fix: Deepseek reasoning model reasoning content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,7 @@ dist.zip
 /scripts/
 .env
 /server/node/ssl/certificate
-/backup
-backup-init.sh
-backup-now.sh
+
 
 # Due to Cargo.lock makes the project build fail, we ignore it
 Cargo.lock


### PR DESCRIPTION
# PR Checklist
- [V] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Deepseek-Reasoner model from Deepseek Probider couldn't show Reasoning contents, so I fixed it
It send reasoning content in choices[0].message.reasoning_content, not choices[0].reasoning_content, but I keep original one for prevent unexpected bug