### PR TITLE
fix: correct trimStartNewChat condition logic

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -753,7 +753,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
 
     let chats:OpenAIChat[] = examples
 
-    if(!DBState.db.aiModel.startsWith('novelai') || DBState.db?.promptSettings?.trimStartNewChat){
+    if(!DBState.db.aiModel.startsWith('novelai') && !DBState.db?.promptSettings?.trimStartNewChat){
         chats.push({
             role: 'system',
             content: '[Start a new chat]',


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
## Problem

The original condition for adding the `[Start a new chat]` message had incorrect logic:

```typescript
if(!DBState.db.aiModel.startsWith('novelai') || DBState.db?.promptSettings?.trimStartNewChat){
    chats.push({
        role: 'system',
        content: '[Start a new chat]',
        memo: "NewChat"
    })
}
```

This condition would add the message when:
- The model is NOT NovelAI, OR
- `trimStartNewChat` is true

This was problematic because:
1. NovelAI models could still get the message if `trimStartNewChat` was true
2. The `trimStartNewChat` option name implies "trim/remove" but the logic was inverted - it would ADD the message when true instead of removing it

## Expected Behavior

- NovelAI models should NEVER receive the `[Start a new chat]` message
- For all other models, the `trimStartNewChat` setting should control whether the message is trimmed (removed)
  - `trimStartNewChat: true` → Remove the message (don't add it)
  - `trimStartNewChat: false` → Keep the message (add it)

## Solution

Changed the condition from `||` to `&&` and negated the `trimStartNewChat` check:

```typescript
if(!DBState.db.aiModel.startsWith('novelai') && !DBState.db?.promptSettings?.trimStartNewChat){
    chats.push({
        role: 'system',
        content: '[Start a new chat]',
        memo: "NewChat"
    })
}
```

Now the message is only added when:
- The model is NOT NovelAI, AND
- `trimStartNewChat` is false (or undefined)

## Files Changed

- `src/ts/process/index.svelte.ts`
