### PR TITLE
fix: welcome screen API key validation feedback

### DIFF
--- a/src/lib/Others/WelcomeRisu.svelte
+++ b/src/lib/Others/WelcomeRisu.svelte
@@ -6,6 +6,7 @@
     import Chat from "../ChatScreens/Chat.svelte";
     import { prebuiltPresets } from "src/ts/process/templates/templates";
     import { updateTextThemeAndCSS } from "src/ts/gui/colorscheme";
+    import { alertError } from "src/ts/alert";
     import Airisu from '../../etc/Airisu.webp'
 
     const airisuStyle = `background: url("${Airisu}");background-size: cover;`
@@ -46,27 +47,25 @@
                 break
             }
             case 4:{
+                if(input.length === 0){
+                    break
+                }
+                if(!input.startsWith('sk-')){
+                    alertError('Invalid API key')
+                    break
+                }
                 if(provider === 'openai'){
-                    if(input.length > 0 && input.startsWith('sk-')){
-                        DBState.db.openAIKey = input
-                        step = 5
-                        input = ''
-                    }
+                    DBState.db.openAIKey = input
                 }
                 if(provider === 'openrouter'){
-                    if(input.length > 0 && input.startsWith('sk-')){
-                        DBState.db.openrouterKey = input
-                        step = 5
-                        input = ''
-                    }
+                    DBState.db.openrouterKey = input
                 }
                 if(provider === 'claude'){
-                    if(input.length > 0 && input.startsWith('sk-')){
-                        DBState.db.claudeAPIKey = input
-                        step = 5
-                        input = ''
-                    }
+                    DBState.db.claudeAPIKey = input
                 }
+                step = 5
+                input = ''
+                break
             }
         }
     }


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Fix send button doing nothing when entering an invalid API key on the welcome screen
- Add error message when API key doesn't start with 'sk-'

## Problem

On the welcome screen setup wizard, when users entered an API key that didn't start with 'sk-', pressing the send button did nothing. There was no feedback to indicate why the key was rejected, leaving users confused.

## Changes

### `src/lib/Others/WelcomeRisu.svelte`

- Refactored case 4 (API key input step) to validate input first before checking provider
- Added `alertError('Invalid API key')` when the API key doesn't start with 'sk-'
- Simplified the code by removing redundant nested conditions
- Added proper `break` statements to prevent fall-through
