### PR TITLE
fix: update missing inlay tag in imggen inlay mode

### DIFF
--- a/src/ts/process/inlayScreen.ts
+++ b/src/ts/process/inlayScreen.ts
@@ -26,7 +26,7 @@ export function runInlayScreen(char:character, data:string):{text:string, promis
                                 const imgHTML = new Image()
                                 imgHTML.src = v
                                 const inlay = await writeInlayImage(imgHTML)
-                                return inlay
+                                return `{{inlay::${inlay}}}`
                             })())
                             return match
                         })


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
This issue was a regression caused by a refactor (commit 2fee3aa7). At that time, the `writeInlayImage` function in [inlays.ts](src/ts/process/files/inlays.ts) was modified to return a raw **UUID string** instead of a formatted tag (`{{inlay::UUID}}`) to simplify the implementation of image previews in the chat input UI.

However, the `runInlayScreen` function in [inlayScreen.ts](src/ts/process/inlayScreen.ts) remained unchanged. It directly injects the return value of `writeInlayImage` into the message text. Since the return value was changed to a raw UUID, the message parser no longer recognizes it as an image asset, causing the rendering break.

### How to Reproduce
1. Set a character's **Additional Character Screen** to `Image Generation`.
2. Enable the **Inlay Screen** option on the bottom.
3. Chat with the character and trigger an output containing `<ImgGen="...">` or `{{ImgGen="..."}}`.
4. Wait for the image generation to complete.

### Behavior
*   **Actual Behavior**: After the `[Generating...]` placeholder disappears, a raw UUID string (e.g., `550e8400-e29b-41d4-a716-446655440000`) is displayed in the chat.
*   **Expected Behavior**: The generated image should be rendered within the chat message.

### Fix
Since `writeInlayImage` is now designed to return a raw ID for UI flexibility, I have updated `runInlayScreen` to manually wrap the returned ID in the required `{{inlay::...}}` tag format before performing the text replacement. This ensures the parser correctly identifies and renders the asset.

### Note to Reviewers
Since I do not have access to existing image generation providers (like NovelAI or Stable Diffusion WebUI) for testing, I performed my verification using a new provider currently under development in this branch: [`feature/chutes-image-20260114`](https://github.com/luyiourwong/RisuAI/tree/feature/chutes-image-20260114). 

While this fix works perfectly with my new implementation, I would appreciate it if someone with access to existing providers could double-check if this aligns with their current behavior.
