### PR TITLE
refactor: Cache getAssetSrc/getEmoSrc results

### DIFF
--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 import type { character, Database, groupChat } from "./storage/database.svelte";
-import { resetAssetsCache, type simpleCharacterArgument } from "./parser.svelte";
+import { type simpleCharacterArgument } from "./parser.svelte";
 import type { alertData } from "./alert";
 import { moduleUpdate } from "./process/modules";
 import { resetScriptCache } from "./process/scripts";
@@ -147,7 +147,6 @@ export const hotReloading = $state<string[]>([])
 
 ReloadGUIPointer.subscribe(() => {
     ReloadChatPointer.set({})
-    resetAssetsCache()
     resetScriptCache()
 })
 


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

## Motivation

If you run a measurement, the waterfall which `ChatBody` draws is far from ideal.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e6bc9c60-3114-41d7-9a2d-49417647062e" />

And the bulk of it is caused by repeated calls to `getAssetSrc()`, taking more than 60%. Since those `get$2()` are also caused by `getAssetSrc()`, it really is a bottleneck.

<img width="599" height="155" alt="image" src="https://github.com/user-attachments/assets/f8799ed6-1680-4175-8adc-627153549fc3" />

## Implementation

~~This is somewhat lame implementation, but I'm caching `getAsserSrc()` return values. It's the most quickest way to resolve current performance issue with asset-heavy chars/modules, without major rewrites.~~

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2798ecce-74ef-4791-a416-71bb26d3bc44" />

~~Now the same measurement only takes less than 200ms, 70% faster.~~

~~The cache is invalidated when `ReloadGUIPointer` changes, as usual.~~

New implementation: Still caches the result, but will react to any asset changes realtime, rather than `ReloadGUIPointer`. Performance measurements are similar to the above image.