### PR TITLE
add: Disable checkCorruption backupcheck logic

### DIFF
--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -26,16 +26,18 @@ export async function SaveLocalBackup(){
     }
 
     //check backup data is corrupted
-    const corrupted = await fetch(hubURL + '/backupcheck', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(getDatabase()),
-    })
-    if(corrupted.status === 400){
-        alertError('Failed, Backup data is corrupted')
-        return
+    if(getDatabase().checkCorruption){
+        const corrupted = await fetch(hubURL + '/backupcheck', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(getDatabase()),
+        })
+        if(corrupted.status === 400){
+            alertError('Failed, Backup data is corrupted')
+            return
+        }
     }
 
     const db = getDatabase()

--- a/src/ts/drive/drive.ts
+++ b/src/ts/drive/drive.ts
@@ -121,16 +121,18 @@ async function backupDrive(ACCESS_TOKEN:string) {
     })
 
     //check backup data is corrupted
-    const corrupted = await fetch(hubURL + '/backupcheck', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(getDatabase()),
-    })
-    if(corrupted.status === 400){
-        alertError('Failed, Backup data is corrupted')
-        return
+    if(getDatabase().checkCorruption){
+        const corrupted = await fetch(hubURL + '/backupcheck', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(getDatabase()),
+        })
+        if(corrupted.status === 400){
+            alertError('Failed, Backup data is corrupted')
+            return
+        }
     }
 
     const files:DriveFile[] = await getFilesInFolder(ACCESS_TOKEN)


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Right now, Risu has an option called checkCorruption, but it doesn't do anything.
In this PR, change to /backupcheck only when checkCorruption is true.