### PR TITLE
fix: Partial backup asset path handling in Tauri

### DIFF
--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -263,7 +263,7 @@ export async function SavePartialLocalBackup(){
                 continue
             }
 
-            const keyWithPrefix = 'assets/' + asset.name;
+            const keyWithPrefix = asset.name.startsWith('assets/') ? asset.name : `assets/${asset.name}`
             if(!keyWithPrefix.endsWith('.png')){
                 continue
             }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Fixed an issue where partial local backup in Tauri failed to save assets due to path prefix mismatch.

- readDir() returns filenames without 'assets/' prefix in Tauri
- assetMap keys include 'assets/' prefix
- Added keyWithPrefix variable to ensure consistent key format
- Now backup correctly matches and saves all mapped assets

Sorry for my previous mistake.

# Test
I tested it with my tauri save file

## Save in Tauri
<img width="98" height="862" alt="image" src="https://github.com/user-attachments/assets/f051d658-48ea-4efa-a62c-d29631616631" />

## Load Result in Web
<img width="108" height="946" alt="image" src="https://github.com/user-attachments/assets/e1fab722-4914-440f-8848-0e221bfb1b1a" />

