### PR TITLE
fix: add execCommand fallback for clipboard API on iOS Safari

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -631,14 +631,40 @@
             }
             catch (e) {
                 alertClear()
-                window.navigator.clipboard.writeText(msgDisplay).then(() => {
+                // Try clipboard API first, with execCommand fallback for iOS
+                try {
+                    await window.navigator.clipboard.writeText(msgDisplay)
                     setStatusMessage(language.copied)
-                })
+                } catch {
+                    // Fallback for iOS Safari where clipboard API may fail
+                    const textarea = document.createElement('textarea')
+                    textarea.value = msgDisplay
+                    textarea.style.position = 'fixed'
+                    textarea.style.left = '-9999px'
+                    document.body.appendChild(textarea)
+                    textarea.select()
+                    document.execCommand('copy')
+                    document.body.removeChild(textarea)
+                    setStatusMessage(language.copied)
+                }
             }
         }
-        window.navigator.clipboard.writeText(msgDisplay).then(() => {
+        // Try clipboard API first, with execCommand fallback for iOS
+        try {
+            await window.navigator.clipboard.writeText(msgDisplay)
             setStatusMessage(language.copied)
-        })
+        } catch {
+            // Fallback for iOS Safari where clipboard API may fail
+            const textarea = document.createElement('textarea')
+            textarea.value = msgDisplay
+            textarea.style.position = 'fixed'
+            textarea.style.left = '-9999px'
+            document.body.appendChild(textarea)
+            textarea.select()
+            document.execCommand('copy')
+            document.body.removeChild(textarea)
+            setStatusMessage(language.copied)
+        }
     }}>
         <CopyIcon size={20}/>
         {#if showNames}

--- a/src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte
+++ b/src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte
@@ -66,7 +66,19 @@ Show Statistics
 
         const json = JSON.stringify(db, null, 2)
         await downloadFile('risuai-settings-report.json', new TextEncoder().encode(json))
-        await navigator.clipboard.writeText(json)
+        try {
+            await navigator.clipboard.writeText(json)
+        } catch {
+            // Fallback for iOS Safari
+            const textarea = document.createElement('textarea')
+            textarea.value = json
+            textarea.style.position = 'fixed'
+            textarea.style.left = '-9999px'
+            document.body.appendChild(textarea)
+            textarea.select()
+            document.execCommand('copy')
+            document.body.removeChild(textarea)
+        }
         alertNormal(language.settingsExported)
         
 

--- a/src/lib/UI/Realm/RealmPopUp.svelte
+++ b/src/lib/UI/Realm/RealmPopUp.svelte
@@ -115,7 +115,20 @@
             {/if}
             <button class="text-textcolor2 hover:text-green-500" onclick={(async (e) => {
                 e.stopPropagation()
-                await navigator.clipboard.writeText(`https://realm.risuai.net/character/${openedData.id}`)
+                const url = `https://realm.risuai.net/character/${openedData.id}`
+                try {
+                    await navigator.clipboard.writeText(url)
+                } catch {
+                    // Fallback for iOS Safari
+                    const textarea = document.createElement('textarea')
+                    textarea.value = url
+                    textarea.style.position = 'fixed'
+                    textarea.style.left = '-9999px'
+                    document.body.appendChild(textarea)
+                    textarea.select()
+                    document.execCommand('copy')
+                    document.body.removeChild(textarea)
+                }
                 alertNormal(language.clipboardSuccess)
             })}>
                 <PaperclipIcon />

--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -349,7 +349,19 @@ export async function exportChat(page:number){
                 'text/html': new Blob([template], { type: 'text/html' }),
                 'text/plain': new Blob([template], { type: 'text/plain' })
             })
-            await navigator.clipboard.write([item])
+            try {
+                await navigator.clipboard.write([item])
+            } catch {
+                // Fallback for iOS Safari - copy as plain text
+                const textarea = document.createElement('textarea')
+                textarea.value = template
+                textarea.style.position = 'fixed'
+                textarea.style.left = '-9999px'
+                document.body.appendChild(textarea)
+                textarea.select()
+                document.execCommand('copy')
+                document.body.removeChild(textarea)
+            }
 
             alertNormal(language.clipboardSuccess)
             return

--- a/src/ts/observer.svelte.ts
+++ b/src/ts/observer.svelte.ts
@@ -23,8 +23,20 @@ function nodeObserve(node:HTMLElement){
             const copyOption = document.createElement('div')
             copyOption.textContent = 'Copy'
             copyOption.setAttribute('class', 'px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 cursor-pointer')
-            copyOption.addEventListener('click', ()=>{
-                navigator.clipboard.writeText(node.textContent)
+            copyOption.addEventListener('click', async ()=>{
+                try {
+                    await navigator.clipboard.writeText(node.textContent)
+                } catch {
+                    // Fallback for iOS Safari
+                    const textarea = document.createElement('textarea')
+                    textarea.value = node.textContent
+                    textarea.style.position = 'fixed'
+                    textarea.style.left = '-9999px'
+                    document.body.appendChild(textarea)
+                    textarea.select()
+                    document.execCommand('copy')
+                    document.body.removeChild(textarea)
+                }
                 menu.remove()
             })
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

## Problem

Fixed an issue where the chat copy feature was not working on iOS Safari.

Error message:
> The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.

## Cause

iOS Safari has restrictions on the Clipboard API (`navigator.clipboard.writeText()`, `navigator.clipboard.write()`):

1. **User Gesture Required**: The Clipboard API must be called synchronously within a direct user click/touch event handler.
2. **Fails After Async Operations**: When accessing the clipboard after multiple `await` operations, iOS Safari considers the user gesture as "expired" and denies permission.

## Solution

Added `document.execCommand('copy')` fallback. This is an older API but works in iOS Safari even in asynchronous contexts.

## Changes

| File | Description |
|------|-------------|
| src/lib/ChatScreens/Chat.svelte | Added fallback to chat copy button |
| src/ts/observer.svelte.ts | Added fallback to code block context menu copy |
| src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte | Added fallback to settings export |
| src/lib/UI/Realm/RealmPopUp.svelte | Added fallback to Realm link copy |
| src/ts/characters.ts | Added fallback to chat HTML export |

## Fallback Pattern

```typescript
try {
    await navigator.clipboard.writeText(text)
} catch {
    // Fallback for iOS Safari
    const textarea = document.createElement('textarea')
    textarea.value = text
    textarea.style.position = 'fixed'
    textarea.style.left = '-9999px'
    document.body.appendChild(textarea)
    textarea.select()
    document.execCommand('copy')
    document.body.removeChild(textarea)
}