### PR TITLE
chore: Update `@adobe/css-tools` to 4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hono:build": "vite build --sourcemap && node server/hono/src/utils/postbuild.js"
   },
   "dependencies": {
-    "@adobe/css-tools": "4.3.2",
+    "@adobe/css-tools": "4.4.4",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@breezystack/lamejs": "^1.2.7",
     "@browsermt/bergamot-translator": "^0.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@adobe/css-tools':
-        specifier: 4.3.2
-        version: 4.3.2
+        specifier: 4.4.4
+        version: 4.4.4
       '@aws-crypto/sha256-js':
         specifier: ^5.2.0
         version: 5.2.0
@@ -318,8 +318,8 @@ importers:
 
 packages:
 
-  '@adobe/css-tools@4.3.2':
-    resolution: {integrity: sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==}
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@aws-crypto/sha256-js@5.2.0':
     resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
@@ -4086,7 +4086,7 @@ packages:
 
 snapshots:
 
-  '@adobe/css-tools@4.3.2': {}
+  '@adobe/css-tools@4.4.4': {}
 
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description

[An issue of the package](https://github.com/adobe/css-tools/issues/271) is blocking its dts files from loading.

<img width="751" height="112" alt="image" src="https://github.com/user-attachments/assets/9c3e834c-9aed-48e2-bd38-2b364e1f7662" />

This has been fixed in 4.3.3.

This PR updates it to the latest, 4.4.4, for a new at-rule support and a bit of performance gain.

<img width="1175" height="346" alt="image" src="https://github.com/user-attachments/assets/c090539a-3e43-4b7e-b16f-9a82cb4aa0b3" />
