### PR TITLE
refactor: Import lodash functions from individual modules

### DIFF
--- a/src/lang/index.ts
+++ b/src/lang/index.ts
@@ -1,4 +1,4 @@
-import { merge } from "lodash";
+import merge from "lodash/merge";
 import { languageChinese } from "./cn";
 import { languageGerman } from "./de";
 import { languageEnglish } from "./en";

--- a/src/lib/ChatScreens/ChatBody.svelte
+++ b/src/lib/ChatScreens/ChatBody.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { isEqual } from "lodash"
+    import isEqual from "lodash/isEqual"
     import { DBState } from 'src/ts/stores.svelte'
     import { sleep } from "src/ts/util"
     import { alertError } from "../../ts/alert"

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -38,7 +38,7 @@
   } from "../../ts/characters";
     import CharConfig from "./CharConfig.svelte";
     import { language } from "../../lang";
-    import { isEqual } from "lodash";
+    import isEqual from "lodash/isEqual";
     import SidebarAvatar from "./SidebarAvatar.svelte";
     import BaseRoundedButton from "../UI/BaseRoundedButton.svelte";
     import { getCharacterIndexObject, selectSingleFile } from "src/ts/util";

--- a/src/ts/process/group.ts
+++ b/src/ts/process/group.ts
@@ -1,4 +1,4 @@
-import { shuffle } from "lodash";
+import shuffle from "lodash/shuffle";
 import { findCharacterbyId } from "../util";
 import { alertConfirm, alertError, alertSelectChar } from "../alert";
 import { language } from "src/lang";

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -7,7 +7,7 @@ import { CharEmotion } from "../stores.svelte"
 import type { OpenAIChat } from "./index.svelte"
 import { processZip } from "./processzip"
 import { keiServerURL } from "../kei/kei"
-import { random } from "lodash"
+import random from "lodash/random"
 
 export async function stableDiff(currentChar:character,prompt:string){
     let db = getDatabase()


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly ai generated[^2], check the following:
    - [ ] Have you understanded what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

Instead of `import { foo } from 'lodash'`, uses `import foo from 'lodash/foo'`.

## Related Issues

None.

## Changes

By doing so, all other unused lodash functions will not get into the main bundle. This PR reduces the bundle around 40kb.

## Impact

None.
