### PR TITLE
fix: resolve syntax and import errors in multiple files

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -53,6 +53,8 @@
 
     function scrollToBottom() {
         chatsInstance?.scrollToLatestMessage();
+    }
+
     $effect(() => {
         if(ScrollToMessageStore.value !== -1){
             const index = ScrollToMessageStore.value

--- a/src/lib/Setting/Pages/Advanced/BanCharacterSetSettings.svelte
+++ b/src/lib/Setting/Pages/Advanced/BanCharacterSetSettings.svelte
@@ -2,7 +2,7 @@
     import { DBState } from 'src/ts/stores.svelte';
     import { language } from "src/lang";
     import Button from "src/lib/UI/GUI/Button.svelte";
-    import Arcodion from "src/lib/UI/Arcodion.svelte";
+    import Accordion from "src/lib/UI/Accordion.svelte";
 
     const characterSets = [
         'Latn', 'Hani', 'Arab', 'Deva', 'Cyrl', 'Beng', 'Hira', 'Kana', 'Telu', 'Hang',
@@ -17,7 +17,7 @@
     };
 </script>
 
-<Arcodion styled name={language.banCharacterset}>
+<Accordion styled name={language.banCharacterset}>
     {#each characterSets as set}
         <Button styled={DBState.db.banCharacterset.includes(set) ? 'primary' : "outlined"} onclick={(e) => {
             if (DBState.db.banCharacterset.includes(set)) {
@@ -29,4 +29,4 @@
             {new Intl.DisplayNames([navigator.language,'en'], { type: 'script' }).of(set)} ({characterSetsPreview[set]})
         </Button>
     {/each}
-</Arcodion>
+</Accordion>

--- a/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
+++ b/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
@@ -5,7 +5,7 @@
     import TextInput from "src/lib/UI/GUI/TextInput.svelte";
     import SelectInput from "src/lib/UI/GUI/SelectInput.svelte";
     import OptionInput from "src/lib/UI/GUI/OptionInput.svelte";
-    import Arcodion from "src/lib/UI/Arcodion.svelte";
+    import Accordion from "src/lib/UI/Accordion.svelte";
     import { PlusIcon, TrashIcon, ArrowUp, ArrowDown } from "@lucide/svelte";
     import { v4 } from "uuid";
 
@@ -25,7 +25,7 @@
     </Button>
 {/snippet}
 
-<Arcodion styled name={language.customModels} className="overflow-x-auto">
+<Accordion styled name={language.customModels} className="overflow-x-auto">
     {#each DBState.db.customModels as model, index (model.id)}
         <div class="flex flex-col mt-2">
             <button class="hover:bg-selected px-6 py-2 text-lg rounded-t-md border-selected border flex justify-between items-center"
@@ -125,7 +125,7 @@
             <TextInput size={"sm"} bind:value={DBState.db.customModels[index].key}/>
             <span class="text-textcolor">{language.additionalParams}</span>
             <TextInput size={"sm"} bind:value={DBState.db.customModels[index].params}/>
-            <Arcodion styled name={language.flags}>
+            <Accordion styled name={language.flags}>
                 {@render CustomFlagButton(index,'hasImageInput', 0)}
                 {@render CustomFlagButton(index,'hasImageOutput', 1)}
                 {@render CustomFlagButton(index,'hasAudioInput', 2)}
@@ -145,7 +145,7 @@
                 {@render CustomFlagButton(index,'deepSeekPrefix', 17)}
                 {@render CustomFlagButton(index,'deepSeekThinkingInput', 18)}
                 {@render CustomFlagButton(index,'deepSeekThinkingOutput', 19)}
-            </Arcodion>
+            </Accordion>
                 </div>
             {/if}
         </div>
@@ -167,4 +167,4 @@
             <PlusIcon />
         </button>
     </div>
-</Arcodion>
+</Accordion>

--- a/src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte
+++ b/src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte
@@ -3,7 +3,8 @@
     import Button from "src/lib/UI/GUI/Button.svelte";
     import { DBState } from 'src/ts/stores.svelte';
     import { alertMd, alertNormal } from "src/ts/alert";
-    import { downloadFile, getRequestLog, isNodeServer, isTauri } from "src/ts/globalApi.svelte";
+    import { downloadFile, getRequestLog } from "src/ts/globalApi.svelte";
+    import { isNodeServer, isTauri } from "src/ts/platform";
     import { getDatabase } from "src/ts/storage/database.svelte";
 
 </script>

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -34,9 +34,7 @@ import { moduleUpdate } from "./process/modules";
 import type { AccountStorage } from "./storage/accountStorage";
 import { makeColdData } from "./process/coldstorage.svelte";
 import {
-    isTauri,
     forageStorage,
-    isNodeServer,
     saveDb,
     getDbBackups,
     getUnpargeables,
@@ -44,6 +42,7 @@ import {
     setUsingSw,
     checkCharOrder
 } from "./globalApi.svelte";
+import { isTauri, isNodeServer } from "./platform";
 
 const appWindow = isTauri ? getCurrentWebviewWindow() : null
 

--- a/src/ts/setting/advancedSettingsData.ts
+++ b/src/ts/setting/advancedSettingsData.ts
@@ -1,6 +1,6 @@
 
 import type { SettingItem } from './types';
-import { isNodeServer, isTauri } from '../globalApi.svelte';
+import { isNodeServer, isTauri } from '../platform';
 
 export const advancedSettingsItems: SettingItem[] = [
     { type: 'header', id: 'adv.header', labelKey: 'advancedSettings', options: { level: 'h2' }, classes: '!mb-0' },


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

## Summary
Fix syntax and import errors that were causing build failures.

## Changes

### 1. Fix missing closing brace in DefaultChatScreen.svelte
- The `scrollToBottom()` function was missing its closing `}`, causing a syntax error at line 502.

### 2. Fix `Arcodion` typo to `Accordion`
- **Files affected**: CustomModelsSettings.svelte, BanCharacterSetSettings.svelte
- The import and component usage was referencing `Arcodion.svelte` which doesn't exist. The correct file is Accordion.svelte.

### 3. Fix incorrect import paths for `isNodeServer` and `isTauri`
- **Files affected**: SettingsExportButtons.svelte, advancedSettingsData.ts, bootstrap.ts
- These were importing from `src/ts/globalApi.svelte` which doesn't export them. Changed to import from `src/ts/platform` where they are actually exported.