### PR TITLE
fix: Working #when::keep, #when::legacy

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -1284,10 +1284,12 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
                     }
                     case 'keep':{
                         mode = 'keep'
+                        statement.push(condition)
                         break
                     }
                     case 'legacy':{
                         mode = 'legacy'
+                        statement.push(condition)
                         break
                     }
                     case 'and':{


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

`#when::keep::A` and `#when::legacy::A` doesn't work. This PR fixes it.