### PR TITLE
fix: sidebar bot drag triggering import error

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -38,6 +38,9 @@
     e.dataTransfer.dropEffect = 'link'
 }} ondrop={async (e) => {
     e.preventDefault()
+    if (e.dataTransfer.types.includes('application/x-risu-internal')) {
+        return
+    }
     const file = e.dataTransfer.files[0]
     if (file) {
         await importCharacterProcess({

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -269,6 +269,7 @@
   }
   const avatarDragStart = (ind:DragData, e:DragEv) => {
     e.dataTransfer.setData('text/plain', '');
+    e.dataTransfer.setData('application/x-risu-internal', 'true');
     currentDrag = ind
     const avatar = e.currentTarget.querySelector('.avatar')
     if(avatar){


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fix "There is no data in file, or the file is corrupted" error when dragging bots in the sidebar
- Prevent internal drag-and-drop from triggering file import logic

## Problem

When dragging a bot avatar in the left sidebar to reorder it, users encountered the error message:

> "There is no data in file, or the file is corrupted" (`language.errors.noData`)
<img width="345" height="130" alt="Screenshot 2025-12-30 011356" src="https://github.com/user-attachments/assets/fcc1c434-4fd4-4e3f-96e9-fc61d77871ec" />


This happened because the drag event bubbled up to the global drop handler in `App.svelte`, which attempted to import the dragged content as a character file.

## Root Cause

Two handlers were conflicting:

1. **Sidebar.svelte**: Internal drag-and-drop for reordering bots
2. **App.svelte**: Global drop handler for importing character files from external sources

```svelte
<!-- App.svelte - Global drop handler -->
<main ondrop={async (e) => {
    e.preventDefault()
    const file = e.dataTransfer.files[0]
    if (file) {
        await importCharacterProcess({  // This was called for internal drags!
            name: file.name,
            data: file
        })
    }
}}>
```

When dragging an avatar image in the sidebar, the browser could add image data to `e.dataTransfer.files`. Since sidebar drop handlers didn't stop event propagation, the event bubbled up to `App.svelte`, triggering `importCharacterProcess` with invalid data.

## Solution

Mark internal drags with a custom data transfer type and filter them out in the global handler:

**Sidebar.svelte** - Mark drag as internal:
```javascript
const avatarDragStart = (ind:DragData, e:DragEv) => {
    e.dataTransfer.setData('text/plain', '');
    e.dataTransfer.setData('application/x-risu-internal', 'true');  // Added
    currentDrag = ind
    // ...
}
```

**App.svelte** - Skip internal drags:
```javascript
ondrop={async (e) => {
    e.preventDefault()
    if (e.dataTransfer.types.includes('application/x-risu-internal')) {
        return  // Skip internal sidebar drags
    }
    const file = e.dataTransfer.files[0]
    // ...
}}
```

## Why This Approach?

Instead of adding `e.stopPropagation()` to every inline drop handler in Sidebar.svelte (6+ locations), this solution:

1. Requires changes in only 2 places
2. Clearly distinguishes internal vs external drag operations
3. Is more maintainable as sidebar code evolves
