### PR TITLE
test: Add `#when` multiple operators + logical operator case

### DIFF
--- a/src/ts/parser/tests/cbs/conditionals.test.ts
+++ b/src/ts/parser/tests/cbs/conditionals.test.ts
@@ -257,6 +257,24 @@ describe('#when', () => {
       expect(quickParse('#when::0::or::0', 'CBS')).toBe(`0  9`)
       expect(quickParse('#when::0::or::not::false', 'CBS')).toBe(`0 CBS 9`)
     })
+
+    test('right-to-left evaluation', () => {
+      expect(quickParse('#when::1::or::0::and::0', 'CBS')).toBe(`0 CBS 9`)
+      expect(quickParse('#when::0::or::1::and::0', 'CBS')).toBe(`0  9`)
+      expect(quickParse('#when::0::or::0::and::1', 'CBS')).toBe(`0  9`)
+
+      expect(quickParse('#when::1::and::1::or::0', 'CBS')).toBe(`0 CBS 9`)
+      expect(quickParse('#when::1::and::0::or::1', 'CBS')).toBe(`0 CBS 9`)
+      expect(quickParse('#when::0::and::1::or::1', 'CBS')).toBe(`0  9`)
+    })
+
+    test.skip('Lower precedence than other operators', () => {
+      // FIXME: left-hand/right-hand must be evaluated first, then or
+      // Given #when::a::tis::3::or::b::tis::7
+      //   AS-IS: a::tis::3 -> 1, 1::or::7 -> 1, 1::tis::7 -> 0
+      //   TO-BE: a::tis::3 -> 1, b::tis::7 -> 1, 1::or::1 -> 1
+      expect(quickParse('#when::3::tis::3::or::7::tis::7', 'CBS')).toBe(`0 CBS 9`)
+    })
   })
 
   describe('Operators: whitespaces', () => {
@@ -285,7 +303,7 @@ describe('#when', () => {
       )
     })
 
-    test('::vis, visnot', () => {
+    test('::vis, visnot, tis, tisnot', () => {
       fc.assert(
         fc.property(validCBSArgProp, validCBSArgProp, (a, b) => {
           fc.pre(a !== b)


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly ai generated[^2], check the following:
    - [ ] Have you understanded what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

Thes PR covers two cases of `#when` regarding composited operator usages:

- That `::and::` and `::or::` have no precedence, only right-to-left evaluation
- That `::and::` and `::or::` should be evaluated at last (currently not working, skipped)

## Related Issues

None.

## Changes

No code changes other than the test file.

## Impact

None.
