### PR TITLE
feat: add dark, monokai-light, and monokai-black color schemes

### DIFF
--- a/src/ts/gui/colorscheme.ts
+++ b/src/ts/gui/colorscheme.ts
@@ -35,6 +35,18 @@ export const defaultColorScheme: ColorScheme = {
 
 const colorShemes = {
     "default": defaultColorScheme,
+    "dark": {
+        bgcolor: "#1a1a1a",
+        darkbg: "#141414",
+        borderc: "#525252",
+        selected: "#3d3d3d",
+        draculared: "#ff5555",
+        textcolor: "#f5f5f5",
+        textcolor2: "#a3a3a3",
+        darkBorderc: "#404040",
+        darkbutton: "#2e2e2e",
+        type:'dark'
+    },
     "light": {
         bgcolor: "#ffffff",
         darkbg: "#f0f0f0",
@@ -93,6 +105,30 @@ const colorShemes = {
         textcolor2: "#64748b",
         darkBorderc: "#4b5563",
         darkbutton: "#374151",
+        type:'dark'
+    },
+    "monokai-light": {
+        bgcolor: "#f8f8f2",
+        darkbg: "#e8e8e3",
+        borderc: "#75715e",
+        selected: "#d8d8d0",
+        draculared: "#f92672",
+        textcolor: "#272822",
+        textcolor2: "#75715e",
+        darkBorderc: "#c0c0b8",
+        darkbutton: "#d0d0c8",
+        type:'light'
+    },
+    "monokai-black": {
+        bgcolor: "#272822",
+        darkbg: "#1e1f1a",
+        borderc: "#75715e",
+        selected: "#3e3d32",
+        draculared: "#f92672",
+        textcolor: "#f8f8f2",
+        textcolor2: "#a6a68a",
+        darkBorderc: "#3e3d32",
+        darkbutton: "#3e3d32",
         type:'dark'
     },
     "lite": {


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

Add 3 new color schemes to the Display Settings → Theme tab:

- **dark**: A neutral gray dark theme without the blue tint of the default Dracula theme
- **monokai-light**: A light theme based on the classic Monokai color palette with warm cream background
- **monokai-black**: A dark theme based on the classic Monokai dark olive background (#272822)

All color schemes use proper type definitions and work across all platforms (web, local, node).

## Preview
| dark | monokai-light | monokai-black |
| ---- | ---- | ---- |
| <img width="1461" height="797" alt="dark" src="https://github.com/user-attachments/assets/a2542ef1-035d-4a11-be8a-288d81b4dca1" /> | <img width="1461" height="797" alt="monokai-light" src="https://github.com/user-attachments/assets/7fb2b8fe-d1f1-4cd2-a09a-83687d416423" /> | <img width="1461" height="797" alt="monokai-black" src="https://github.com/user-attachments/assets/d7635624-7983-4d52-a5d4-f109033dd956" /> |