### PR TITLE
feat: improve prompt diff replace-block alignment using DP + similarity scoring

### DIFF
--- a/src/lib/Others/PromptDiffModal.svelte
+++ b/src/lib/Others/PromptDiffModal.svelte
@@ -15,6 +15,8 @@
     const SIM_THRESHOLD = 0.35
     const DEFAULT_BAND_MIN = 15
     const DEFAULT_BAND_RATIO = 0.15
+    const FULL_DP_LIMIT = 100
+    const BANDED_DP_LIMIT = 1000
 
 // Types
 // -----------------------------------------------------------------------------
@@ -627,8 +629,8 @@
                 if (nextPart?.added) {
                     const leftLines = linePart.value
                     const rightLines = nextPart.value
-
-                    if (0) {
+                    const maxLen = Math.max(leftLines.length, rightLines.length)
+                    if (maxLen > BANDED_DP_LIMIT) {
                     const n = Math.min(leftLines.length, rightLines.length)
 
                     for (let j = 0; j < n; j++) {
@@ -655,7 +657,10 @@
                     }
                     }
                     else {
-                        const band = Math.max(DEFAULT_BAND_MIN, Math.floor(Math.max(leftLines.length, rightLines.length) * DEFAULT_BAND_RATIO))
+                        const band =
+                            maxLen <= FULL_DP_LIMIT
+                            ? null
+                            : Math.max(DEFAULT_BAND_MIN, Math.floor(maxLen * DEFAULT_BAND_RATIO))
                         const pairs = alignByDP(leftLines, rightLines, SIM_THRESHOLD, band)
                         const replaceBlockPairs = buildAlignmentFromAnchorPair(leftLines.length, rightLines.length, pairs)
 

--- a/src/lib/Others/PromptDiffModal.svelte
+++ b/src/lib/Others/PromptDiffModal.svelte
@@ -10,6 +10,14 @@
     }
     let { firstPresetId, secondPresetId, onClose = () => {} }: Props = $props();
 
+
+// Lazy-loaded diff module
+// -----------------------------------------------------------------------------
+    let diffModulePromise: Promise<typeof import("diff")> | null = null
+    function loadDiffModule() {
+        return (diffModulePromise ??= import("diff"))
+    }
+
 // Config / constants
 // -----------------------------------------------------------------------------
     const SIM_THRESHOLD = 0.35
@@ -542,8 +550,8 @@
     }
 
     async function computeDiffCardLine(prompt1: PromptCard[], prompt2: PromptCard[], style: DiffStyle): Promise<CardDiffSummary> {
-        const { diffArrays } = await import('diff')
-        const arrayDiffs = diffArrays(prompt1, prompt2, {
+        const diff = await loadDiffModule()
+        const arrayDiffs = diff.diffArrays(prompt1, prompt2, {
             comparator: (x, y) => x.body === y.body && x.header === y.header && x.kind === y.kind && x.name === y.name
         })
 
@@ -612,8 +620,8 @@
     }
 
     async function computeDiffLineByLine(prompt1: PromptLine[], prompt2: PromptLine[], style: DiffStyle): Promise<DiffResult> {
-        const { diffArrays } = await import('diff')
-        const arrayDiffs = diffArrays(prompt1, prompt2, {
+        const diff = await loadDiffModule()
+        const arrayDiffs = diff.diffArrays(prompt1, prompt2, {
             comparator: (x, y) => x.text === y.text && x.lineRole === y.lineRole
         })
 
@@ -720,8 +728,8 @@
     }
 
     async function computeDiffFlat(prompt1: string, prompt2: string, style: DiffStyle): Promise<DiffResult> {
-        const { diffLines } = await import('diff')
-        const lineDiffs = diffLines(prompt1, prompt2)
+        const diff = await loadDiffModule()
+        const lineDiffs = diff.diffLines(prompt1, prompt2)
 
         const parts: DiffPart[] = []
         let modifiedCount = 0, addedCount = 0, removedCount = 0
@@ -767,8 +775,8 @@
     }
 
     async function diffIntralineTokens(string1: string, string2: string): Promise<WordToken[]> {
-        const { diffWordsWithSpace } = await import('diff')
-        const charDiffs = diffWordsWithSpace(string1, string2)
+        const diff = await loadDiffModule()
+        const charDiffs = diff.diffWordsWithSpace(string1, string2)
 
         return charDiffs.map(charPart => {
             if (charPart.added) return { t: 'add', v: charPart.value }

--- a/src/lib/Others/PromptDiffModal.svelte
+++ b/src/lib/Others/PromptDiffModal.svelte
@@ -786,7 +786,7 @@
     }
 
 
-// Similarity helpers
+// Line alignment (similarity + DP + pairing)
 // -----------------------------------------------------------------------------
     function normalizeText(s: string): string {
         return s.trim().replace(/^[\s>*\-•]+/, "").replace(/\s+/g, " ").replace(/[!?.,]+$/, "").toLowerCase()

--- a/src/lib/Others/PromptDiffModal.svelte
+++ b/src/lib/Others/PromptDiffModal.svelte
@@ -670,7 +670,7 @@ const t0 = performance.now();
                     }
                     }
                     else {
-                        const pairs = alignByDP(leftLines, rightLines)
+                        const pairs = alignByDP(leftLines, rightLines, 15)
                         const replaceBlockPairs = buildAlignmentFromAnchorPair(leftLines.length, rightLines.length, pairs)
 
                         for (const pair of replaceBlockPairs) {
@@ -910,7 +910,7 @@ const t0 = performance.now();
     const DIR_LEFT = 2
     const DIR_DIAG = 3
     
-    function alignByDP(leftOrig: PromptLine[], rightOrig: PromptLine[]): Pair[] {
+    function alignByDP(leftOrig: PromptLine[], rightOrig: PromptLine[], bandWidth: number | null): Pair[] {
         const left = prepareLines(leftOrig)
         const right = prepareLines(rightOrig)
 
@@ -925,8 +925,19 @@ const t0 = performance.now();
 
         const SIM_THRESHOLD = 0.35
 
+        const useBand = bandWidth !== null && bandWidth >= 0 && bandWidth < Math.max(n, m)
+        const diagSlope = n > 0 ? m / n : 0
+
         for (let i = 1; i <= n; i++) {
-            for (let j = 1; j <= m; j++) {
+            let jStart = 1
+            let jEnd = m
+            if (useBand) {
+                const center = Math.round(i * diagSlope)
+                jStart = Math.max(1, center - bandWidth)
+                jEnd = Math.min(m, center + bandWidth)
+            }
+
+            for (let j = jStart; j <= jEnd; j++) {
                 const upIdx = idx(i - 1, j)
                 const leftIdx = idx(i, j - 1)
                 const diagIdx = idx(i - 1, j - 1)
@@ -962,7 +973,7 @@ const t0 = performance.now();
         let i = n
         let j = m
 
-        while (i > 0 && j > 0) {
+        outer: while (i > 0 && j > 0) {
             const d = dirs[idx(i, j)]
             switch (d) {
                 case DIR_DIAG:
@@ -976,7 +987,7 @@ const t0 = performance.now();
                     j--
                     break
                 default:
-                    break
+                    break outer
             }
         }
 

--- a/src/lib/Others/PromptDiffModal.svelte
+++ b/src/lib/Others/PromptDiffModal.svelte
@@ -2,7 +2,6 @@
     import { XIcon } from "@lucide/svelte"
     import { getDatabase, type PromptDiffPrefs } from "../../ts/storage/database.svelte"
     import type { PromptItem, PromptItemPlain, PromptItemChatML, PromptItemTyped, PromptItemAuthorNote, PromptItemChat } from "src/ts/process/prompt.ts";
-import { tick } from 'svelte';
 
     interface Props {
         firstPresetId: number;
@@ -87,11 +86,6 @@ import { tick } from 'svelte';
     type DiffSegment =
         | { kind: 'context' | 'changes'; parts: DiffPart[] }
         | { kind: 'divider'; pos: 'start' | 'between' | 'end'; omitted: number; id: string; from: number; to: number }
-
-    type DPCell = {
-        score: number
-        from: "none" | "up" | "left" | "diag"
-    }
 
     type Pair = {
         leftIndex: number
@@ -460,7 +454,7 @@ import { tick } from 'svelte';
     async function recomputeDiff(firstCards: PromptCard[], secondCards: PromptCard[]) {
         if (!firstCards || !secondCards) return
         const runId = ++diffRunId
-const t0 = performance.now();
+
         if (isFlatText) {
             const r = await computeDiffFlat(renderRaw(firstCards), renderRaw(secondCards), diffStyle)
             if (runId !== diffRunId) return
@@ -471,22 +465,8 @@ const t0 = performance.now();
 
         const cr = await computeCardViewDiff(firstCards, secondCards, diffStyle)
         if (runId !== diffRunId) return
-            const t1 = performance.now();
         cardDiffResult = cr
-            const t2 = performance.now();
         diffResult = null
-            await tick(); // 여기까지 오면 Svelte가 DOM 패치 완료한 시점
-    const t3 = performance.now();
-
-        requestAnimationFrame(() => {
-      const t4 = performance.now();
-      alert(
-        `compute: ${(t1 - t0).toFixed(2)}ms\n` +
-        `assign: ${(t2 - t1).toFixed(2)}ms\n` +
-        `svelte DOM flush: ${(t3 - t2).toFixed(2)}ms\n` +
-        `paint latency (rAF): ${(t4 - t3).toFixed(2)}ms`
-      );
-    });
     }
 
     async function computeCardViewDiff(prompt1: PromptCard[], prompt2: PromptCard[], style: DiffStyle): Promise<CardDiffResult> {


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description
## Summary

This improves how we align lines inside a "replace" block in prompt-diff.

Previously, lines were paired purely by index (line `i` on the left with line `i` on the right). This works for simple edits, but breaks down when there are insertions/deletions/reordering inside the block and leads to noisy intraline diffs.

This PR replaces the index-based pairing with a **similarity-based DP alignment**.

This is a follow-up to #1114, which originally introduced the prompt-diff feature.

See the before/after comparison below.

## Screenshots

### Before

| Mode | Before (index-based pairing) | After (similarity-based DP alignment) |
| ---- | ------ | ----- |
| **Intraline diff** | <img width="803" height="245" alt="1" src="https://github.com/user-attachments/assets/1a934208-f144-4908-a696-8d87fb1155c3" /><br/>*Different lines are paired and shown as a single **modify** block, which makes the intraline diff misleading.* | <img width="797" height="255" alt="2" src="https://github.com/user-attachments/assets/69c548a9-a642-46fa-925a-46dffa0ab5ef" /><br/>*The actually edited lines are correctly matched, so the intraline diff highlights only the real changes.* |
| **Split view** |<img width="795" height="376" alt="3" src="https://github.com/user-attachments/assets/6271eb54-b646-446a-9a1b-527b0085bf50" /><br/>*In split view it becomes more obvious that unrelated lines are being paired as **modify**, which looks confusing.* | <img width="791" height="367" alt="4" src="https://github.com/user-attachments/assets/1bb00c57-6c4c-4574-a3e7-233c33a1e72f" /><br/>*In split view, highly similar lines are paired together, so the diff reads much more intuitively.* |

## How it works
### Line similarity + DP alignment

- Normalize each line (trim, strip bullets, collapse whitespace, lowercase).
- For each pair of lines, compute a similarity score that mixes:
  - a prefix/suffix score on the raw text, and
  - a bigram Dice similarity on normalized text.
- Run a dynamic programming alignment over the two sequences of lines to find an order-preserving alignment that maximizes the total similarity.
- Expand the DP anchors into a full alignment and use it to decide which lines become `modify` vs `add` vs `remove`.

### Implementation details / optimizations

- Precompute per-line normalized text and bigram profiles and reuse them.
- Store the DP table in flat `Float32Array`/`Uint8Array` instead of a 2D grid of objects to avoid per-cell allocations.
- Use length-based upper bounds on prefix/suffix and Dice scores to skip expensive similarity computations when we know they cannot reach the threshold.
- Choose the alignment strategy per replace block size to balance accuracy and performance:
  - use full DP for blocks with < 100 lines,
  - banded DP for blocks with < 1000 lines,
  - and fall back to the previous index-based pairing for very large blocks.

## Funtions
### `buildBigramProfile`
 
```ts
// buildBigramProfile builds a multiset of character bigrams for a string,
// packed into 32-bit integers (two charCodes), and stores the total number
// of bigrams for later Dice similarity computation.
function buildBigramProfile(s: string): BigramProfile { ... }
```

### `prepareLines`

```ts
// prepareLines precomputes normalized text, lengths, and a bigram profile
// for each line, so that line similarity can reuse this data without
// re-normalizing or re-tokenizing every time.
function prepareLines(lines: PromptLine[]): PreparedLine[] { ... }
```

### `diceFromProfiles`
```ts
// diceFromProfiles computes the bigram Dice similarity between two
// BigramProfiles: 2 * |A ∩ B| / (|A| + |B|). We iterate over the smaller
// map to keep it efficient.
function diceFromProfiles(a: BigramProfile, b: BigramProfile): number { ... }
```

### `prefixSuffixScore`
```ts
// prefixSuffixScore measures how much of the *edges* (prefix + suffix)
// of the two raw lines match. It rewards common leading/trailing text and
// interpolates the score based on the length ratio, so large length
// mismatches are penalized.
function prefixSuffixScore(a: string, b: string): number { ... }
```

### `lineSimilarity`
```ts
// lineSimilarity computes a thresholded similarity between two prepared lines.
// It first computes cheap upper bounds for prefix/suffix and Dice scores
// based on string lengths and bigram counts. If the best possible combined
// score cannot reach the threshold, it returns 0 early.
// Otherwise it computes prefixSuffixScore (and, if needed, the full Dice)
// and returns the final mixed score, or 0 if still below the threshold.
function lineSimilarity(a: PreparedLine, b: PreparedLine, threshold: number): number { ... }
```

### `alignByDP`
```ts
// alignByDP performs a dynamic programming alignment between two sequences
// of lines. Each DP cell considers:
//   - skipping a left line,
//   - skipping a right line,
//   - or matching a pair of lines and adding their similarity
//     (if it is >= threshold).
// The DP table is stored in flat typed arrays (scores + directions), and
// can optionally be restricted to a band around the main diagonal for
// performance on larger blocks.
function alignByDP(
  leftOrig: PromptLine[],
  rightOrig: PromptLine[],
  threshold: number,
  bandWidth: number | null,
): Pair[] { ... }
```

### `buildAlignmentFromAnchorPair`
```ts
// buildAlignmentFromAnchorPair expands the DP anchor pairs into a full
// line-by-line alignment, inserting (left-only) and (right-only) gaps
// between anchors. The result is a sequence of PairCell entries that
// drives how we classify lines as modify/add/remove inside a replace block.
function buildAlignmentFromAnchorPair(
  nLeft: number,
  nRight: number,
  pairs: Pair[],
): PairCell[] { ... }
```

## Performance

Numbers below measure alignment computation only (no rendering), on local devices.

**2021 MacBook Pro (M1 Pro), macOS Sequoia 15.5**

- Single ~160-line replace block  
  - previous index-based pairing: ~21 ms  
  - new similarity-based DP: ~30 ms

- Single ~900-line replace block  
  - previous index-based pairing: ~180 ms  
  - new similarity-based DP: ~300 ms

**iPhone 8, iOS 16**

- Single ~160-line replace block  
  - previous index-based pairing: ~25 ms  
  - new similarity-based DP: ~40 ms

The extra cost is small compared to the gain in alignment quality (especially when lines are inserted/deleted in the middle of a block).

For replace blocks larger than 1000 lines, the implementation still falls back to the previous index-based pairing strategy to keep worst-case latency under control.

> Note: 160–900-line single replace blocks are not typical in normal usage; these measurements are intended as a worst-case/stress test for large blocks.

---

There are many possible approaches here. This implementation intentionally prioritizes readability, predictable performance, and maintainability, since prompt-diff is a supporting feature and this project is not a dedicated, full-featured text editor.

Happy to adjust anything if you have concerns or suggestions.

Thanks for taking the time to review this!
