### PR TITLE
feat: Support OpenAI compatible image generation endpoints

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -118,6 +118,7 @@
             <OptionInput value="fal" >Fal.ai</OptionInput>
             <OptionInput value="comfyui" >ComfyUI</OptionInput>
             <OptionInput value="Imagen" >Imagen</OptionInput>
+            <OptionInput value="openai-compat" >OpenAI Compatible</OptionInput>
 
             <!-- Legacy -->
             {#if DBState.db.sdProvider === 'comfy'}
@@ -635,6 +636,34 @@
                 <OptionInput value="allow_all" >Allow all</OptionInput>
                 <OptionInput value="allow_adult" >Allow adult</OptionInput>
                 <OptionInput value="dont_allow" >Don't allow</OptionInput>
+            </SelectInput>
+        {/if}
+
+        {#if DBState.db.sdProvider === 'openai-compat'}
+            <span class="text-textcolor mt-2">API URL</span>
+            <TextInput size="sm" marginBottom placeholder="https://api.example.com/v1/images/generations" bind:value={DBState.db.openaiCompatImage.url}/>
+
+            <span class="text-textcolor">API Key</span>
+            <TextInput size="sm" marginBottom placeholder="sk-..." hideText={DBState.db.hideApiKey} bind:value={DBState.db.openaiCompatImage.key}/>
+
+            <span class="text-textcolor">Model</span>
+            <TextInput size="sm" marginBottom placeholder="dall-e-3" bind:value={DBState.db.openaiCompatImage.model}/>
+
+            <span class="text-textcolor">Image Size</span>
+            <SelectInput className="mb-4" bind:value={DBState.db.openaiCompatImage.size}>
+                <OptionInput value="1024x1024" >1024x1024</OptionInput>
+                <OptionInput value="1536x1024" >1536x1024</OptionInput>
+                <OptionInput value="1024x1536" >1024x1536</OptionInput>
+                <OptionInput value="512x512" >512x512</OptionInput>
+                <OptionInput value="256x256" >256x256</OptionInput>
+            </SelectInput>
+
+            <span class="text-textcolor">Quality</span>
+            <SelectInput className="mb-4" bind:value={DBState.db.openaiCompatImage.quality}>
+                <OptionInput value="auto" >Auto</OptionInput>
+                <OptionInput value="low" >Low</OptionInput>
+                <OptionInput value="medium" >Medium</OptionInput>
+                <OptionInput value="high" >High</OptionInput>
             </SelectInput>
         {/if}
     </Accordion>

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -613,6 +613,13 @@ export function setDatabase(data:Database){
     data.ImagenImageSize ??= '1K'
     data.ImagenAspectRatio ??= '1:1'
     data.ImagenPersonGeneration ??= 'allow_all'
+    data.openaiCompatImage ??= {
+        url: '',
+        key: '',
+        model: '',
+        size: '1024x1024',
+        quality: 'auto'
+    }
     data.autoScrollToNewMessage ??= true
     data.alwaysScrollToNewMessage ??= false
     data.newMessageButtonStyle ??= 'bottom-center'
@@ -1130,6 +1137,13 @@ export interface Database{
     ImagenImageSize:string
     ImagenAspectRatio:string
     ImagenPersonGeneration:string,
+    openaiCompatImage: {
+        url: string
+        key: string
+        model: string
+        size: string
+        quality: string
+    }
     sourcemapTranslate:boolean
     settingsCloseButtonSize:number
     promptDiffPrefs:PromptDiffPrefs


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models?
  - Tested with [Nano-GPT](https://docs.nano-gpt.com/api-reference/image-generation)'s endpoint.
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
  - Tested on node hosted version on pc and mobile interface.
- [x] Have you added type definitions?

# Description
This PR adds support for OpenAI compatible image generation (`/v1/images/generations` like DallE).

## Screenshots
<img width="1042" height="610" alt="image" src="https://github.com/user-attachments/assets/ca72a3c7-aed6-46c2-bd7b-44b02c751fde" />

<img width="860" height="920" alt="image" src="https://github.com/user-attachments/assets/31badd15-29a3-47e6-90b7-265b6d43c51b" />
