### PR TITLE
feat: add default value support to alertInput and related components

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -240,7 +240,7 @@
             chat.bookmarks.push(messageId);
 
             const msgSender = chat.message[idx]?.role === 'user' ? getUserName() : name;
-            const newName= await alertInput(language.bookmarkAskNameOrDefault);
+            const newName= await alertInput(language.bookmarkAskNameOrDefault, [], chat.bookmarkNames[messageId] || '');
 
             if (newName && newName.trim() !== '') {
                 chat.bookmarkNames[messageId] = newName;

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -300,7 +300,7 @@
                     })
                 }}>OK</Button>
             {:else if $alertStore.type === 'input'}
-                <TextInput value="" id="alert-input" autocomplete="off" marginTop list="alert-input-list" />
+                <TextInput value={$alertStore.defaultValue} id="alert-input" autocomplete="off" marginTop list="alert-input-list" />
                 <Button className="mt-4" onclick={() => {
                     alertStore.set({
                         type: 'none',

--- a/src/lib/Others/BookmarkList.svelte
+++ b/src/lib/Others/BookmarkList.svelte
@@ -92,7 +92,7 @@
 
     async function editName(chatId: string) {
         const chat = chara.chats[chara.chatPage];
-        const newName = await alertInput(language.bookmarkAskNameOrCancel);
+        const newName = await alertInput(language.bookmarkAskNameOrCancel, [], chat.bookmarkNames?.[chatId] || '');
         if (newName && newName.trim() !== '') {
             chat.bookmarkNames[chatId] = newName;
         }

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -815,7 +815,7 @@
 
                     const id = DBState.db.hypaV3PresetId
                     const preset = presets[id]
-                    const newName = await alertInput(`Enter new name for ${preset.name}`)
+                    const newName = await alertInput(`Enter new name for ${preset.name}`, [], preset.name)
 
                     if (!newName || newName.trim().length === 0) return
 

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -554,7 +554,7 @@
                 e.preventDefault()
                 const sel = parseInt(await alertSelect([language.renameFolder,language.changeFolderColor,language.changeFolderImage,language.cancel]))
                 if(sel === 0){
-                  const v = await alertInput(language.changeFolderName)
+                  const v = await alertInput(language.changeFolderName, [], char.name)
                   const db = DBState.db
                   if(v){
                     const oder = db.characterOrder[ind]

--- a/src/ts/alert.ts
+++ b/src/ts/alert.ts
@@ -14,6 +14,7 @@ export interface alertData{
     submsg?: string
     datalist?: [string, string][],
     stackTrace?: string;
+    defaultValue?: string
 }
 
 type AlertGenerationInfoStoreData = {
@@ -252,12 +253,13 @@ export async function alertTOS(){
     return false
 }
 
-export async function alertInput(msg:string, datalist?:[string, string][]) {
+export async function alertInput(msg:string, datalist?:[string, string][], defaultValue?:string) {
 
     alertStoreImported.set({
         'type': 'input',
         'msg': msg,
-        'datalist': datalist ?? []
+        'datalist': datalist ?? [],
+        'defaultValue': defaultValue ?? ''
     })
 
     await waitAlert()


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly ai generated[^2], check the following:
    - [ ] Have you understanded what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

The defaultValue property was added to alertInput to allow pre-entering of a word.

## Related Issues

During testing, pressing the Esc key occasionally resulted in 0 being entered. This is a bug caused by interaction with the Esc button, and will need to be fixed later, but is not covered in this PR.

## Changes

A defaultValue property was added to alertInput, and some elements that use alertInput were modified to use defaultValue. Key and password fields were not touched.

## Impact

For example, when renaming bookmarks, folders, etc., you can edit the desired field instead of renaming them from beginning. This feature can also be used in other development projects.
<img width="248" height="197" alt="image" src="https://github.com/user-attachments/assets/3cff31b6-7b2b-4b2e-92c8-0622377dcca2" />

## Additional Notes

This feature needs to be modified to work with v2trigger and lua, but since another PR #998 is currently in progress, I'll rewrite this later.