### PR TITLE
fix: Change DBSaveError alertConfirm in saveDb to alertError

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -484,7 +484,7 @@ export async function saveDb() {
         } catch (error) {
             savetrys += 1
             if (savetrys > 4) {
-                await alertConfirm(`DBSaveError: ${error.message ?? error}. report to the developer.`)
+                alertError(error)
             }
             else {
                 console.error(error)


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
It's almost always been a failed to fetch related error when users post DBSaveError, but I still don't know why they get that error.
I think alertError can provide more information.