### PR TITLE
feat: Always prefix toggle_ in getGlobalChatVar()

### DIFF
--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -1286,7 +1286,7 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
                         break
                     }
                     case 'toggle':{
-                        const variable = getGlobalChatVar('toggle_' + condition)
+                        const variable = getGlobalChatVar(condition)
                         if(isTruthy(variable)){
                             statement.push('1')
                         }
@@ -1316,7 +1316,7 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
                         break
                     }
                     case 'tis':{ //tis = toggle is
-                        const variable = getGlobalChatVar('toggle_' + statement.pop())
+                        const variable = getGlobalChatVar(statement.pop())
                         if(variable === condition){
                             statement.push('1')
                         }
@@ -1326,7 +1326,7 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
                         break
                     }
                     case 'tisnot':{ //tisnot = toggle is not
-                        const variable = getGlobalChatVar('toggle_' + statement.pop())
+                        const variable = getGlobalChatVar(statement.pop())
                         if(variable !== condition){
                             statement.push('1')
                         }

--- a/src/ts/parser/chatVar.svelte.ts
+++ b/src/ts/parser/chatVar.svelte.ts
@@ -32,6 +32,12 @@ export function setChatVar(key:string, value:string): void {
     DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate['$' + key] = value
 }
 
-export function getGlobalChatVar(key:string): string {
-    return DBState.db.globalChatVariables[key] ?? 'null'
+/**
+ * Retrieves a global variable ("toggle value") by its key.
+ * 
+ * @param key The key. Must start with `'toggle_'`, or it will be prepended automatically.
+ */
+export function getGlobalChatVar(key: string): string {
+    const key_ = key.startsWith('toggle_') ? key : `toggle_${key}`
+    return DBState.db.globalChatVariables[key_] ?? 'null'
 }

--- a/src/ts/parser/tests/chatVar.svelte.test.ts
+++ b/src/ts/parser/tests/chatVar.svelte.test.ts
@@ -40,6 +40,9 @@ vi.mock(import('../../stores.svelte'), () => {
         templateDefaultVariables: '',
       },
     },
+    selIdState: {
+      selId: 0,
+    },
     selectedCharID: writable(0),
   } as typeof import('../../stores.svelte')
 })
@@ -111,6 +114,8 @@ test('can get a global chat variable', () => {
         .map(JSON.stringify),
       (key, value) => {
         DBState.db.globalChatVariables[`toggle_${key}`] = value
+
+        expect(getGlobalChatVar(key)).toBe(value)
         expect(getGlobalChatVar(`toggle_${key}`)).toBe(value)
       }
     )
@@ -121,7 +126,7 @@ test('returns "null" for undefined variables', () => {
   fc.assert(
     fc.property(fc.string({ unit: 'grapheme' }), (key) => {
       expect(getChatVar(key)).toBe('null')
-      expect(getGlobalChatVar(`toggle_${key}`)).toBe('null')
+      expect(getGlobalChatVar(key)).toBe('null')
     })
   )
 })


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

Try writing `{{getglobalvar::toString}}`. It throws instead of returning `'null'`, because it's `DBState.db.globalChatVariables[toString]` which is an unexpected function.

I can't see any path this might be exploited as an attack vector, but shouldn't hurt being safe, and fewer errors thrown the better.

## Related Issues

None.

## Changes

`getGlobalChatVar()` now prefixes the key with `toggle_` if it isn't already.

```js
getGlobalChatVar('supertoggle') === getGlobalChatVar('toggle_suppertoggle')
```

It can also help reduce CBS complexity.

```
{{#when {{and::{{? {{length::{{trim::{{getglobalvar::toggle_mood}} }} }} > 0 }}::{{? {{getglobalvar::toggle_mood}} != null }}}} }}
```

One can shorten the above CBS into:

```
{{#when {{and::{{? {{length::{{trim::{{getglobalvar::mood}} }} }} > 0 }}::{{? {{getglobalvar::mood}} != null }}}} }}
```

## Impact

Backward compatible, should be none. Both `ABC` and `toggle_ABC` are supported.
