### PR TITLE
feat: Add caption/textarea toggles

### DIFF
--- a/src/lib/SideBars/Toggles.svelte
+++ b/src/lib/SideBars/Toggles.svelte
@@ -8,6 +8,7 @@
     import CheckInput from "../UI/GUI/CheckInput.svelte";
     import SelectInput from "../UI/GUI/SelectInput.svelte";
     import OptionInput from "../UI/GUI/OptionInput.svelte";
+    import TextAreaInput from '../UI/GUI/TextAreaInput.svelte'
     import TextInput from "../UI/GUI/TextInput.svelte";
 
     interface Props {
@@ -59,6 +60,15 @@
             <div class="w-full flex gap-2 mt-2 items-center" class:justify-end={$MobileGUI}>
                 <span>{toggle.value}</span>
                 <TextInput className="w-32" bind:value={DBState.db.globalChatVariables[`toggle_${toggle.key}`]} />
+            </div>
+        {:else if toggle.type === 'textarea'}
+            <div class="w-full flex gap-2 mt-2 items-start" class:justify-end={$MobileGUI}>
+                <span class="mt-1.5">{toggle.value}</span>
+                <TextAreaInput className="w-32" height='20' bind:value={DBState.db.globalChatVariables[`toggle_${toggle.key}`]} />
+            </div>
+        {:else if toggle.type === 'caption'}
+            <div class="w-full mt-1 text-xs text-textcolor2">
+                {toggle.value}
             </div>
         {:else if toggle.type === 'divider'}
             <!-- Prevent multiple dividers appearing in a row -->

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -1026,6 +1026,11 @@ export type sidebarToggle =
     | {
         key?:string,
         value?:string,
+        type:'caption',
+    } 
+    | {
+        key?:string,
+        value?:string,
         type:'divider',
     } 
     | {
@@ -1037,7 +1042,7 @@ export type sidebarToggle =
     | {
         key:string,
         value:string,
-        type:'text'|undefined,
+        type:'text'|'textarea'|undefined,
         options?:string[]
     }
 
@@ -1060,11 +1065,17 @@ export function parseToggleSyntax(template:string){
                     type,
                     children: []
                 })
+            } else if(type === 'caption' && value){
+                keyValue.push({
+                    key,
+                    value,
+                    type
+                })
             } else if((key && value)){
                 keyValue.push({
                     key,
                     value,
-                    type: type === 'select' || type === 'text' ? type : undefined,
+                    type: type === 'select' || type === 'text' || type === 'textarea' ? type : undefined,
                     options: option?.split(',') ?? []
                 })
             }


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

```
mood=Mood=textarea
=How to depict the scene=caption
```

## Motivation

### Caption

<img width="256" alt="image" src="https://github.com/user-attachments/assets/e4368152-195e-45fd-8876-4ec7297ab7a0" />

It'd help both creators and users if toggles can communicate what they are. In the past, fake checkboxes served the purpose, and currently, dividers that are not really dividers do so.

But dividers, inherently, divides. More dividers, more visual clutter. And they have the same visual hierarchy with other controls, hindering readability.

This PR adds a dedicated `caption` type toggle with lower presence.

<img width="256" alt="image" src="https://github.com/user-attachments/assets/4ea89783-ae3a-49da-9eca-052266d3be73" />

### Textarea

<img width="256" alt="image" src="https://github.com/user-attachments/assets/7304c3c0-3ef7-41f4-bb78-a613124cbc4e" />

Text toggles do their job well but lacks in:

- Ability to input line breaks
- Unsuitable for long texts

Textarea toggle can help with both.

- Can break lines
- Larger surface area, scrolls vertically

<img width="256" alt="image" src="https://github.com/user-attachments/assets/7f84afa1-8fa6-482f-a52e-58a1dca5c285" />
