### PR TITLE
feat: Enable F12 DevTools in Tauri builds

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "2.2.0", features = [] }
 
 [dependencies]
-tauri = { version = "2.9.5", features = ["protocol-asset"] }
+tauri = { version = "2.9.5", features = ["protocol-asset", "devtools"] }
 serde_json = "1.0"
 tiktoken-rs = "0.4.0"
 base64 = "0.21.0"


### PR DESCRIPTION
# PR Checklist
- [x] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] Have you added type definitions?

# Description

Enables F12 DevTools in Tauri desktop builds by adding the `devtools` feature flag to `src-tauri/Cargo.toml`. (dependencies)

This allows developers and plugin creators to access browser DevTools for debugging. Only affects Tauri builds - web and node versions are unaffected.

## Changes
- Added `"devtools"` to Tauri features

## Testing
- Tested on Windows Tauri build - F12 successfully opens DevTools