### PR TITLE
fix: Exclude account information from local backups

### DIFF
--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -139,7 +139,8 @@ export async function SaveLocalBackup(){
         }
     }
 
-    const dbData = encodeRisuSaveLegacy(getDatabase(), 'compression')
+    const dbWithoutAccount = { ...db, account: undefined }
+    const dbData = encodeRisuSaveLegacy(dbWithoutAccount, 'compression')
 
     alertWait(`Saving local Backup... (Saving database)`) 
 
@@ -337,7 +338,8 @@ export async function SavePartialLocalBackup(){
         }
     }
 
-    const dbData = encodeRisuSaveLegacy(getDatabase(), 'compression')
+    const dbWithoutAccount = { ...db, account: undefined }
+    const dbData = encodeRisuSaveLegacy(dbWithoutAccount, 'compression')
 
     alertWait(`Saving partial local backup... (Saving database)`) 
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly ai generated[^2], check the following:
    - [ ] Have you understanded what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary
This pr changes all local backup methods to exclude account information.


## Background & Analysis
I investigated the potential issue #1174 raised regarding local backups:

> Account information must never be included.
> regarding the first point, if account information is included in the backup, then when restoring it while “save data to account” is enabled, account data saving is triggered. This causes the existing backup data stored in the account to be automatically overwritten, resulting in the account backup being updated in a state where all characters are missing.

After analyzing the code, I concluded that this concern is **not entirely accurate** in terms of how the synchronization logic works.

While it is true that login information resides in the database (which is included in local backups), the actual synchronization process is distinct. As shown in the code below, enabling account data synchronization is ultimately a manual choice made by the user via the UI, regardless of the data present in the backup.

```javascript
{#if DBState.db.account.useSync || forageStorage.isAccount}
    <Check check={true} name={language.SaveDataInAccount} onChange={(v) => {
        if(v){
            unMigrationAccount()
        }
    }}/>
{:else}
    <Check check={false} name={language.SaveDataInAccount} onChange={(v) => {
        if(v){
            localStorage.setItem('dosync', 'sync')
            location.reload()
        }
    }}/>
{/if}
```

## Conclusion
However, I agree that there is no reason to retain account information in local backup files.

Even if the overwrite doesn't happen automatically, removing sensitive account data from local exports acts as a safeguard. This change prevents potential user errors and ensures a safer backup/restore process.

But if it's intended, you can just close it.
Actually you know much better than me about the account sync haha