### PR TITLE
feat: Add drag-drop import support for .risup and .risum files

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,8 @@
     import { showRealmInfoStore, importCharacterProcess } from './ts/characterCards';
     import { importPreset, getDatabase, setDatabase } from './ts/storage/database.svelte';
     import { readModule } from './ts/process/modules';
+    import { alertNormal } from './ts/alert';
+    import { language } from './lang';
     import RealmFrame from './lib/UI/Realm/RealmFrame.svelte';
     import SavePopupIconComp from './lib/Others/SavePopupIcon.svelte';
     import Botpreset from './lib/Setting/botpreset.svelte';
@@ -47,12 +49,14 @@
         if (name.endsWith('.risup')) {
             const data = new Uint8Array(await file.arrayBuffer())
             await importPreset({ name: file.name, data })
+            alertNormal(language.successImport)
         } else if (name.endsWith('.risum')) {
             const data = new Uint8Array(await file.arrayBuffer())
             const module = await readModule(Buffer.from(data))
             const db = getDatabase()
             db.modules.push(module)
             setDatabase(db)
+            alertNormal(language.successImport)
         } else {
             await importCharacterProcess({
                 name: file.name,


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Extends the existing drag-and-drop file import functionality to support preset (`.risup`) and module (`.risum`) files, in addition to the existing character file import.

### Changes
- Added file extension detection in the `ondrop` handler in `App.svelte`
- `.risup` files are now imported using `importPreset()`
- `.risum` files are now imported using `readModule()` and saved to database
- Other files fall back to the existing `importCharacterProcess()` behavior
- Added success notification after preset/module import

### Files Modified
- `src/App.svelte`

### How it works
When a file is dropped onto the application:
1. Check the file extension (case-insensitive)
2. If `.risup` → import as prompt preset
3. If `.risum` → import as module
4. Otherwise → import as character file (existing behavior)
