### PR TITLE
chore: Delete promptTypeParser in parser.svelte.ts

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -1854,53 +1854,6 @@ export function setChatVar(key:string, value:string){
     DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate['$' + key] = value
 }
 
-export type PromptParsed ={[key:string]:string|PromptParsed}
-
-export function promptTypeParser(prompt:string):string | PromptParsed{
-    //XML type
-    try {
-        const parser = new DOMParser()
-        const dom = `<root>${prompt}</root>`
-        const xmlDoc = parser.parseFromString(dom, "text/xml")
-        const root = xmlDoc.documentElement
-
-        const errorNode = root.getElementsByTagName('parsererror')
-
-        if(errorNode.length > 0){
-            throw new Error('XML Parse Error') //fallback to other parser
-        }
-
-        const parseNode = (node:Element):string|PromptParsed => {
-            if(node.children.length === 0){
-                return node.textContent
-            }
-
-            const data:{[key:string]:string|PromptParsed} = {}
-
-            for(let i=0;i<node.children.length;i++){
-                const child = node.children[i]
-                data[child.tagName] = parseNode(child)
-            }
-
-            return data
-        }
-
-        const pnresult = parseNode(root)
-
-        if(typeof(pnresult) === 'string'){
-            throw new Error('XML Parse Error') //fallback to other parser
-        }
-
-        return pnresult
-
-    } catch (error) {
-        
-    }
-
-    return prompt
-}
-
-
 export function applyMarkdownToNode(node: Node) {
     if (node.nodeType === Node.TEXT_NODE) {
         const text = node.textContent;


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

Nothing references it or `type PromptParsed`.