### PR TITLE
test: Add newly found edge cases of #if

### DIFF
--- a/src/ts/parser/tests/cbs/conditionals.test.ts
+++ b/src/ts/parser/tests/cbs/conditionals.test.ts
@@ -86,19 +86,34 @@ describe('#if', () => {
   test('renders when "1" or "true"', () => {
     expect(quickParse('#if 1', 'CBS')).toBe(`0 CBS 9`)
     expect(quickParse('#if true', 'CBS')).toBe(`0 CBS 9`)
+
+    // Edge case: {{#if 1\s+.*}} also renders
+    fc.assert(
+      fc.property(
+        fc.constantFrom('1', 'true'),
+        fc.stringMatching(/^ +[^#:{}\r\n]*$/),
+        (truthy, tail) => {
+          expect(quickParse(`#if ${truthy}${tail}`, 'CBS')).toBe(`0 CBS 9`)
+        }
+      ),
+    )
   })
 
   test('does not render when anything else', async () => {
     expect(quickParse('#if 0', 'CBS')).toBe('0  9')
     expect(quickParse('#if false', 'CBS')).toBe('0  9')
 
+    // Edge case: {{#if \s+1}} does not render
+    expect(quickParse('#if  1', 'CBS')).toBe(`0  9`)
+    expect(quickParse('#if   true', 'CBS')).toBe(`0  9`)
+
     fc.assert(
       fc.property(
-        validCBSArgProp.filter((s) => s !== '1' && s !== 'true'),
+        validCBSArgProp.filter((s) => !/^1|(?:true)\s*/.test(s)),
         (anythingElse) => {
           expect(quickParse(`#if ${anythingElse}`, 'CBS')).toBe(`0  9`)
         }
-      )
+      ),
     )
   })
 
@@ -118,19 +133,34 @@ describe('#if_pure', () => {
   test('renders when "1" or "true"', () => {
     expect(quickParse('#if_pure 1', 'CBS')).toBe(`0 CBS 9`)
     expect(quickParse('#if_pure true', 'CBS')).toBe(`0 CBS 9`)
+
+    // Edge case: {{#if_pure 1\s+.*}} also renders
+    fc.assert(
+      fc.property(
+        fc.constantFrom('1', 'true'),
+        fc.stringMatching(/^ +[^#:{}\r\n]*$/),
+        (truthy, tail) => {
+          expect(quickParse(`#if_pure ${truthy}${tail}`, 'CBS')).toBe(`0 CBS 9`)
+        }
+      ),
+    )
   })
 
   test('does not render when anything else', async () => {
     expect(quickParse('#if_pure 0', 'CBS')).toBe('0  9')
     expect(quickParse('#if_pure false', 'CBS')).toBe('0  9')
 
+    // Edge case: {{#if_pure \s+1}} does not render
+    expect(quickParse('#if_pure  1', 'CBS')).toBe(`0  9`)
+    expect(quickParse('#if_pure   true', 'CBS')).toBe(`0  9`)
+
     fc.assert(
       fc.property(
-        validCBSArgProp.filter((s) => s !== '1' && s !== 'true'),
+        validCBSArgProp.filter((s) => !/^1|(?:true)\s*/.test(s)),
         (anythingElse) => {
           expect(quickParse(`#if_pure ${anythingElse}`, 'CBS')).toBe(`0  9`)
         }
-      )
+      ),
     )
   })
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

fast-check has found out that for `#if` and `#if_pure`, these render:

```
#if true                
#if true    ab
#if 1        !^%zzc
```

But these don't render:

```
#if  true
#if    1
```

This PR adds test cases for these edge cases.