### PR TITLE
fix: improve Unicode string handling and fix tonumber whitespace bug

### DIFF
--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -4,6 +4,7 @@ import type { RisuModule } from './process/modules';
 import type { LLMModel } from './model/modellist';
 import { get } from 'svelte/store';
 import { CurrentTriggerIdStore } from './stores.svelte';
+import { toGraphemes } from './util';
 
 export const defaultCBSRegisterArg: CBSRegisterArg = {
     registerFunction: () => { throw new Error('registerFunction not implemented') },
@@ -1134,7 +1135,7 @@ export function registerCBS(arg:CBSRegisterArg) {
         name: 'tonumber',
         callback: (str, matcherArg, args, vars) => {
             return ([...args[0]].filter((v) => {
-                return !isNaN(Number(v)) || v === '.'
+                return '0123456789.'.includes(v)
             })).join('')
         },
         alias: [],
@@ -2118,7 +2119,7 @@ export function registerCBS(arg:CBSRegisterArg) {
     registerFunction({
         name: 'reverse',
         callback: (str, matcherArg, args, vars) => {
-            return [...str].reverse().join('')
+            return toGraphemes(str).reverse().join('')
         },
         alias: [],
         description: 'Reverses the input string.\n\nUsage:: {{reverse::some_value}}',

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -5,7 +5,7 @@ import { getModuleTriggers } from "./modules";
 import { get } from "svelte/store";
 import { ReloadChatPointer, ReloadGUIPointer, selectedCharID, CurrentTriggerIdStore } from "../stores.svelte";
 import { processMultiCommand } from "./command";
-import { parseKeyValue, sleep } from "../util";
+import { parseKeyValue, sleep, toGraphemes } from "../util";
 import { alertError, alertInput, alertNormal, alertSelect } from "../alert";
 import type { OpenAIChat } from "./index.svelte";
 import { HypaProcesser } from "./memory/hypamemory";
@@ -2027,7 +2027,7 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
                     let source = effect.sourceType === 'value' ? risuChatParser(effect.source,{chara:char}) : getVar(risuChatParser(effect.source,{chara:char}))
                     let index = effect.indexType === 'value' ? Number(risuChatParser(effect.index,{chara:char})) : Number(getVar(risuChatParser(effect.index,{chara:char})))
                     let value = effect.valueType === 'value' ? risuChatParser(effect.value,{chara:char}) : getVar(risuChatParser(effect.value,{chara:char}))
-                    const source2 = [...source]
+                    const source2 = toGraphemes(source)
                     source2[index] = value
                     setVar(risuChatParser(effect.outputVar, {chara:char}), source2.join(''))
                     break

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -1224,3 +1224,9 @@ export function asBuffer(arr: Uint8Array<ArrayBufferLike> | ArrayBufferLike): Ui
         return arr as unknown as ArrayBuffer
     }
 }
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+
+export function toGraphemes(str: string): string[] {
+    return [...graphemeSegmenter.segment(str)].map(s => s.segment)
+}


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This PR fixes two categories of string handling issues:

1. **Unicode grapheme cluster handling** - The `reverse` CBS function and `v2SetCharAt` trigger effect were using spread operator (`[...str]`) which doesn't correctly handle complex Unicode characters like emojis with skin tones, flag emojis, or combined characters.

2. **tonumber whitespace bug** - The `tonumber` CBS function was incorrectly allowing whitespace characters (space, tab, newline) to pass through the filter.

## Problems

### 1. Grapheme Cluster Handling

The spread operator `[...str]` splits strings by Unicode code points, not by what users perceive as "characters" (grapheme clusters).

**Example of the problem:**

```javascript
// Combined emoji: family emoji
const family = '👨‍👩‍👧‍👦'
console.log([...family])
// Output: ['👨', '‍', '👩', '‍', '👧', '‍', '👦'] - 7 elements!

// Flag emoji
const flag = '🇰🇷'
console.log([...flag])
// Output: ['🇰', '🇷'] - 2 elements!

// Emoji with skin tone
const thumbs = '👍🏻'
console.log([...thumbs])
// Output: ['👍', '🏻'] - 2 elements!
```

This caused `{{reverse::👨‍👩‍👧‍👦}}` to produce broken output instead of the same emoji.

### 2. tonumber Whitespace Bug

The original implementation used `!isNaN(Number(v))` to check if a character is numeric:

```javascript
return ([...args[0]].filter((v) => {
    return !isNaN(Number(v)) || v === '.'
})).join('')
```

**The problem:** `Number(' ')`, `Number('\t')`, and `Number('\n')` all return `0`, not `NaN`.

```javascript
Number(' ')   // 0
Number('\t')  // 0
Number('\n')  // 0
isNaN(Number(' '))  // false - passes the filter!
```

**Result:**
```
Input: "12 34"
Expected: "1234"
Actual: "12 34" (whitespace preserved)
```

This contradicts the function's description: "Extracts only numeric characters (0-9) and decimal points".

## Solution

### 1. Add `toGraphemes()` Utility

Added a shared utility function in `util.ts` that uses `Intl.Segmenter` to properly split strings by grapheme clusters:

```typescript
const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })

export function toGraphemes(str: string): string[] {
    return [...graphemeSegmenter.segment(str)].map(s => s.segment)
}
```

The `Intl.Segmenter` instance is created once at module load and reused for all calls, avoiding repeated instantiation overhead.

**Usage example:**
```javascript
toGraphemes('👨‍👩‍👧‍👦')  // ['👨‍👩‍👧‍👦'] - 1 element!
toGraphemes('🇰🇷')      // ['🇰🇷'] - 1 element!
toGraphemes('👍🏻')      // ['👍🏻'] - 1 element!
```

### 2. Fix tonumber

Changed from `isNaN` check to explicit character inclusion:

```typescript
// Before
return !isNaN(Number(v)) || v === '.'

// After
return '0123456789.'.includes(v)
```

This is simpler, more explicit, and correctly rejects whitespace.

## Why This Approach?

### Why `Intl.Segmenter` over alternatives?

| Alternative | Problem |
|-------------|---------|
| `[...str]` (spread) | Splits surrogate pairs correctly but not grapheme clusters |
| Regex with `/./gu` | Same issue as spread operator |
| Third-party library | Adds dependency, `Intl.Segmenter` is built-in |

`Intl.Segmenter` is:
- Built into modern browsers (no dependencies)
- Designed specifically for this use case
- Handles all Unicode edge cases correctly

### Why `includes()` over regex for tonumber?

| Alternative | Consideration |
|-------------|---------------|
| `/^[0-9.]$/.test(v)` | Works, but regex is overkill for simple char check |
| `'0123456789.'.includes(v)` | Simple, readable, fast |

The `includes()` approach was chosen for its simplicity and readability.

## Files Changed

- `src/ts/util.ts` - Added `toGraphemes()` function
- `src/ts/cbs.ts` - Updated `reverse` CBS and fixed `tonumber` CBS
- `src/ts/process/triggers.ts` - Updated `v2SetCharAt` effect