### PR TITLE
fix: Long Term Memory UI spacing and add embedding help tooltip and 

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -180,6 +180,15 @@ export const languageChinese = {
         openrouterProviderIgnore: "忽略此列表中的提供商，若所有提供商都被忽略，请求将会失败。详见 https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
         additionalPrompt:
             "启用提示词预处理时，这段文本会添加到主提示词的末尾。默认值是 'The assistant must act as {{char}}. user is {{user}}.'，用于设置基本的角色扮演背景。",
+        embedding:
+            "嵌入模型用于多个功能中的相似度搜索：\n\n" +
+            "- **长期记忆**: HypaV2, HypaV3, Hanurai Memory 和 SupaMemory (启用 HypaMemory 时)\n" +
+            "- **附加文本**: 基于上下文匹配角色附加信息\n" +
+            "- **动态资产**: 当未找到精确匹配时查找相似的资产名称\n" +
+            "- **情感图片**: 当情感方式设置为 'embedding' 时\n" +
+            "- **触发脚本**: 触发脚本中的相似度条件\n" +
+            "- **文件附件**: 在 PDF/TXT/XML 附件中搜索\n" +
+            "- **Playground**: Playground 中的嵌入测试",
     },
     setup: {
         chooseProvider: "选择 AI 提供者",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -215,6 +215,15 @@ export const languageGerman = {
             "Ignorieren Sie die Anbieter in dieser Liste. Wenn alle Anbieter ignoriert werden, schlägt die Anfrage fehl. Siehe Details unter https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
         additionalPrompt:
             "Text, der am Ende der Haupt-Anweisung angehängt wird, wenn die Anweisungsvorverarbeitung aktiviert ist. Der Standardwert ist 'The assistant must act as {{char}}. user is {{user}}.' Dies hilft, den grundlegenden Rollenspielkontext einzurichten.",
+        embedding:
+            "Das Embedding-Modell wird für die Ähnlichkeitssuche in mehreren Funktionen verwendet:\n\n" +
+            "- **Langzeitgedächtnis**: HypaV2, HypaV3, Hanurai Memory und SupaMemory (bei aktiviertem HypaMemory)\n" +
+            "- **Zusätzlicher Text**: Abgleich zusätzlicher Charakterinformationen basierend auf dem Kontext\n" +
+            "- **Dynamische Assets**: Finden ähnlicher Asset-Namen, wenn keine exakte Übereinstimmung gefunden wird\n" +
+            "- **Emotionsbilder**: Wenn die Emotionsmethode auf 'Embedding' gesetzt ist\n" +
+            "- **Trigger-Skripte**: Ähnlichkeitsbedingungen in Trigger-Skripten\n" +
+            "- **Dateianhänge**: Suche in PDF/TXT/XML-Anhängen\n" +
+            "- **Playground**: Embedding-Tests im Playground",
     },
     setup: {
         chooseProvider: "Wählen Sie Ihren AI-Anbieter aus",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -238,6 +238,15 @@ export const languageEnglish = {
             "Ignore the providers in this list, if all the provider is ingored, the request will failed. See detail on https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
         additionalPrompt:
             "Text that gets appended to the Main Prompt when Prompt Preprocess is enabled. Default is 'The assistant must act as {{char}}. user is {{user}}.' This helps set up basic roleplay context.",
+        embedding:
+            "Embedding model is used for similarity search across multiple features:\n\n" +
+            "- **Long Term Memory**: HypaV2, HypaV3, Hanurai Memory, and SupaMemory (with HypaMemory enabled)\n" +
+            "- **Additional Text**: Matching character additional info based on context\n" +
+            "- **Dynamic Assets**: Finding similar asset names when exact match is not found\n" +
+            "- **Emotion Images**: When Emotion method is set to 'embedding'\n" +
+            "- **Trigger Scripts**: Similarity conditions in trigger scripts\n" +
+            "- **File Attachments**: Searching within PDF/TXT/XML attachments\n" +
+            "- **Playground**: Embedding testing in Playground",
     },
     setup: {
         chooseProvider: "Choose AI Provider",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -207,6 +207,15 @@ export const languageSpanish = {
             "Ignorar los proveedores en esta lista, si todos los proveedores son ignorados, la solicitud fallará. Ver detalles en https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
         additionalPrompt:
             "Texto que se agrega al final del Prompt Principal cuando el Preprocesamiento de Prompt está habilitado. El valor predeterminado es 'The assistant must act as {{char}}. user is {{user}}.' Esto ayuda a establecer el contexto básico del juego de roles.",
+        embedding:
+            "El modelo de incrustación (embedding) se utiliza para la búsqueda de similitud en múltiples características:\n\n" +
+            "- **Memoria a Largo Plazo**: HypaV2, HypaV3, Memoria Hanurai y SupaMemory (con HypaMemory habilitado)\n" +
+            "- **Texto Adicional**: Coincidencia de información adicional del personaje basada en el contexto\n" +
+            "- **Activos Dinámicos**: Encontrar nombres de activos similares cuando no se encuentra una coincidencia exacta\n" +
+            "- **Imágenes de Emoción**: Cuando el método de Emoción está configurado en 'embedding'\n" +
+            "- **Scripts de Activación**: Condiciones de similitud en scripts de activación\n" +
+            "- **Archivos Adjuntos**: Búsqueda dentro de archivos adjuntos PDF/TXT/XML\n" +
+            "- **Playground**: Pruebas de incrustación en Playground",
     },
     setup: {
         chooseProvider: "Elige Proveedor de IA",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -191,6 +191,15 @@ export const languageKorean = {
             "이 목록의 제공자를 무시합니다. 모든 제공자가 무시되면 요청이 실패합니다. 자세한 내용은 https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers 를 참조하세요",
         additionalPrompt:
             "프롬프트 선보정이 활성화되어 있을 때 메인 프롬프트 끝에 추가되는 텍스트입니다. 기본값은 'The assistant must act as {{char}}. user is {{user}}.'이며, 이를 통해 기본적인 롤플레이 맥락을 설정합니다.",
+        embedding:
+            "임베딩 모델은 여러 기능에서 유사도 검색에 사용됩니다:\n\n" +
+            "- **장기 기억**: HypaV2, HypaV3, Hanurai Memory, SupaMemory (HypaMemory 활성화 시)\n" +
+            "- **추가 텍스트**: 컨텍스트 기반 캐릭터 추가 정보 매칭\n" +
+            "- **동적 에셋**: 정확한 에셋 이름을 찾지 못했을 때 유사한 이름 검색\n" +
+            "- **감정 이미지**: 감정 방식이 'embedding'으로 설정된 경우\n" +
+            "- **트리거 스크립트**: 트리거 스크립트의 유사도 조건\n" +
+            "- **파일 첨부**: PDF/TXT/XML 첨부 파일 내 검색\n" +
+            "- **Playground**: Playground에서 임베딩 테스트",
     },
     setup: {
         chooseProvider: "AI 제공자를 선택해 주세요",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -200,6 +200,15 @@ export const LanguageVietnamese = {
             "Bỏ qua các nhà cung cấp trong danh sách này, nếu tất cả các nhà cung cấp bị bỏ qua, yêu cầu sẽ thất bại. Xem chi tiết tại https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
         additionalPrompt:
             "Văn bản được thêm vào cuối Lời nhắc chính khi Tiền xử lý lời nhắc được bật. Mặc định là 'The assistant must act as {{char}}. user is {{user}}.' Điều này giúp thiết lập ngữ cảnh nhập vai cơ bản.",
+        embedding:
+            "Mô hình nhúng được sử dụng cho tìm kiếm tương đồng trên nhiều tính năng:\n\n" +
+            "- **Bộ nhớ dài hạn**: HypaV2, HypaV3, Bộ nhớ Hanurai và SupaMemory (khi bật HypaMemory)\n" +
+            "- **Văn bản bổ sung**: Khớp thông tin bổ sung của nhân vật dựa trên ngữ cảnh\n" +
+            "- **Tài sản động**: Tìm tên tài sản tương tự khi không tìm thấy kết quả khớp chính xác\n" +
+            "- **Hình ảnh cảm xúc**: Khi phương pháp Cảm xúc được đặt thành 'embedding'\n" +
+            "- **Tập lệnh kích hoạt**: Các điều kiện tương đồng trong tập lệnh kích hoạt\n" +
+            "- **Tệp đính kèm**: Tìm kiếm trong các tệp đính kèm PDF/TXT/XML\n" +
+            "- **Playground**: Thử nghiệm nhúng trong Playground",
     },
     setup: {
         chooseProvider: "Chọn nhà cung cấp AI",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -181,6 +181,15 @@ export const languageChineseTraditional = {
             "忽略此列表中的提供商,若所有提供商均被忽略,請求將失敗。詳情請參閱 https://openrouter.ai/docs/guides/routing/provider-selection#ignoring-providers",
         additionalPrompt:
             "啟用提示詞預處理時，這段文字會加在主要提示詞的末尾。預設值是 'The assistant must act as {{char}}. user is {{user}}.'，用於設定基本的角色扮演情境。",
+        embedding:
+            "嵌入模型用於多個功能中的相似度搜尋：\n\n" +
+            "- **長期記憶**: HypaV2, HypaV3, Hanurai Memory 和 SupaMemory (啟用 HypaMemory 時)\n" +
+            "- **附加文本**: 基於上下文匹配角色附加資訊\n" +
+            "- **動態資源**: 當未找到精確匹配時尋找相似的資源名稱\n" +
+            "- **情感圖片**: 當情感方式設定為 'embedding' 時\n" +
+            "- **觸發腳本**: 觸發腳本中的相似度條件\n" +
+            "- **檔案附件**: 在 PDF/TXT/XML 附件中搜尋\n" +
+            "- **Playground**: Playground 中的嵌入測試",
     },
     setup: {
         chooseProvider: "選擇 AI 提供者",

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -680,7 +680,7 @@
     <Arcodion name={language.longTermMemory} styled disabled={submenu !== -1}>
         <span class="text-textcolor mt-4">{language.type}</span>
 
-        <SelectInput value={
+        <SelectInput className="mb-4" value={
             DBState.db.hypaV3 ? 'hypaV3' :
             DBState.db.hypav2 ? 'hypaV2' :
             DBState.db.supaModelType !== 'none' ? 'supaMemory' :
@@ -731,7 +731,7 @@
             <span class="mb-2 text-textcolor2 text-sm text-wrap wrap-break-word max-w-full">{language.hanuraiDesc}</span>
             <span>Chunk Size</span>
             <NumberInput size="sm" marginBottom bind:value={DBState.db.hanuraiTokens} min={100} />
-            <div class="flex">
+            <div class="flex mb-4">
                 <Check bind:check={DBState.db.hanuraiSplit} name="Text Spliting"/>
             </div>
         {:else if DBState.db.hypav2}
@@ -963,12 +963,12 @@
                 <span class="text-textcolor">{language.SuperMemory} Prompt</span>
                 <TextInput size="sm" marginBottom bind:value={DBState.db.supaMemoryPrompt} placeholder="Leave it blank to use default"/>
             {/if}
-            <div class="flex">
+            <div class="flex mb-4">
                 <Check bind:check={DBState.db.hypaMemory} name={language.enable + ' ' + language.HypaMemory}/>
             </div>
         {/if}
 
-        <span class="text-textcolor">{language.embedding}</span>
+        <span class="text-textcolor">{language.embedding} <Help key="embedding"/></span>
         <SelectInput className="mb-4" bind:value={DBState.db.hypaModel}>
             {#if 'gpu' in navigator}
                 <OptionInput value="MiniLMGPU">MiniLM L6 v2 (GPU)</OptionInput>


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
## Before
<img width="392" height="271" alt="Screenshot 2025-12-30 030016" src="https://github.com/user-attachments/assets/fbafc508-6c14-40af-bb45-84d2173dadc4" />

## After
<img width="386" height="281" alt="Screenshot 2025-12-30 030030" src="https://github.com/user-attachments/assets/08e5dd9f-bfdd-45f0-b4f3-957ccc986305" />

## Problem

1. **Embedding dropdown lacks context**: The Embedding dropdown in Other Bots > Long Term Memory settings was always visible regardless of the selected memory Type (including "None"). Users might wonder why it's shown when Long Term Memory is disabled.

2. **Investigation revealed**: Embedding is used by many features beyond Long Term Memory:
   - Long Term Memory (HypaV2, HypaV3, Hanurai, SupaMemory with HypaMemory)
   - Additional Text matching
   - Dynamic Assets name search
   - Emotion Images (when method is "embedding")
   - Trigger Scripts similarity conditions
   - File Attachments search (PDF/TXT/XML)
   - Playground embedding testing

3. **UI spacing inconsistency**: The Type dropdown and memory type sections had inconsistent spacing compared to other settings.

## Solution

1. **Added help tooltip for Embedding**: Added a Help icon next to the Embedding label that explains all the features that use the embedding model. This clarifies why the setting is always visible.

2. **Fixed UI spacing**:
   - Added `className="mb-4"` to Type SelectInput
   - Added `mb-4` to Hanurai Memory section's last element
   - Added `mb-4` to SupaMemory section's last element

## Files Changed

- `src/lang/en.ts` - Added `embedding` help text
- `src/lang/ko.ts` - Added Korean translation for embedding help
- `src/lang/cn.ts` - Added Chinese (Simplified) translation
- `src/lang/zh-Hant.ts` - Added Chinese (Traditional) translation
- `src/lang/de.ts` - Added German translation
- `src/lang/es.ts` - Added Spanish translation
- `src/lang/vi.ts` - Added Vietnamese translation
- `src/lib/Setting/Pages/OtherBotSettings.svelte` - Added Help component and fixed spacing