### PR TITLE
fix: prevent null parameters when separate params are enabled but unset

### DIFF
--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -215,7 +215,7 @@ export function applyParameters(data: { [key: string]: any }, parameters: Parame
                 }
             }
 
-            if(value === -1000 || value === undefined){
+            if(value === -1000 || value === undefined || value === null || (typeof value === 'number' && isNaN(value))){
                 continue
             }
 


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

## Problem
When `seperateParametersEnabled` is enabled but individual parameters for auxiliary modes (e.g., translate, memory, emotion) are not configured, the request body contains `null` values for `temperature`, `frequency_penalty`, and `presence_penalty`. This causes API errors with some model providers that don't accept null parameter values.

## Root Cause
In `applyParameters()` function:
1. `db.seperateParameters['translate'].temperature` is `undefined` (empty object)
2. `undefined === -1000` evaluates to `false`
3. `undefined / 100` results in `NaN`
4. The existing check `value === -1000 || value === undefined` doesn't catch `NaN`
5. `JSON.stringify()` converts `NaN` to `null`

## Solution
Added `NaN` and `null` checks to the parameter validation:
```typescript
// Before
if(value === -1000 || value === undefined){
    continue
}

// After
if(value === -1000 || value === undefined || value === null || (typeof value === 'number' && isNaN(value))){
    continue
}