### PR TITLE
fix: Help Icon Vertical Alignment and Spacing

### DIFF
--- a/src/lib/Others/Help.svelte
+++ b/src/lib/Others/Help.svelte
@@ -1,4 +1,4 @@
-<button title={name+' '+language.showHelp} class="relative help inline-block cursor-default hover:text-green-500" onclick={() => {
+<button title={name+' '+language.showHelp} class="relative help inline-block align-middle cursor-default hover:text-green-500" onclick={() => {
     alertMd(language.help[key])
 }}>
     

--- a/src/lib/UI/GUI/CheckInput.svelte
+++ b/src/lib/UI/GUI/CheckInput.svelte
@@ -32,7 +32,7 @@
     aria-labelledby="{name} {check ? 'abled' : 'disabled'}"
 >
     {#if reverse}
-        <span>{name}{@render children?.()}</span>
+        <span>{name} {@render children?.()}</span>
     {/if}
     <input 
         class="hidden" 
@@ -58,6 +58,6 @@
         {/if}
     </span>
     {#if !hiddenName && !reverse}
-        <span>{name}{@render children?.()}</span>
+        <span>{name} {@render children?.()}</span>
     {/if}
 </label>


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fix help icons appearing slightly misaligned (floating above text) in Advanced Settings
- Add proper spacing between checkbox labels and help icons

## Before / After

### Before
<img width="196" height="73" alt="Screenshot 2025-12-30 002339" src="https://github.com/user-attachments/assets/00548f59-ef96-4bd5-b059-5cd65536c07b" />

### After
<img width="185" height="81" alt="Screenshot 2025-12-30 002319" src="https://github.com/user-attachments/assets/df317d6c-0f61-4e54-bd9b-fb34bbbc496e" />

## Changes

### `src/lib/Others/Help.svelte`
- Added `align-middle` class to the help button for proper vertical centering with inline text

### `src/lib/UI/GUI/CheckInput.svelte`
- Added space between `{name}` and `{@render children?.()}` to ensure consistent spacing between label text and help icons


