### PR TITLE
fix(ui): force remount chat components on variable updates

### DIFF
--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -3,9 +3,9 @@
     import { mount, onDestroy, unmount } from 'svelte';
     import Chat from './Chat.svelte';
     import { getCharImage } from 'src/ts/characters';
-    import { createSimpleCharacter, DBState, selectedCharID } from 'src/ts/stores.svelte';
+    import { createSimpleCharacter, DBState, selectedCharID, ReloadGUIPointer  } from 'src/ts/stores.svelte';
     import { chatFoldedStateMessageIndex } from 'src/ts/globalApi.svelte';
-    import { get } from 'svelte/store';
+    import { get } from "svelte/store";
     
     const getCurrentChatRoomId = () => {
         const charId = get(selectedCharID);
@@ -73,7 +73,7 @@
             if(i < 0) break; // Prevent out of bounds
             const message = messages[i];
             const messageLargePortrait = message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false);
-            let hashd = message.data + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString();
+            let hashd = message.data + (message.chatId ?? "") + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + get(ReloadGUIPointer).toString();
             const currentHash = hashCode(hashd);
             currentHashes.add(currentHash);
             if(!hashes.has(currentHash)){
@@ -165,6 +165,7 @@
 
     $effect(() => {
         console.log('Updating Chats');
+        $ReloadGUIPointer; 
         const wasAtBottom = checkIfAtBottom();
         updateChatBody()
         


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

This PR resolves a persistent issue where UI elements embedded in chat messages (such as the sidebar toggle) would fail to update state correctly after the first interaction.

**The Bug:**
The sidebar would open successfully but fail to close on subsequent clicks, even though the variable was updating correctly in the database.

**Root Cause:**
`Chats.svelte` uses an imperative `mount()` approach to render chat bubbles for performance. These mounted components were isolated from Svelte's reactivity system for global store changes. When a trigger updated a variable (updating `ReloadGUIPointer`), the hash used to identify and cache these components remained the same because the raw message data hadn't changed. As a result, the component was re-used without re-parsing, causing the HTML to remain stuck in its previous state (e.g., "opened").

**The Fix:**
1.  Imported `ReloadGUIPointer` store into `Chats.svelte`.
2.  Modified the hash calculation (`hashd`) for chat messages to include `ReloadGUIPointer`'s value.
3.  Added `$ReloadGUIPointer` as a dependency in the main `$effect` block.

**Result:**
Now, whenever a variable changes via trigger/script (triggering a `ReloadGUIPointer` update), the message hash changes. This forces `Chats.svelte` to unmount the stale `Chat` component and mount a fresh one, triggering a re-parse of the content and correctly rendering the updated UI state.
