### PR TITLE
chore: Remove AI21 from LLMProvider

### DIFF
--- a/src/etc/docs/docs_text.cbs
+++ b/src/etc/docs/docs_text.cbs
@@ -13,7 +13,7 @@ And their are some technical information about versions. since this is kinda tec
 - Node version: Has account sync feature. saved in hosted server, no size limitation. needs to be manually updated. must be hosted on your own server in HTTPS. if it isn't configured properly, it can not work properly. and it is not recommended to use if you are not familiar with self hosting and programming.
 [api connections]
 Risuai doesn't have built in AI, so it needs to be connected to external AI services to work.
-Risuai can be connected to OpenAI, Anthropic, GoogleCloud, VertexAI, Mistral, NovelList, Cohere, NovelAI, WebLLM, Horde, AWS, AI21, DeepSeek, DeepInfra, Ooba, Mancer, OpenRouter, Kobold, Ollama, and more.
+Risuai can be connected to OpenAI, Anthropic, GoogleCloud, VertexAI, Mistral, NovelList, Cohere, NovelAI, WebLLM, Horde, AWS, DeepSeek, DeepInfra, Ooba, Mancer, OpenRouter, Kobold, Ollama, and more.
 To connect to these services, you need to have an API key or other credentials to access the service.
 Risuai doesn't manage things that handled by external services, so if you have any issues with these services, such as billing, account, or other issues, you need to contact the service provider directly, not Risuai.
 Note: If Airisu has been asked for connection information, if AI knows about it, Airisu will provide the information, if not known, Airisu will say something like "I don't know about it, but you can find it on the internet."

--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -137,10 +137,6 @@ let tokens = $state({
             </OptionInput>
         </SelectInput>    
     {/if}
-    {#if modelInfo.provider === LLMProvider.AI21 || subModelInfo.provider === LLMProvider.AI21}
-        <span class="text-textcolor">AI21 {language.apiKey}</span>
-        <TextInput hideText={DBState.db.hideApiKey} marginBottom={true} size={"sm"} placeholder="..." bind:value={DBState.db.ai21Key}/>
-    {/if}
     {#if modelInfo.provider === LLMProvider.NovelList || subModelInfo.provider === LLMProvider.NovelList}
         <span class="text-textcolor">NovelList {language.apiKey}</span>
         <TextInput hideText={DBState.db.hideApiKey} marginBottom={true} size={"sm"} placeholder="..." bind:value={DBState.db.novellistAPI}/>

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -38,7 +38,6 @@ export enum LLMProvider{
     WebLLM,
     Horde,
     AWS,
-    AI21,
     DeepSeek,
     DeepInfra,
     Echo

--- a/src/ts/process/request/openAI.ts
+++ b/src/ts/process/request/openAI.ts
@@ -535,10 +535,6 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
     if(risuIdentify){
         headers["X-Proxy-Risu"] = 'RisuAI'
     }
-    if(aiModel.startsWith('jamba')){
-        headers['Authorization'] = 'Bearer ' + db.ai21Key
-        replacerURL = 'https://api.ai21.com/studio/v1/chat/completions'
-    }
     if(arg.multiGen){
         // Check if tools are enabled - multiGen with tools is not supported
         if(arg.tools && arg.tools.length > 0){

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1022,7 +1022,6 @@ export interface Database{
     jsonSchema:string
     strictJsonSchema:boolean
     extractJson:string
-    ai21Key:string
     statics: {
         messages: number
         imports: number


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

Jamba was added and then removed from the LLM list, so `LLMProvider.AI21` is never being used. Removes all references of it.

## Related Issues

None.

## Changes

All references of AI21 or `'jamba'` were removed.

## Impact

None. Users who have `ai21Key` might lose the value, but since ` modelInfo.provider === LLMProvider.AI21 || subModelInfo.provider === LLMProvider.AI21` is never true, it shouldn't matter.
