### PR TITLE
fix: Improve character card export Speed when logged in

### DIFF
--- a/src/ts/storage/accountStorage.ts
+++ b/src/ts/storage/accountStorage.ts
@@ -84,6 +84,9 @@ export class AccountStorage{
         if(da.status < 200 || da.status >= 300){
             throw await getDaText()
         }
+        if(key.startsWith('assets/')){
+            await localforage.setItem(key, new Uint8Array(value).buffer)
+        }
         return await getDaText()
     }
     async getItem(key:string, callback?:(status:number) => void):Promise<Buffer> {


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Issue
When creating an Asset Bot while logged in, exporting the bot is slow.

# Cause

AccountStorage.getItem caches images, but setItem does not.
This is the root cause because bot creators only use setItem when adding assets.
And Currently setItem only saves assets to the Risu server, not to localforage.

However, when exporting a bot, getItem checks if the image is cached in localforage. If not, it requests the data from the server.

Ultimately, the bot creator must fetch the image from the Risu server because it's not in localforage, even though they uploaded it themselves.

# Conclusion
This PR improves the speed of exporting bots while logged in and reduces unnecessary load on the Risu server.
