### PR TITLE
fix: Working #each, add #each::keep

### DIFF
--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -2454,10 +2454,15 @@ Usage:: {{#when condition}}...{{/when}} or {{#when::not::condition}}...{{/when}}
     })
 
     registerFunction({
-        name:':each',
+        name:'#each',
         callback: 'doc_only',
-        alias: ['#each'],
-        description: 'Iterates over an array or object.\n\nUsage:: {{#each array}}...{{/each}} or {{#each object as key}}... {{slot::key}}...{{/each}}',
+        alias: [':each'],
+        description: `Iterates over an array.
+
+Operators:
+{{#each::keep A as V}} - keep whitespace handling, so it will not trim spaces inside block.
+
+Usage:: {{#each A as V}} ... {{slot::V}} ... {{/each}}`,
     })
 
     registerFunction({

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -1239,7 +1239,7 @@ function makeArray(p1:string[]):string{
     }))
 }
 
-function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,type2?:string,funcArg?:string[]}{
+function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,type2?:string,funcArg?:string[],mode?:string}{
     if(p1.startsWith('#if') || p1.startsWith('#if_pure ')){
         const statement = p1.split(' ', 2)
         const state = statement[1]
@@ -1489,10 +1489,15 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
     }
     if(p1.startsWith('#each')){
         let t2 = p1.substring(5).trim()
+        let mode: string | undefined
+        if(t2.startsWith('::keep ')){
+            mode = 'keep'
+            t2 = t2.substring(7).trim()
+        }
         if(t2.startsWith('as ')){
             t2 = t2.substring(3).trim()
         }
-        return {type:'each',type2:t2}
+        return {type:'each', type2:t2, mode}
     }
     if(p1.startsWith('#func')){
         const statement = p1.split(' ')
@@ -1501,7 +1506,6 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
         }
 
     }
-
 
     return {type:'nothing'}
 }
@@ -1512,7 +1516,7 @@ function trimLines(p1:string){
     }).join('\n').trim()
 }
 
-function blockEndMatcher(p1:string,type:{type:blockMatch,type2?:string},matcherArg:matcherArg):string{
+function blockEndMatcher(p1:string,type:{type:blockMatch,type2?:string,mode?:string},matcherArg:matcherArg):string{
     const p1Trimed = p1.trim() 
     switch(type.type){
         case 'pure':
@@ -1520,8 +1524,13 @@ function blockEndMatcher(p1:string,type:{type:blockMatch,type2?:string},matcherA
         case 'function':{
             return p1Trimed
         }
-        case 'parse':
+        case 'parse':{
+            return trimLines(p1Trimed)
+        }
         case 'each':{
+            if(type.mode === 'keep'){
+                return p1
+            }
             return trimLines(p1Trimed)
         }
         case 'ifpure':{
@@ -1658,7 +1667,6 @@ export function risuChatParser(da:string, arg:{
         }
     }
 
-    
     let pointer = 0;
     let nested:string[] = [""]
     let stackType = new Uint8Array(512)
@@ -1668,6 +1676,7 @@ export function risuChatParser(da:string, arg:{
         type:blockMatch,
         type2?:string
         funcArg?:string[]
+        mode?:string
     }> = new Map()
     let commentMode = false
     let commentLatest:string[] = [""]
@@ -1711,12 +1720,7 @@ export function risuChatParser(da:string, arg:{
     const isPureMode = () => {
         return pureModeNest.size > 0
     }
-    const pureModeType = () => {
-        if(pureModeNest.size === 0){
-            return ''
-        }
-        return pureModeNestType.get(nested.length) ?? [...pureModeNestType.values()].at(-1) ?? ''
-    }
+
     while(pointer < da.length){
         switch(da[pointer]){
             case '{':{
@@ -1788,15 +1792,18 @@ export function risuChatParser(da:string, arg:{
                         const dat2 = nested.shift()
                         const matchResult = blockEndMatcher(dat2, blockType, matcherObj)
                         if(blockType.type === 'each'){
-                            const subind = blockType.type2.lastIndexOf(' ')
-                            const sub = blockType.type2.substring(subind + 1)
-                            const array = parseArray(blockType.type2.substring(0, subind))
+                            const asIndex = blockType.type2.lastIndexOf(' as ')
+                            if(asIndex === -1){
+                                break
+                            }
+                            const sub = blockType.type2.substring(asIndex + 4).trim()
+                            const array = parseArray(blockType.type2.substring(0, asIndex))
                             let added = ''
                             for(let i = 0;i < array.length;i++){
                                 const res = matchResult.replaceAll(`{{slot::${sub}}}`, array[i])
                                 added += res
                             }
-                            da = da.substring(0, pointer + 1) + added.trim() + da.substring(pointer + 1)
+                            da = da.substring(0, pointer + 1) + (blockType.mode === 'keep' ? added : added.trim()) + da.substring(pointer + 1)
                             break
                         }
                         if(blockType.type === 'function'){


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

`{{#each}}` doesn't work in its current form.

The doc says:

- Works on both array and dict keys
- Does not require `as v` with arrays

But implementation:

- Has a parsing error - incorrectly looks for a space
- Requires `as V` even with arrays
- Does not work with dict keys

This PR:

- Requires `as V`
- Fixes the parsing error by looking for `as` instead
- Does not add dict keys support. Instead, update CBS doc

This PR also adds `::keep` operator to `#each` because keeping breaks within loops are super useful if not a necessity.