### PR TITLE
test: Add selIdState to stores.svelte mocks

### DIFF
--- a/src/ts/parser/tests/cbs/conditionals.test.ts
+++ b/src/ts/parser/tests/cbs/conditionals.test.ts
@@ -35,12 +35,11 @@ const varStorage = vi.hoisted(
 )
 
 vi.mock(import('../../../stores.svelte'), () => {
-  // @ts-expect-error Minimal mock
   return {
     DBState: {
       db: {
-        characters: {
-          char: {
+        characters: [
+          {
             chatPage: 0,
             chats: [
               {
@@ -49,12 +48,15 @@ vi.mock(import('../../../stores.svelte'), () => {
             ],
             defaultVariables: '',
           },
-        },
+        ],
         globalChatVariables: varStorage,
         templateDefaultVariables: '',
       },
     },
-    selectedCharID: writable('char'),
+    selIdState: {
+      selId: 0,
+    },
+    selectedCharID: writable(0),
   } as typeof import('../../../stores.svelte')
 })
 

--- a/src/ts/parser/tests/cbs/escapes.test.ts
+++ b/src/ts/parser/tests/cbs/escapes.test.ts
@@ -35,12 +35,11 @@ const varStorage = vi.hoisted(
 )
 
 vi.mock(import('../../../stores.svelte'), () => {
-  // @ts-expect-error Minimal mock
   return {
     DBState: {
       db: {
-        characters: {
-          char: {
+        characters: [
+          {
             chatPage: 0,
             chats: [
               {
@@ -49,12 +48,15 @@ vi.mock(import('../../../stores.svelte'), () => {
             ],
             defaultVariables: '',
           },
-        },
+        ],
         globalChatVariables: varStorage,
         templateDefaultVariables: '',
       },
     },
-    selectedCharID: writable('char'),
+    selIdState: {
+      selId: 0,
+    },
+    selectedCharID: writable(0),
   } as typeof import('../../../stores.svelte')
 })
 

--- a/src/ts/parser/tests/cbs/strings.test.ts
+++ b/src/ts/parser/tests/cbs/strings.test.ts
@@ -35,12 +35,11 @@ const varStorage = vi.hoisted(
 )
 
 vi.mock(import('../../../stores.svelte'), () => {
-  // @ts-expect-error Minimal mock
   return {
     DBState: {
       db: {
-        characters: {
-          char: {
+        characters: [
+          {
             chatPage: 0,
             chats: [
               {
@@ -49,12 +48,15 @@ vi.mock(import('../../../stores.svelte'), () => {
             ],
             defaultVariables: '',
           },
-        },
+        ],
         globalChatVariables: varStorage,
         templateDefaultVariables: '',
       },
     },
-    selectedCharID: writable('char'),
+    selIdState: {
+      selId: 0,
+    },
+    selectedCharID: writable(0),
   } as typeof import('../../../stores.svelte')
 })
 

--- a/src/ts/parser/tests/chatVar.svelte.test.ts
+++ b/src/ts/parser/tests/chatVar.svelte.test.ts
@@ -40,6 +40,9 @@ vi.mock(import('../../stores.svelte'), () => {
         templateDefaultVariables: '',
       },
     },
+    selIdState: {
+      selId: 0,
+    },
     selectedCharID: writable(0),
   } as typeof import('../../stores.svelte')
 })
@@ -111,6 +114,8 @@ test('can get a global chat variable', () => {
         .map(JSON.stringify),
       (key, value) => {
         DBState.db.globalChatVariables[`toggle_${key}`] = value
+
+        expect(getGlobalChatVar(key)).toBe(value)
         expect(getGlobalChatVar(`toggle_${key}`)).toBe(value)
       }
     )

--- a/src/ts/process/mcp/risuaccess/tests/modules.test.ts
+++ b/src/ts/process/mcp/risuaccess/tests/modules.test.ts
@@ -5,6 +5,7 @@ import { DBState } from 'src/ts/stores.svelte'
 import { beforeEach, expect, test, vi } from 'vitest'
 import type { RPCToolCallTextContent } from '../../mcplib'
 import { ModuleHandler } from '../modules'
+import { writable } from 'svelte/store'
 
 //#region module mocks
 
@@ -20,10 +21,25 @@ vi.mock(import('src/ts/stores.svelte'), () => {
   return {
     DBState: {
       db: {
-        enabledModules: [],
-        modules: [],
+        characters: [
+          {
+            chatPage: 0,
+            chats: [
+              {
+                scriptstate: {},
+              },
+            ],
+            defaultVariables: '',
+          },
+        ],
+        globalChatVariables: {},
+        templateDefaultVariables: '',
       },
     },
+    selIdState: {
+      selId: 0,
+    },
+    selectedCharID: writable(0),
   } as typeof import('src/ts/stores.svelte')
 })
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

#1204 referenced `selIdState` of `stores.svelte` but current test cases did not include that in their mocks, resulted in tests failing.

This PR adds `selIdState` mocks.

## Related Issues

None.

## Changes

Please refer to the Summary. Also fixed minor type mismatch of `DBState.db.characters`.

## Impact

None.
