### PR TITLE
feat: Add tokenizer selector to playground

### DIFF
--- a/src/lib/Playground/PlaygroundTokenizer.svelte
+++ b/src/lib/Playground/PlaygroundTokenizer.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
-    import { encode } from "src/ts/tokenizer";
+    import { encodeWithTokenizer, tokenizerList } from "src/ts/tokenizer";
     import TextAreaInput from "../UI/GUI/TextAreaInput.svelte";
+    import SelectInput from "../UI/GUI/SelectInput.svelte";
     import { language } from 'src/lang';
 
     let input = $state("");
     let output = $state("");
     let outputLength = $state(0);
-    let time = $state(0)
+    let time = $state(0);
+    let selectedTokenizer = $state("tik");
+
     const onInput = async () => {
         try {
             const start = performance.now();
-            const tokenized = await encode(input);
+            const tokenized = await encodeWithTokenizer(input, selectedTokenizer);
             time = performance.now() - start;
             const tokenizedNumArray = Array.from(tokenized)
             outputLength = tokenizedNumArray.length;
@@ -19,9 +22,23 @@
             output = `Error: ${e}`
         }
     }
+
+    const onTokenizerChange = () => {
+        if (input) {
+            onInput();
+        }
+    }
 </script>
 
 <h2 class="text-4xl text-textcolor my-6 font-black relative">{language.tokenizer}</h2>
+
+<span class="text-textcolor text-lg">Tokenizer</span>
+
+<SelectInput bind:value={selectedTokenizer} onchange={onTokenizerChange}>
+    {#each tokenizerList as [value, label]}
+        <option {value} class="bg-bgcolor">{label}</option>
+    {/each}
+</SelectInput>
 
 <span class="text-textcolor text-lg">Input</span>
 

--- a/src/ts/tokenizer.ts
+++ b/src/ts/tokenizer.ts
@@ -42,6 +42,33 @@ export const tokenizerList = [
     ['deepseek', 'DeepSeek'],
 ] as const
 
+export async function encodeWithTokenizer(data: string, tokenizerType: string): Promise<(number[] | Uint32Array | Int32Array)> {
+    switch (tokenizerType) {
+        case 'tik':
+            return await tikJS(data, 'cl100k_base');
+        case 'mistral':
+            return await tokenizeWebTokenizers(data, 'mistral');
+        case 'novelai':
+            return await tokenizeWebTokenizers(data, 'novelai');
+        case 'claude':
+            return await tokenizeWebTokenizers(data, 'claude');
+        case 'llama':
+            return await tokenizeWebTokenizers(data, 'llama');
+        case 'llama3':
+            return await tokenizeWebTokenizers(data, 'llama3');
+        case 'novellist':
+            return await tokenizeWebTokenizers(data, 'novellist');
+        case 'gemma':
+            return await gemmaTokenize(data);
+        case 'cohere':
+            return await tokenizeWebTokenizers(data, 'cohere');
+        case 'deepseek':
+            return await tokenizeWebTokenizers(data, 'DeepSeek');
+        default:
+            return await tikJS(data, 'cl100k_base');
+    }
+}
+
 export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Array)>{
     const db = getDatabase();
     const modelInfo = getModelInfo(db.aiModel);


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
- Add a dropdown selector to choose tokenizer type in the Playground Tokenizer tool
- Previously, the tokenizer was automatically determined based on model settings
- Now users can manually select which tokenizer to use for testing

## Changes

### Before
<img width="351" height="359" alt="Screenshot 2025-12-30 184634" src="https://github.com/user-attachments/assets/3776436d-b2ca-4550-bd96-3ad9383206a0" />

### After
<img width="385" height="450" alt="Screenshot 2025-12-30 184643" src="https://github.com/user-attachments/assets/c6b81b26-9928-47dd-b720-91e14c48e702" />

### `src/ts/tokenizer.ts`

- Added new `encodeWithTokenizer(data: string, tokenizerType: string)` function
- Allows direct tokenization with a specified tokenizer type
- Supports all available tokenizers: Tiktoken, Mistral, NovelAI, Claude, Llama, Llama3, Novellist, Gemma, Cohere, DeepSeek

### `src/lib/Playground/PlaygroundTokenizer.svelte`

- Added tokenizer selector dropdown using `SelectInput` component
- Imports `tokenizerList` from tokenizer module for available options
- Updates tokenization result immediately when tokenizer selection changes
- Styled consistently with existing playground UI
