### PR TITLE
fix: sidebar folder background overflow on right edge

### DIFF
--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -569,7 +569,7 @@
       {#if char.type === 'folder' && openFolders.includes(char.id)}
         {#key char.color}
         <div class="p-1 flex flex-col items-center py-1 mt-1 rounded-lg relative">
-          <div class="absolute top-0 left-1 border border-selected w-full h-full rounded-lg z-0 {
+          <div class="absolute top-0 left-1 right-1 border border-selected h-full rounded-lg z-0 {
             char.color === 'red' ? 'bg-red-700/20' :
             char.color === 'yellow' ? 'bg-yellow-700/20' :
             char.color === 'green' ? 'bg-green-700/20' :


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
## Before / After

### Before
<img width="114" height="183" alt="Screenshot 2025-12-30 021751" src="https://github.com/user-attachments/assets/3c4c123c-77c3-4dba-974f-ef42659d96e8" />

### After
<img width="116" height="183" alt="Screenshot 2025-12-30 021810" src="https://github.com/user-attachments/assets/81bb2a97-b426-4df3-891d-a9b8fdd4833a" />

## Problem

When expanding a folder in the sidebar, the background div had asymmetric margins:
- Used `left-1` to add 0.25rem margin on the left
- Used `w-full` (100% width) which caused the background to overflow by 0.25rem on the right

```
Container:  |<-------- 100% -------->|
Background:   left-1|<-------- 100% -------->| ← Overflows right!
```

## Solution

Replaced `w-full` with `right-1` to create symmetric margins on both sides:

```diff
- <div class="absolute top-0 left-1 border border-selected w-full h-full rounded-lg z-0 ...">
+ <div class="absolute top-0 left-1 right-1 border border-selected h-full rounded-lg z-0 ...">
```

Now the background respects both left and right margins equally.

## Changes

### `src/lib/SideBars/Sidebar.svelte`
- Changed folder background div from `left-1 w-full` to `left-1 right-1` for symmetric margins
