### PR TITLE
feat: add WaveSpeedAI integration for image generation

### DIFF
--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -637,6 +637,14 @@ export function setDatabase(data:Database){
         size: '1024x1024',
         quality: 'auto'
     }
+    data.wavespeedImage ??= {
+        key: '',
+        model: '',
+        loras: [],
+        reference_mode: '',
+        reference_image: '',
+        reference_base64image: ''
+    }
     data.autoScrollToNewMessage ??= true
     data.alwaysScrollToNewMessage ??= false
     data.newMessageButtonStyle ??= 'bottom-center'
@@ -1161,6 +1169,14 @@ export interface Database{
         model: string
         size: string
         quality: string
+    }
+    wavespeedImage: {
+        key: string
+        model: string
+        loras: Array<{path: string, scale: number}>,
+        reference_mode: string
+        reference_image: string
+        reference_base64image: string
     }
     sourcemapTranslate:boolean
     settingsCloseButtonSize:number


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], if true, check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly ai generated[^2], check the following:
    - [ ] Have you understanded what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

Integrates **WaveSpeedAI** as a new image generation provider. It enables users to access a wide range of modern image generation models with support for advanced features like Image-to-Image (Image Reference) and LoRA (Low-Rank Adaptation) customization.

While providers like OpenRouter offer a vast array of models, they function as broad multimedia services. Currently, the existing image providers lack support for recently emerged **natural language image generation models** (such as Z-Image, Qwen). WaveSpeed fills this gap by specializing in these high-fidelity, prompt-adherent models that are missing from other integrations.

### Why WaveSpeed?
WaveSpeed is one of [HuggingFace's Inference Providers](https://huggingface.co/docs/inference-providers). It offers the most comprehensive collection of image and video models available, encompassing both open-source community favorites and proprietary services. This ensures users have access to the latest state-of-the-art models immediately upon release.

## Related Issues

None

## Changes
- [`OtherBotSettings.svelte`](src/lib/Setting/Pages/OtherBotSettings.svelte):
  - Added `wavespeed` option to image provider selector
  - Implemented dynamic model list fetching with real-time API refresh
  - Added model search/filter functionality
  - Conditional LoRA configuration (up to 3 slots with weight sliders) when model supports it
  - Conditional Image Reference modes (Upload/Character Image) when model supports image-to-image
  - Added capability indicator icons in model display (Image Input & LoRA support)
- [`stableDiff.ts`](src/ts/process/stableDiff.ts):
  - Implemented 3-step asynchronous polling mechanism for WaveSpeed API:
    - Task submission with prompt, LoRA configs, and optional base64 reference images
    - Polling-based monitoring (3-second intervals, 10-minute timeout)
    - Binary image retrieval and Base64 conversion for display
  - Support for both `inlay` and default emotion modes
- [`database.svelte.ts`](src/ts/storage/database.svelte.ts):
  - Extended database schema with `wavespeedImage` object containing:
    - `key`: API authentication
    - `model`: Selected model identifier
    - `loras`: Array of LoRA configurations with path and scale
    - `reference_mode`: Image reference type selection
    - `reference_image` & `reference_base64image`: Reference image storage

## Impact

### Database Structure Changes
The database schema has been extended with the `wavespeedImage` configuration object. This is a new, isolated addition with no impact on existing character or provider configurations. Default initialization ensures backward compatibility.

## Additional Notes
Validated primarily on Qwen-Image-Edit and FLUX.2-klein with character reference images, as these models excel at interpreting natural language prompts directly.

While WaveSpeed hosts legacy keyword-based models (e.g., older SD versions), this integration passes the prompt as-is. No additional keyword processing or tag conversion logic was implemented for legacy models in this update.

## Screenshots
Model request and filter, the list provide name, price, image-supported, lora-supported:
<img width="845" height="642" alt="Screenshot 2026-01-16 205938" src="https://github.com/user-attachments/assets/71d87bcb-6228-4520-9361-e455a6351e1b" />

Lora and image configuration:
<img width="800" height="597" alt="Screenshot 2026-01-16 210021" src="https://github.com/user-attachments/assets/860953f2-f586-4d8d-ba35-463e865f2109" />

