### PR TITLE
feat: MCP internal:risuai - Get lorebook by its name

### DIFF
--- a/src/ts/process/mcp/risuaccess/characters.ts
+++ b/src/ts/process/mcp/risuaccess/characters.ts
@@ -458,7 +458,8 @@ export class CharacterHandler extends MCPToolHandler {
     const lorebook = char.globalLore.slice(offset, offset + count)
     const organized = lorebook.map((entry) => {
       return {
-        keys: entry.alwaysActive ? 'alwaysActive' : entry.key,
+        alwaysActive: entry.alwaysActive,
+        keys: entry.key,
         name: entry.comment || 'Unnamed ' + pickHashRand(5515, entry.content),
       }
     })
@@ -505,8 +506,9 @@ export class CharacterHandler extends MCPToolHandler {
     }
 
     const result = entries.map((entry) => ({
+      alwaysActive: entry.alwaysActive,
       content: entry.content,
-      keys: entry.alwaysActive ? 'alwaysActive' : entry.key,
+      keys: entry.key,
       name: entry.comment || 'Unnamed ' + pickHashRand(5515, entry.content),
     }))
 

--- a/src/ts/process/mcp/risuaccess/client.ts
+++ b/src/ts/process/mcp/risuaccess/client.ts
@@ -56,10 +56,10 @@ Regex Scripts are used to replace text in the chat based on regex patterns. Fiel
 - 'comment': The name of the script. This is used to identify the script in the list.
 
 Lorebooks are texts containing various information about the character with conditional activation based on chat history. Fields:
+- 'alwaysActive': A boolean value indicating whether the entry is always active. If true, the entry will be included even if all of its keys are not in the chat history.
 - 'key': The key that will activate this lorebook. Multiple keys can be specified separated by commas. If one of the keys is in the chat history, the entry will be included in the next prompt.
 - 'content': The content of the entry.
-- 'comment': The name of the lorebook. Used for identifying the entry in the list.
-- 'alwaysActive': A boolean value indicating whether the entry is always active. If true, the entry will be included even if all of its keys are not in the chat history.
+- 'name': The name of the lorebook. Used for identifying the entry in the list.
 
 backgroundEmbedding is an HTML string mainly for custom styling. It can, and mostly include <style> tags with CSS. Note that all selectors will be prefixed with '.chattext ' so they cannot escape the chat boundary - No html, body, :root access.
 `

--- a/src/ts/process/mcp/risuaccess/modules.ts
+++ b/src/ts/process/mcp/risuaccess/modules.ts
@@ -431,7 +431,8 @@ export class ModuleHandler extends MCPToolHandler {
     const lorebook = (module.lorebook || []).slice(offset, offset + count)
     const organized = lorebook.map((entry) => {
       return {
-        keys: entry.alwaysActive ? 'alwaysActive' : entry.key,
+        alwaysActive: entry.alwaysActive,
+        keys: entry.key,
         name: entry.comment || 'Unnamed ' + pickHashRand(5515, entry.content),
       }
     })
@@ -471,8 +472,9 @@ export class ModuleHandler extends MCPToolHandler {
     }
 
     const result = entries.map((entry) => ({
+      alwaysActive: entry.alwaysActive,
       content: entry.content,
-      keys: entry.alwaysActive ? 'alwaysActive' : entry.key,
+      keys: entry.key,
       name: entry.comment || 'Unnamed ' + pickHashRand(5515, entry.content),
     }))
 


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

Removed `content` from lorebook listing tool to reduce super long wall of text feeding into the model at once. Instead, added a tool that can read specified lorebook or lorebooks, by its name.

Also added dedicated `alwaysActive` key for lorebook responses as models struggled interpreting it.