### PR TITLE
fix: TTS mode default value mismatch

### DIFF
--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -611,6 +611,11 @@ export function characterFormatUpdate(indexOrCharacter:number|character, arg:{
         if(!cha.newGenData){
             cha = updateInlayScreen(cha)
         }
+        // Migrate legacy 'none' value to '' for UI dropdown compatibility
+        // Using '' because it's falsy, so `if (ttsMode)` correctly detects enabled TTS
+        if (cha.ttsMode === 'none') {
+            cha.ttsMode = ''
+        }
         cha.ttsMode ??= ''
     }
     else{


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fix TTS dropdown showing blank/unselected state instead of "Disabled" for new or existing characters
- Migrate legacy `'none'` value to empty string `''`

## Problem

The TTS mode was previously initialized with `'none'`, but the UI dropdown expects empty string `''` for disabled state:

```html
<OptionInput value="">{language.disabled}</OptionInput>
```

This mismatch caused the dropdown to not match any option, resulting in a blank selection.

## Why use `''` instead of `'none'`?

Empty string is **falsy** in JavaScript, while `'none'` is **truthy**. This matters because the codebase uses boolean checks like:

```svelte
{#if ttsMode}
    <!-- show TTS options -->
{/if}
```

Using `''` allows these checks to work correctly - disabled TTS is falsy, enabled TTS modes are truthy.

## Solution

Added migration code to convert legacy `'none'` values to `''`:

```typescript
// Migrate legacy 'none' value to '' for UI dropdown compatibility
// Using '' because it's falsy, so `if (ttsMode)` correctly detects enabled TTS
if (cha.ttsMode === 'none') {
    cha.ttsMode = ''
}
cha.ttsMode ??= ''
```

## Before / After

### Before
<img width="380" height="122" alt="Screenshot 2025-12-30 005911" src="https://github.com/user-attachments/assets/cdc2a85b-5d23-42d4-b6e9-036070233b8b" />

### After
<img width="379" height="124" alt="Screenshot 2025-12-30 005831" src="https://github.com/user-attachments/assets/87add4a6-ec3a-4680-82ae-1bd813b63d57" />
