### PR TITLE
fix: Welcome Screen Hamburger Menu Errors

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -169,7 +169,7 @@
 
     async function handleButtonTriggerWithin(event: UIEvent) {
         const currentChar = getCurrentCharacter()
-        if(currentChar.type === 'group'){
+        if(!currentChar || currentChar.type === 'group'){
             return
         }
 
@@ -391,14 +391,20 @@
             <div class="flex items-center ml-2 gap-2">
                 {#if window.innerWidth >= 640}
                     {@render majorIconButtonsBody(false)}
-                    <PopupButton>
-                        {@render minorIconButtonsBody(true)}
-                    </PopupButton>
+                    {#if DBState.db.characters[selIdState.selId]}
+                        <PopupButton>
+                            {@render minorIconButtonsBody(true)}
+                        </PopupButton>
+                    {/if}
                 {:else}
-                    <PopupButton>
-                        {@render majorIconButtonsBody(true)}
-                        {@render minorIconButtonsBody(true)}
-                    </PopupButton>
+                    {#if DBState.db.characters[selIdState.selId]}
+                        <PopupButton>
+                            {@render majorIconButtonsBody(true)}
+                            {@render minorIconButtonsBody(true)}
+                        </PopupButton>
+                    {:else}
+                        {@render majorIconButtonsBody(false)}
+                    {/if}
                 {/if}
                 {@render rerolls()}
 


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fix TypeError when clicking hamburger menu button on welcome screen
- Fix TypeError when clicking any button inside the hamburger menu on welcome screen

## Before
<img width="571" height="531" alt="Screenshot 2025-12-30 175418" src="https://github.com/user-attachments/assets/22b6d728-24f1-449f-af25-6f4fee95772c" />

## After
<img width="598" height="118" alt="Screenshot 2025-12-30 175505" src="https://github.com/user-attachments/assets/266bbcad-34b1-4de2-ba96-f5b00370f331" />


## Problem

On the welcome screen, no character is selected, so `getCurrentCharacter()` returns `undefined` and `DBState.db.characters[selIdState.selId]` is also `undefined`. This caused errors when:

1. Clicking the hamburger menu area triggered `handleButtonTriggerWithin` which tried to access `currentChar.type`
2. Clicking buttons inside the hamburger menu (branch, disable message, etc.) tried to access `.chats` on undefined

## Changes

### `src/lib/ChatScreens/Chat.svelte`

#### `handleButtonTriggerWithin` function
- Added null check for `currentChar` before accessing `.type` property

#### Hamburger menu visibility
- Hide `PopupButton` (hamburger menu containing minor buttons) when no character is selected
- On mobile: show `majorIconButtonsBody` directly without popup when no character is selected
- On desktop: hide the popup button entirely when no character is selected
