### PR TITLE
fix: playground chat errors

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -1011,6 +1011,10 @@
                             <span>{DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].role === 'char' ? 'Assistant' : 'User'}</span>
                             <button class="ml-2 text-textcolor2 hover:text-textcolor" onclick={() => {
                                 DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].role = DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].role === 'char' ? 'user' : 'char'
+                                ReloadChatPointer.update((v) => {
+                                    v[idx] = (v[idx] ?? 0) + 1
+                                    return v
+                                })
                             }}><ArrowLeftRightIcon size="18" /></button>
                         </span>
                     {:else if !blankMessage && !$HideIconStore}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fix TypeError when clicking "New Chat" in playground
- Fix role toggle button (User/Assistant) not updating UI immediately

## Changes

### `src/lib/ChatScreens/Chat.svelte`

#### Fix 1: New Chat Error
- Added null check for `message[idx]` in the playground role toggle UI condition
- Prevents `Cannot read properties of undefined (reading 'role')` error when creating a new empty chat

#### Fix 2: Role Toggle UI Not Updating
- Added `ReloadChatPointer.update()` after changing the message role
- Previously, clicking the role toggle button would update the database but not refresh the UI
- Users had to switch chats and come back to see the change
