### PR TITLE
perf: replace state snapshots with DB proxy layer for saveDb performance

### DIFF
--- a/src/lib/Others/WelcomeRisu.svelte
+++ b/src/lib/Others/WelcomeRisu.svelte
@@ -73,7 +73,7 @@
     $effect.pre(() => {
         if(step === 10){
             setTimeout(() => {
-                DBState.db = setPreset(DBState.db, prebuiltPresets.OAI2)
+                setPreset(DBState.db, prebuiltPresets.OAI2)
                 DBState.db.textTheme = 'highcontrast'
                 updateTextThemeAndCSS()
 

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -425,6 +425,8 @@ export async function saveDb() {
             }
             saveTimeoutExecute()
         })
+        // Persist bootstrap mutations emitted before the database listener existed.
+        saveTimeoutExecute()
 
         return () => {
             unsubscribeSel()

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -314,19 +314,32 @@ export async function saveDb() {
 
     const createChangeTracker = (): toSaveType => ({
         character: [],
-        chat: [],
         botPreset: false,
         modules: false,
         loadouts: false,
         plugins: false,
         pluginCustomStorage: false
     })
+    const cloneChangeTracker = (tracker: toSaveType): toSaveType => ({
+        ...tracker,
+        character: [...tracker.character]
+    })
+    const mergeChangeTrackers = (target: toSaveType, source: toSaveType) => {
+        for (const characterId of source.character) {
+            if (!target.character.includes(characterId)) {
+                target.character.push(characterId)
+            }
+        }
+        target.botPreset ||= source.botPreset
+        target.modules ||= source.modules
+        target.loadouts ||= source.loadouts
+        target.plugins ||= source.plugins
+        target.pluginCustomStorage ||= source.pluginCustomStorage
+    }
     let changeTracker = createChangeTracker()
+    let savetrys = 0
 
     let encoder = new RisuSaveEncoder()
-    await encoder.init(getDatabase(), {
-        compression: forageStorage.isAccount
-    })
 
     $effect.root(() => {
 
@@ -348,57 +361,14 @@ export async function saveDb() {
             }, debounceTime);
         }
 
-        type TrackableChat = { id?: string }
-        type TrackableCharacter = { chaId?: string, chatPage?: number, chats?: TrackableChat[] }
-
-        function parseArrayIndex(value: unknown): number | undefined {
-            if (typeof value === 'number') {
-                return value
-            }
-            return typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : undefined
-        }
-
-        function isTrackableChat(value: unknown): value is TrackableChat & { id: string } {
-            return typeof value === 'object' && value !== null && 'id' in value && typeof value.id === 'string'
-        }
-
-        function isCharacterForSaveTracking(value: unknown): value is TrackableCharacter & { chaId: string } {
-            return typeof value === 'object' && value !== null && 'chaId' in value && typeof value.chaId === 'string'
-        }
-
-        function getTrackableCharacters(value: unknown): TrackableCharacter[] {
-            return Array.isArray(value) ? value.filter(isCharacterForSaveTracking) : []
-        }
-
-        function getTrackableChatIds(value: unknown): string[] {
-            return Array.isArray(value) ? value.filter(isTrackableChat).map((chat) => chat.id) : []
-        }
-
-        function updateChangeTrackerForCharacter(
-            char: TrackableCharacter | null | undefined,
-            options: { affectedChatIds?: (string | undefined)[], fallbackToCurrentChat?: boolean } = {}
-        ) {
-            if (!char?.chaId) {
+        const unsubscribeDb = onDatabaseUpdate((info) => {
+            if (info.path.length === 0) {
+                requiresFullEncoderReload.state = true
+                savetrys = 0
+                saveTimeoutExecute()
                 return
             }
-            if (!changeTracker.character.includes(char.chaId)) {
-                changeTracker.character.unshift(char.chaId)
-            }
-            const affectedChatIds = options.affectedChatIds?.filter((id): id is string => Boolean(id)) ?? []
-            if (affectedChatIds.length === 0 && options.fallbackToCurrentChat !== false) {
-                const currentChatId = char.chats?.[char.chatPage ?? 0]?.id
-                if (currentChatId) {
-                    affectedChatIds.push(currentChatId)
-                }
-            }
-            for (const chatId of affectedChatIds) {
-                if (!changeTracker.chat.some(([characterId, trackedChatId]) => characterId === char.chaId && trackedChatId === chatId)) {
-                    changeTracker.chat.unshift([char.chaId, chatId])
-                }
-            }
-        }
 
-        const unsubscribeDb = onDatabaseUpdate((info) => {
             const rootKey = info.path[0]
 
             if (rootKey === 'botPresets' || rootKey === 'botPresetsId') {
@@ -420,50 +390,39 @@ export async function saveDb() {
             }
 
             if (rootKey === 'characters') {
+                const affectedCharacters: Database['characters'] = []
+
                 if (info.path.length === 1) {
-                    for (const character of [...getTrackableCharacters(info.oldValue), ...getTrackableCharacters(info.value)]) {
-                        updateChangeTrackerForCharacter(character)
+                    const oldCharacters = info.oldValue as Database['characters'] | undefined
+                    const newCharacters = info.value as Database['characters'] | undefined
+                    affectedCharacters.push(...(oldCharacters ?? []), ...(newCharacters ?? []))
+                }
+                else if (typeof info.path[1] === 'number') {
+                    if (info.path.length === 2) {
+                        const oldChar = info.oldValue as Database['characters'][number] | undefined
+                        if (oldChar) {
+                            affectedCharacters.push(oldChar)
+                        }
                     }
-                    saveTimeoutExecute()
-                    return
+                    const char = DBState.db.characters[info.path[1]]
+                    if (char) {
+                        affectedCharacters.push(char)
+                    }
                 }
 
-                const characterIndex = parseArrayIndex(info.path[1])
-                const targetChar = characterIndex === undefined ? undefined : DBState.db.characters?.[characterIndex]
-                const fallbackChar = isCharacterForSaveTracking(info.oldValue) ? info.oldValue : undefined
-                const char = targetChar ?? fallbackChar
-                const isChatPath = info.path[2] === 'chats'
-
-                if (info.path.length === 2 && fallbackChar?.chaId !== targetChar?.chaId) {
-                    updateChangeTrackerForCharacter(fallbackChar)
+                for (const char of affectedCharacters) {
+                    if (!changeTracker.character.includes(char.chaId)) {
+                        changeTracker.character.unshift(char.chaId)
+                    }
                 }
-
-                if (isChatPath && info.path.length === 3) {
-                    updateChangeTrackerForCharacter(char, {
-                        affectedChatIds: [
-                            ...getTrackableChatIds(info.oldValue),
-                            ...getTrackableChatIds(info.value),
-                        ],
-                        fallbackToCurrentChat: false,
-                    })
-                    saveTimeoutExecute()
-                    return
-                }
-
-                const chatIndex = isChatPath ? parseArrayIndex(info.path[3]) : undefined
-                const oldChat = info.path.length === 4 && isTrackableChat(info.oldValue) ? info.oldValue : undefined
-                const affectedChatIds = chatIndex === undefined
-                    ? undefined
-                    : [targetChar?.chats?.[chatIndex]?.id, oldChat?.id]
-                updateChangeTrackerForCharacter(char, {
-                    affectedChatIds,
-                    fallbackToCurrentChat: !isChatPath,
-                })
                 saveTimeoutExecute()
                 return
             }
 
-            updateChangeTrackerForCharacter(DBState.db.characters?.[selIdState])
+            const char = DBState.db.characters[selIdState]
+            if (char && !changeTracker.character.includes(char.chaId)) {
+                changeTracker.character.unshift(char.chaId)
+            }
             saveTimeoutExecute()
         })
 
@@ -473,7 +432,16 @@ export async function saveDb() {
         }
     })
 
-    let savetrys = 0
+    try {
+        await encoder.init(getDatabase(), {
+            compression: forageStorage.isAccount
+        })
+    } catch (error) {
+        requiresFullEncoderReload.state = true
+        changed = true
+        console.error(error)
+    }
+
     let lastDbData = new Uint8Array(0)
     await sleep(1000)
     while (true) {
@@ -482,40 +450,46 @@ export async function saveDb() {
             continue
         }
 
+        if (gotChannel) {
+            // Data is saved in another tab.
+            await sleep(1000)
+            continue
+        }
+
         saving.state = true
         changed = false
+        const pendingSave = cloneChangeTracker(changeTracker)
+        changeTracker = createChangeTracker()
+        const toSave = cloneChangeTracker(pendingSave)
         try {
+            const db = getDatabase()
 
             if (requiresFullEncoderReload.state) {
-                encoder = new RisuSaveEncoder()
-                await encoder.init(getDatabase(), {
-                    compression: forageStorage.isAccount,
-                    skipRemoteSavingOnCharacters: false
-                })
                 requiresFullEncoderReload.state = false
+                encoder = new RisuSaveEncoder()
+                try {
+                    await encoder.init(db, {
+                        compression: forageStorage.isAccount,
+                        skipRemoteSavingOnCharacters: false
+                    })
+                } catch (error) {
+                    requiresFullEncoderReload.state = true
+                    throw error
+                }
             }
 
-            const toSave = changeTracker
-            changeTracker = createChangeTracker()
-            if (gotChannel) {
-                //Data is saved in other tab
-                await sleep(1000)
-                continue
-            }
             if (channel) {
                 channel.postMessage(sessionID)
             }
-            let db = getDatabase()
+
             if (!db.characters) {
-                await sleep(1000)
-                continue
+                throw new Error('Database has no character list')
             }
 
             await encoder.set(db, toSave)
             const encoded = encoder.encode()
             if (!encoded) {
-                await sleep(1000)
-                continue
+                throw new Error('Database encoding failed')
             }
             const dbData = new Uint8Array(encoded)
             if (isTauri) {
@@ -539,12 +513,15 @@ export async function saveDb() {
             await saveDbKei()
             await sleep(500)
         } catch (error) {
+            mergeChangeTrackers(changeTracker, pendingSave)
             savetrys += 1
             if (savetrys > 4) {
                 alertError(error)
             }
             else {
                 console.error(error)
+                await sleep(1000)
+                changed = true
             }
         }
 

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -14,7 +14,7 @@ import { appDataDir, join } from "@tauri-apps/api/path";
 import { get } from "svelte/store";
 import { open } from '@tauri-apps/plugin-shell'
 import streamSaver from 'streamsaver';
-import { setDatabase, type Database, defaultSdDataFunc, getDatabase, appVer, getCurrentCharacter, type character, type groupChat } from "./storage/database.svelte";
+import { setDatabase, type Database, defaultSdDataFunc, getDatabase, appVer, getCurrentCharacter, onDatabaseUpdate, type character, type groupChat } from "./storage/database.svelte";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { checkRisuUpdate } from "./update";
 import { MobileGUI, botMakerMode, selectedCharID, loadedStore, DBState, LoadingStatusState, selIdState, ReloadGUIPointer, bodyIntercepterStore } from "./stores.svelte";
@@ -312,7 +312,7 @@ export async function saveDb() {
         }
     }
 
-    const changeTracker: toSaveType = {
+    const createChangeTracker = (): toSaveType => ({
         character: [],
         chat: [],
         botPreset: false,
@@ -320,7 +320,8 @@ export async function saveDb() {
         loadouts: false,
         plugins: false,
         pluginCustomStorage: false
-    }
+    })
+    let changeTracker = createChangeTracker()
 
     let encoder = new RisuSaveEncoder()
     await encoder.init(getDatabase(), {
@@ -334,7 +335,7 @@ export async function saveDb() {
         const debounceTime = 500; // 500 milliseconds
         let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
-        selectedCharID.subscribe((v) => {
+        const unsubscribeSel = selectedCharID.subscribe((v) => {
             selIdState = v
         })
 
@@ -347,60 +348,129 @@ export async function saveDb() {
             }, debounceTime);
         }
 
-        $effect(() => {
-            DBState.db.botPresetsId
-            DBState.db.botPresets.length
-            changeTracker.botPreset = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            $state.snapshot(DBState.db.modules)
-            changeTracker.modules = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            $state.snapshot(DBState.db.loadouts)
-            changeTracker.loadouts = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            $state.snapshot(DBState.db.plugins)
-            changeTracker.plugins = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            $state.snapshot(DBState.db.pluginCustomStorage)
-            changeTracker.pluginCustomStorage = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            for (const key in DBState.db) {
-                if (
-                    key !== 'characters' && key !== 'botPresets' && key !== 'modules' &&
-                    key !== 'loadouts' && key !== 'plugins' && key !== 'pluginCustomStorage'
-                ) {
-                    $state.snapshot(DBState.db[key])
+        type TrackableChat = { id?: string }
+        type TrackableCharacter = { chaId?: string, chatPage?: number, chats?: TrackableChat[] }
+
+        function parseArrayIndex(value: unknown): number | undefined {
+            if (typeof value === 'number') {
+                return value
+            }
+            return typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : undefined
+        }
+
+        function isTrackableChat(value: unknown): value is TrackableChat & { id: string } {
+            return typeof value === 'object' && value !== null && 'id' in value && typeof value.id === 'string'
+        }
+
+        function isCharacterForSaveTracking(value: unknown): value is TrackableCharacter & { chaId: string } {
+            return typeof value === 'object' && value !== null && 'chaId' in value && typeof value.chaId === 'string'
+        }
+
+        function getTrackableCharacters(value: unknown): TrackableCharacter[] {
+            return Array.isArray(value) ? value.filter(isCharacterForSaveTracking) : []
+        }
+
+        function getTrackableChatIds(value: unknown): string[] {
+            return Array.isArray(value) ? value.filter(isTrackableChat).map((chat) => chat.id) : []
+        }
+
+        function updateChangeTrackerForCharacter(
+            char: TrackableCharacter | null | undefined,
+            options: { affectedChatIds?: (string | undefined)[], fallbackToCurrentChat?: boolean } = {}
+        ) {
+            if (!char?.chaId) {
+                return
+            }
+            if (!changeTracker.character.includes(char.chaId)) {
+                changeTracker.character.unshift(char.chaId)
+            }
+            const affectedChatIds = options.affectedChatIds?.filter((id): id is string => Boolean(id)) ?? []
+            if (affectedChatIds.length === 0 && options.fallbackToCurrentChat !== false) {
+                const currentChatId = char.chats?.[char.chatPage ?? 0]?.id
+                if (currentChatId) {
+                    affectedChatIds.push(currentChatId)
                 }
             }
-            if (DBState?.db?.characters?.[selIdState]) {
-                for (const key in DBState.db.characters[selIdState]) {
-                    if (key !== 'chats') {
-                        $state.snapshot(DBState.db.characters[selIdState][key])
+            for (const chatId of affectedChatIds) {
+                if (!changeTracker.chat.some(([characterId, trackedChatId]) => characterId === char.chaId && trackedChatId === chatId)) {
+                    changeTracker.chat.unshift([char.chaId, chatId])
+                }
+            }
+        }
+
+        const unsubscribeDb = onDatabaseUpdate((info) => {
+            const rootKey = info.path[0]
+
+            if (rootKey === 'botPresets' || rootKey === 'botPresetsId') {
+                changeTracker.botPreset = true
+                saveTimeoutExecute()
+                return
+            }
+
+            if (rootKey === 'modules') {
+                changeTracker.modules = true
+                saveTimeoutExecute()
+                return
+            }
+
+            if (rootKey === 'loadouts' || rootKey === 'plugins' || rootKey === 'pluginCustomStorage') {
+                changeTracker[rootKey] = true
+                saveTimeoutExecute()
+                return
+            }
+
+            if (rootKey === 'characters') {
+                if (info.path.length === 1) {
+                    for (const character of [...getTrackableCharacters(info.oldValue), ...getTrackableCharacters(info.value)]) {
+                        updateChangeTrackerForCharacter(character)
                     }
+                    saveTimeoutExecute()
+                    return
                 }
-                $state.snapshot(DBState.db.characters[selIdState].chats)
-                if (changeTracker.character[0] !== DBState.db.characters[selIdState]?.chaId) {
-                    changeTracker.character.unshift(DBState.db.characters[selIdState]?.chaId)
+
+                const characterIndex = parseArrayIndex(info.path[1])
+                const targetChar = characterIndex === undefined ? undefined : DBState.db.characters?.[characterIndex]
+                const fallbackChar = isCharacterForSaveTracking(info.oldValue) ? info.oldValue : undefined
+                const char = targetChar ?? fallbackChar
+                const isChatPath = info.path[2] === 'chats'
+
+                if (info.path.length === 2 && fallbackChar?.chaId !== targetChar?.chaId) {
+                    updateChangeTrackerForCharacter(fallbackChar)
                 }
-                if (
-                    changeTracker.chat[0]?.[0] !== DBState.db.characters[selIdState]?.chaId ||
-                    changeTracker.chat[0]?.[1] !== DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id
-                ) {
-                    changeTracker.chat.unshift([DBState.db.characters[selIdState]?.chaId, DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id])
+
+                if (isChatPath && info.path.length === 3) {
+                    updateChangeTrackerForCharacter(char, {
+                        affectedChatIds: [
+                            ...getTrackableChatIds(info.oldValue),
+                            ...getTrackableChatIds(info.value),
+                        ],
+                        fallbackToCurrentChat: false,
+                    })
+                    saveTimeoutExecute()
+                    return
                 }
+
+                const chatIndex = isChatPath ? parseArrayIndex(info.path[3]) : undefined
+                const oldChat = info.path.length === 4 && isTrackableChat(info.oldValue) ? info.oldValue : undefined
+                const affectedChatIds = chatIndex === undefined
+                    ? undefined
+                    : [targetChar?.chats?.[chatIndex]?.id, oldChat?.id]
+                updateChangeTrackerForCharacter(char, {
+                    affectedChatIds,
+                    fallbackToCurrentChat: !isChatPath,
+                })
+                saveTimeoutExecute()
+                return
             }
+
+            updateChangeTrackerForCharacter(DBState.db.characters?.[selIdState])
             saveTimeoutExecute()
         })
+
+        return () => {
+            unsubscribeSel()
+            unsubscribeDb()
+        }
     })
 
     let savetrys = 0
@@ -425,11 +495,8 @@ export async function saveDb() {
                 requiresFullEncoderReload.state = false
             }
 
-            let toSave = safeStructuredClone(changeTracker)
-            changeTracker.character = changeTracker.character.length === 0 ? [] : [changeTracker.character[0]]
-            changeTracker.chat = changeTracker.chat.length === 0 ? [] : [changeTracker.chat[0]]
-            changeTracker.botPreset = false
-            changeTracker.modules = false
+            const toSave = changeTracker
+            changeTracker = createChangeTracker()
             if (gotChannel) {
                 //Data is saved in other tab
                 await sleep(1000)

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -13,7 +13,7 @@ import { v4 as uuidv4, v4 } from 'uuid';
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { get } from "svelte/store";
 import { open } from '@tauri-apps/plugin-shell'
-import { setDatabase, type Database, defaultSdDataFunc, getDatabase, appVer, getCurrentCharacter } from "./storage/database.svelte";
+import { setDatabase, type Database, defaultSdDataFunc, getDatabase, appVer, getCurrentCharacter, onDatabaseUpdate } from "./storage/database.svelte";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { checkRisuUpdate } from "./update";
 import { MobileGUI, botMakerMode, selectedCharID, loadedStore, DBState, LoadingStatusState, selIdState, ReloadGUIPointer } from "./stores.svelte";
@@ -363,7 +363,7 @@ export async function saveDb() {
         const debounceTime = 500; // 500 milliseconds
         let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
-        selectedCharID.subscribe((v) => {
+        const unsubscribeSel = selectedCharID.subscribe((v) => {
             selIdState = v
         })
 
@@ -376,42 +376,58 @@ export async function saveDb() {
             }, debounceTime);
         }
 
-        $effect(() => {
-            DBState.db.botPresetsId
-            DBState.db.botPresets.length
-            changeTracker.botPreset = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            $state.snapshot(DBState.db.modules)
-            changeTracker.modules = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            for (const key in DBState.db) {
-                if (key !== 'characters' && key !== 'botPresets' && key !== 'modules') {
-                    $state.snapshot(DBState.db[key])
-                }
+        function updateChangeTrackerForCharacter(char: { chaId?: string, chatPage?: number, chats?: { id?: string }[] } | null | undefined) {
+            if (!char?.chaId) {
+                return
             }
-            if (DBState?.db?.characters?.[selIdState]) {
-                for (const key in DBState.db.characters[selIdState]) {
-                    if (key !== 'chats') {
-                        $state.snapshot(DBState.db.characters[selIdState][key])
-                    }
-                }
-                $state.snapshot(DBState.db.characters[selIdState].chats)
-                if (changeTracker.character[0] !== DBState.db.characters[selIdState]?.chaId) {
-                    changeTracker.character.unshift(DBState.db.characters[selIdState]?.chaId)
-                }
-                if (
-                    changeTracker.chat[0]?.[0] !== DBState.db.characters[selIdState]?.chaId ||
-                    changeTracker.chat[0]?.[1] !== DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id
-                ) {
-                    changeTracker.chat.unshift([DBState.db.characters[selIdState]?.chaId, DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id])
-                }
+            if (changeTracker.character[0] !== char.chaId) {
+                changeTracker.character.unshift(char.chaId)
             }
+            const chatId = char.chats?.[char.chatPage ?? 0]?.id
+            if (chatId && (
+                changeTracker.chat[0]?.[0] !== char.chaId ||
+                changeTracker.chat[0]?.[1] !== chatId
+            )) {
+                changeTracker.chat.unshift([char.chaId, chatId])
+            }
+        }
+
+        const unsubscribeDb = onDatabaseUpdate((info) => {
+            // console.log('[DBProxy] Database updated at path:', info.path.join('.'))
+            const rootKey = info.path[0]
+
+            if (rootKey === 'botPresets' || rootKey === 'botPresetsId') {
+                changeTracker.botPreset = true
+                saveTimeoutExecute()
+                return
+            }
+
+            if (rootKey === 'modules') {
+                changeTracker.modules = true
+                saveTimeoutExecute()
+                return
+            }
+
+            if (rootKey === 'characters') {
+                const rawIndex = info.path[1]
+                const index = typeof rawIndex === 'number'
+                    ? rawIndex
+                    : (typeof rawIndex === 'string' && /^\d+$/.test(rawIndex) ? Number(rawIndex) : selIdState)
+                const targetChar = DBState?.db?.characters?.[index ?? selIdState]
+                const fallbackChar = info.oldValue && typeof info.oldValue === 'object' ? info.oldValue as any : null
+                updateChangeTrackerForCharacter(targetChar ?? fallbackChar)
+                saveTimeoutExecute()
+                return
+            }
+
+            updateChangeTrackerForCharacter(DBState?.db?.characters?.[selIdState])
             saveTimeoutExecute()
         })
+
+        return () => {
+            unsubscribeSel()
+            unsubscribeDb()
+        }
     })
 
     let savetrys = 0

--- a/src/ts/plugins/plugins.svelte.ts
+++ b/src/ts/plugins/plugins.svelte.ts
@@ -754,7 +754,6 @@ export const getV2PluginAPIs = () => {
                     db.pluginCustomStorage[key] = newDb[key];
                 }
             }
-            DBState.db = db;
         },
         setDatabase: async (newDb: any) => {
             const db = getDatabase();

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -20,6 +20,9 @@ import {
     DEFAULT_CHAT_LOAD_INITIAL_PAGES,
     normalizeChatLoadPages,
 } from '../chatLoadPages';
+import { setDatabaseLite } from './databaseState.svelte';
+
+export { onDatabaseUpdate, setDatabaseLite } from './databaseState.svelte';
 
 //APP_VERSION_POINT is to locate the app version in the database file for version bumping
 export let appVer = "2026.6.214" //<APP_VERSION_POINT>
@@ -709,10 +712,6 @@ export function setDatabase(data:Database){
     data.coldstorage ??= data?.plugins?.length === 0
     changeLanguage(data.language)
     setDatabaseLite(data)
-}
-
-export function setDatabaseLite(data:Database){
-    DBState.db = data
 }
 
 interface getDatabaseOptions{

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -18,6 +18,96 @@ import { isTauri, isNodeServer } from "src/ts/platform"
 export let appVer = "2026.1.90" //<APP_VERSION_POINT>
 export let webAppSubVer = ''
 
+type DatabaseUpdatePathKey = string | number | symbol
+
+export interface DatabaseUpdateInfo {
+    path: DatabaseUpdatePathKey[]
+    value: unknown
+    oldValue: unknown
+    type: 'set' | 'delete'
+}
+
+const databaseUpdateListeners = new Set<(info: DatabaseUpdateInfo) => void>()
+const dbProxyInstances = new WeakSet<object>()
+const dbProxyCache = new WeakMap<object, object>()
+
+function emitDatabaseUpdate(info: DatabaseUpdateInfo) {
+    for (const listener of databaseUpdateListeners) {
+        try {
+            listener(info)
+        } catch (error) {
+            console.error(error)
+        }
+    }
+}
+
+function normalizePathKey(target: object, prop: PropertyKey): DatabaseUpdatePathKey {
+    if (Array.isArray(target) && typeof prop === 'string' && /^\d+$/.test(prop)) {
+        return Number(prop)
+    }
+    return prop
+}
+
+function createDatabaseProxy<T extends object>(target: T, path: DatabaseUpdatePathKey[] = []): T {
+    if (!target || typeof target !== 'object') {
+        return target
+    }
+    if (dbProxyInstances.has(target)) {
+        return target
+    }
+    const cached = dbProxyCache.get(target as object)
+    if (cached) {
+        return cached as T
+    }
+
+    const proxy = new Proxy(target, {
+        get(obj, prop, receiver) {
+            const value = Reflect.get(obj, prop, receiver)
+            if (value && typeof value === 'object') {
+                return createDatabaseProxy(value, [...path, normalizePathKey(obj, prop)])
+            }
+            return value
+        },
+        set(obj, prop, value, receiver) {
+            // console.log('[DBProxy] Setting database property', [...path, normalizePathKey(obj, prop)].join('.'))
+            const oldValue = Reflect.get(obj, prop, receiver)
+            const result = Reflect.set(obj, prop, value, receiver)
+            if (oldValue !== value) {
+                emitDatabaseUpdate({
+                    path: [...path, normalizePathKey(obj, prop)],
+                    value,
+                    oldValue,
+                    type: 'set'
+                })
+            }
+            return result
+        },
+        deleteProperty(obj, prop) {
+            // console.log('[DBProxy] Deleting database property', [...path, normalizePathKey(obj, prop)].join('.'))
+            const oldValue = Reflect.get(obj, prop)
+            const result = Reflect.deleteProperty(obj, prop)
+            emitDatabaseUpdate({
+                path: [...path, normalizePathKey(obj, prop)],
+                value: undefined,
+                oldValue,
+                type: 'delete'
+            })
+            return result
+        }
+    })
+
+    dbProxyCache.set(target as object, proxy)
+    dbProxyInstances.add(proxy as object)
+    return proxy
+}
+
+export function onDatabaseUpdate(listener: (info: DatabaseUpdateInfo) => void) {
+    databaseUpdateListeners.add(listener)
+    return () => {
+        databaseUpdateListeners.delete(listener)
+    }
+}
+
 
 export function setDatabase(data:Database){
     if(checkNullish(data.characters)){
@@ -652,7 +742,7 @@ export function setDatabase(data:Database){
 }
 
 export function setDatabaseLite(data:Database){
-    DBState.db = data
+    DBState.db = createDatabaseProxy(data)
 }
 
 interface getDatabaseOptions{

--- a/src/ts/storage/databaseState.svelte.test.ts
+++ b/src/ts/storage/databaseState.svelte.test.ts
@@ -93,13 +93,14 @@ describe('database proxy layering', () => {
         unsubscribe()
     })
 
-    it('does not proxy non-plain objects', () => {
+    it('does not proxy non-plain or frozen objects', () => {
         const date = new Date()
         const map = new Map([['key', 'value']])
         const set = new Set(['value'])
         const bytes = new Uint8Array([1, 2])
         const instance = new CustomValue()
-        setDatabaseLite(database({ pluginCustomStorage: { date, map, set, bytes, instance } }))
+        const frozen = Object.freeze({ nested: Object.freeze({ value: 1 }) })
+        setDatabaseLite(database({ pluginCustomStorage: { date, map, set, bytes, instance, frozen } }))
         const storage = DBState.db.pluginCustomStorage
 
         expect(storage.date).toBe(date)
@@ -107,6 +108,10 @@ describe('database proxy layering', () => {
         expect(storage.set).toBe(set)
         expect(storage.bytes).toBe(bytes)
         expect(storage.instance).toBe(instance)
+        expect(storage.frozen.nested.value).toBe(1)
+        expect(JSON.parse(JSON.stringify(getDatabase())).pluginCustomStorage.frozen).toEqual({
+            nested: { value: 1 },
+        })
     })
 
     it('reports the access path used for shared plain objects', () => {

--- a/src/ts/storage/databaseState.svelte.test.ts
+++ b/src/ts/storage/databaseState.svelte.test.ts
@@ -1,7 +1,7 @@
 import { flushSync } from 'svelte'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DBState } from '../stores.svelte'
-import { getDatabase, onDatabaseUpdate, setDatabaseLite, type Database } from './database.svelte'
+import { getDatabase, onDatabaseUpdate, setDatabaseLite, type character, type Chat, type Database } from './database.svelte'
 
 vi.mock('../globalApi.svelte', () => ({
     downloadFile: vi.fn(),
@@ -125,6 +125,150 @@ describe('database proxy layering', () => {
         unsubscribe()
     })
 
+    it('resolves paths through characters and chats after they move', () => {
+        const makeCharacter = (chaId: string) => ({
+            chaId,
+            name: chaId,
+            chatPage: 0,
+            chats: [
+                { id: `${chaId}-first`, message: [] },
+                { id: `${chaId}-second`, message: [] },
+            ],
+        })
+        setDatabaseLite(database({ characters: [makeCharacter('A'), makeCharacter('B')] as character[] }))
+        const movedCharacter = DBState.db.characters[1]
+        const movedMessages = movedCharacter.chats[1].message
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.characters.splice(0, 1)
+        DBState.db.characters[0].chats.splice(0, 1)
+        listener.mockClear()
+        movedCharacter.name = 'moved'
+        movedMessages.push({ role: 'user', data: 'moved' })
+        DBState.db.characters[0].name = 're-accessed'
+        DBState.db.characters[0].chats[0].message.push({ role: 'user', data: 're-accessed' })
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['characters', 0, 'name'],
+            ['characters', 0, 'chats', 0, 'message', 0],
+            ['characters', 0, 'name'],
+            ['characters', 0, 'chats', 0, 'message', 1],
+        ])
+        unsubscribe()
+    })
+
+    it('resolves retained chat paths after unshift', () => {
+        setDatabaseLite(database({
+            characters: [{
+                chaId: 'character',
+                chatPage: 0,
+                chats: [
+                    { id: 'first', message: [] },
+                    { id: 'moved', message: [] },
+                ],
+            }] as character[],
+        }))
+        const movedMessages = DBState.db.characters[0].chats[1].message
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.characters[0].chats.unshift({ id: 'inserted', message: [] } as Chat)
+        listener.mockClear()
+        movedMessages.push({ role: 'user', data: 'after unshift' })
+
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+            path: ['characters', 0, 'chats', 2, 'message', 0],
+        }))
+        unsubscribe()
+    })
+
+    it('resolves moved elements in other database arrays', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { items: [{ value: 0 }, { value: 1 }] } }))
+        const movedItem = DBState.db.pluginCustomStorage.items[1]
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.pluginCustomStorage.items.splice(0, 1)
+        listener.mockClear()
+        movedItem.value = 2
+
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+            path: ['pluginCustomStorage', 'items', 0, 'value'],
+        }))
+        unsubscribe()
+    })
+
+    it('does not emit from detached or inactive proxies', () => {
+        const makeCharacter = (chaId: string) => ({ chaId, name: chaId, chatPage: 0, chats: [] })
+        setDatabaseLite(database({
+            characters: [makeCharacter('A'), makeCharacter('B')] as character[],
+            pluginCustomStorage: { nested: { value: 0 } },
+        }))
+        const detachedCharacter = DBState.db.characters[1]
+        const oldRoot = DBState.db
+        const oldNested = DBState.db.pluginCustomStorage.nested
+        DBState.db.characters.splice(1, 1)
+        setDatabaseLite(database())
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        detachedCharacter.name = 'detached'
+        oldRoot.username = 'inactive'
+        oldNested.value = 1
+
+        expect(listener).not.toHaveBeenCalled()
+        unsubscribe()
+    })
+
+    it('tracks an old value after it is re-accessed through the active root', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
+        const retained = DBState.db.pluginCustomStorage.retained
+        setDatabaseLite(database({ pluginCustomStorage: {} }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.pluginCustomStorage.reattached = retained
+        listener.mockClear()
+        retained.value = 1
+        DBState.db.pluginCustomStorage.reattached.value = 2
+
+        expect(listener).toHaveBeenCalledOnce()
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+            path: ['pluginCustomStorage', 'reattached', 'value'],
+        }))
+        unsubscribe()
+    })
+
+    it('does not emit when deleting a missing property', () => {
+        setDatabaseLite(database({ pluginCustomStorage: {} }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        delete DBState.db.pluginCustomStorage.missing
+
+        expect(listener).not.toHaveBeenCalled()
+        unsubscribe()
+    })
+
+    it('emits root replacement as an empty path', () => {
+        const oldValue = DBState.db
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        setDatabaseLite(DBState.db)
+        setDatabaseLite(database({ username: 'replacement' }))
+
+        expect(listener).toHaveBeenCalledTimes(1)
+        expect(listener).toHaveBeenCalledWith({
+            path: [],
+            value: DBState.db,
+            oldValue,
+            type: 'set',
+        })
+        unsubscribe()
+    })
+
     it('reports the actual non-current chat index in nested mutation paths', () => {
         setDatabaseLite(database({
             characters: [{
@@ -134,7 +278,7 @@ describe('database proxy layering', () => {
                     { id: 'current', message: [] },
                     { id: 'other', message: [] },
                 ],
-            }] as Database['characters'],
+            }] as character[],
         }))
         const listener = vi.fn()
         const unsubscribe = onDatabaseUpdate(listener)
@@ -150,7 +294,7 @@ describe('database proxy layering', () => {
     it('preserves old and new identities in character replacement and splice events', () => {
         const makeCharacter = (chaId: string) => ({ chaId, chatPage: 0, chats: [{ id: `${chaId}-chat`, message: [] }] })
         setDatabaseLite(database({
-            characters: [makeCharacter('A'), makeCharacter('B'), makeCharacter('C')] as Database['characters'],
+            characters: [makeCharacter('A'), makeCharacter('B'), makeCharacter('C')] as character[],
         }))
         const events: { path: (string | number | symbol)[], oldValue: unknown, value: unknown }[] = []
         const unsubscribe = onDatabaseUpdate((event) => events.push(event))
@@ -170,12 +314,12 @@ describe('database proxy layering', () => {
                 chaId: 'A',
                 chatPage: 0,
                 chats: [{ id: 'old-0', message: [] }, { id: 'old-1', message: [] }],
-            }] as Database['characters'],
+            }] as character[],
         }))
         const listener = vi.fn()
         const unsubscribe = onDatabaseUpdate(listener)
 
-        DBState.db.characters[0].chats = [{ id: 'new-0', message: [] }] as Database['characters'][number]['chats']
+        DBState.db.characters[0].chats = [{ id: 'new-0', message: [] }] as Chat[]
 
         expect(listener).toHaveBeenCalledWith(expect.objectContaining({
             path: ['characters', 0, 'chats'],
@@ -188,7 +332,7 @@ describe('database proxy layering', () => {
     it('reports characters removed by direct array truncation', () => {
         const makeCharacter = (chaId: string) => ({ chaId, chatPage: 0, chats: [{ id: `${chaId}-chat`, message: [] }] })
         setDatabaseLite(database({
-            characters: [makeCharacter('A'), makeCharacter('B'), makeCharacter('C')] as Database['characters'],
+            characters: [makeCharacter('A'), makeCharacter('B'), makeCharacter('C')] as character[],
         }))
         const listener = vi.fn()
         const unsubscribe = onDatabaseUpdate(listener)
@@ -213,7 +357,7 @@ describe('database proxy layering', () => {
                     { id: 'chat-1', message: [] },
                     { id: 'chat-2', message: [] },
                 ],
-            }] as Database['characters'],
+            }] as character[],
         }))
         const listener = vi.fn()
         const unsubscribe = onDatabaseUpdate(listener)
@@ -231,7 +375,7 @@ describe('database proxy layering', () => {
     it('does not duplicate deletion events from pop', () => {
         const makeCharacter = (chaId: string) => ({ chaId, chatPage: 0, chats: [{ id: `${chaId}-chat`, message: [] }] })
         setDatabaseLite(database({
-            characters: [makeCharacter('A'), makeCharacter('B')] as Database['characters'],
+            characters: [makeCharacter('A'), makeCharacter('B')] as character[],
         }))
         const listener = vi.fn()
         const unsubscribe = onDatabaseUpdate(listener)
@@ -252,6 +396,6 @@ describe('database proxy layering', () => {
             // @ts-expect-error Database replacement must use setDatabaseLite().
             DBState.db = database()
         }
-        DBState.db.characters.push({} as Database['characters'][number])
+        DBState.db.characters.push({} as character)
     })
 })

--- a/src/ts/storage/databaseState.svelte.test.ts
+++ b/src/ts/storage/databaseState.svelte.test.ts
@@ -1,0 +1,257 @@
+import { flushSync } from 'svelte'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DBState } from '../stores.svelte'
+import { getDatabase, onDatabaseUpdate, setDatabaseLite, type Database } from './database.svelte'
+
+vi.mock('../globalApi.svelte', () => ({
+    downloadFile: vi.fn(),
+    saveAsset: vi.fn(),
+}))
+vi.mock('../parser/parser.svelte', () => ({
+    applyMarkdownToNode: vi.fn(),
+    assetRegex: /$^/,
+    hasher: vi.fn(),
+    risuChatParser: vi.fn(),
+    risuEscape: vi.fn((value: string) => value),
+    risuUnescape: vi.fn((value: string) => value),
+}))
+
+class CustomValue {
+    value = 1
+}
+
+function database(values: Partial<Database> = {}): Database {
+    return {
+        characters: [],
+        ...values,
+    } as Database
+}
+
+afterEach(() => {
+    setDatabaseLite(database())
+})
+
+describe('database proxy layering', () => {
+    it('tracks nested mutations after receiving a plain object', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { plugin: { enabled: false } } }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.pluginCustomStorage.plugin.enabled = true
+
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+            path: ['pluginCustomStorage', 'plugin', 'enabled'],
+            value: true,
+            oldValue: false,
+            type: 'set',
+        }))
+        unsubscribe()
+    })
+
+    it('keeps Svelte reactivity outside the database proxy', () => {
+        setDatabaseLite(database({ username: 'before' }))
+        let observed = ''
+        const dispose = $effect.root(() => {
+            $effect(() => {
+                observed = DBState.db.username
+            })
+        })
+
+        flushSync()
+        DBState.db.username = 'after'
+        flushSync()
+
+        expect(observed).toBe('after')
+        dispose()
+    })
+
+    it('does not add another database proxy when passed the wrapped database again', () => {
+        setDatabaseLite(database({ username: 'before' }))
+        setDatabaseLite(DBState.db)
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.username = 'after'
+
+        expect(listener).toHaveBeenCalledTimes(1)
+        unsubscribe()
+    })
+
+    it('tracks mutations after restoring a plain snapshot', () => {
+        setDatabaseLite(database({ username: 'backup' }))
+        const backup = structuredClone(getDatabase({ snapshot: true }))
+        setDatabaseLite(backup)
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.username = 'restored and edited'
+
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+            path: ['username'],
+            value: 'restored and edited',
+        }))
+        unsubscribe()
+    })
+
+    it('does not proxy non-plain objects', () => {
+        const date = new Date()
+        const map = new Map([['key', 'value']])
+        const set = new Set(['value'])
+        const bytes = new Uint8Array([1, 2])
+        const instance = new CustomValue()
+        setDatabaseLite(database({ pluginCustomStorage: { date, map, set, bytes, instance } }))
+        const storage = DBState.db.pluginCustomStorage
+
+        expect(storage.date).toBe(date)
+        expect(storage.map).toBe(map)
+        expect(storage.set).toBe(set)
+        expect(storage.bytes).toBe(bytes)
+        expect(storage.instance).toBe(instance)
+    })
+
+    it('reports the access path used for shared plain objects', () => {
+        const shared = { value: 0 }
+        setDatabaseLite(database({ pluginCustomStorage: { first: shared, second: shared } }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.pluginCustomStorage.first.value = 1
+        DBState.db.pluginCustomStorage.second.value = 2
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'first', 'value'],
+            ['pluginCustomStorage', 'second', 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('reports the actual non-current chat index in nested mutation paths', () => {
+        setDatabaseLite(database({
+            characters: [{
+                chaId: 'character',
+                chatPage: 0,
+                chats: [
+                    { id: 'current', message: [] },
+                    { id: 'other', message: [] },
+                ],
+            }] as Database['characters'],
+        }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.characters[0].chats[1].message.push({ role: 'user', data: 'changed' })
+
+        expect(listener.mock.calls.some(([info]) =>
+            info.path[0] === 'characters' && info.path[1] === 0 && info.path[2] === 'chats' && info.path[3] === 1
+        )).toBe(true)
+        unsubscribe()
+    })
+
+    it('preserves old and new identities in character replacement and splice events', () => {
+        const makeCharacter = (chaId: string) => ({ chaId, chatPage: 0, chats: [{ id: `${chaId}-chat`, message: [] }] })
+        setDatabaseLite(database({
+            characters: [makeCharacter('A'), makeCharacter('B'), makeCharacter('C')] as Database['characters'],
+        }))
+        const events: { path: (string | number | symbol)[], oldValue: unknown, value: unknown }[] = []
+        const unsubscribe = onDatabaseUpdate((event) => events.push(event))
+
+        DBState.db.characters.splice(1, 1)
+
+        expect(events).toEqual(expect.arrayContaining([
+            expect.objectContaining({ path: ['characters', 1], oldValue: expect.objectContaining({ chaId: 'B' }), value: expect.objectContaining({ chaId: 'C' }) }),
+            expect.objectContaining({ path: ['characters', 2], oldValue: expect.objectContaining({ chaId: 'C' }), value: undefined }),
+        ]))
+        unsubscribe()
+    })
+
+    it('preserves complete old and new chat arrays in replacement events', () => {
+        setDatabaseLite(database({
+            characters: [{
+                chaId: 'A',
+                chatPage: 0,
+                chats: [{ id: 'old-0', message: [] }, { id: 'old-1', message: [] }],
+            }] as Database['characters'],
+        }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.characters[0].chats = [{ id: 'new-0', message: [] }] as Database['characters'][number]['chats']
+
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+            path: ['characters', 0, 'chats'],
+            oldValue: [expect.objectContaining({ id: 'old-0' }), expect.objectContaining({ id: 'old-1' })],
+            value: [expect.objectContaining({ id: 'new-0' })],
+        }))
+        unsubscribe()
+    })
+
+    it('reports characters removed by direct array truncation', () => {
+        const makeCharacter = (chaId: string) => ({ chaId, chatPage: 0, chats: [{ id: `${chaId}-chat`, message: [] }] })
+        setDatabaseLite(database({
+            characters: [makeCharacter('A'), makeCharacter('B'), makeCharacter('C')] as Database['characters'],
+        }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.characters.length = 1
+
+        expect(listener.mock.calls.map(([info]) => ({ path: info.path, oldValue: info.oldValue }))).toEqual([
+            { path: ['characters', 2], oldValue: expect.objectContaining({ chaId: 'C' }) },
+            { path: ['characters', 1], oldValue: expect.objectContaining({ chaId: 'B' }) },
+            { path: ['characters', 'length'], oldValue: 3 },
+        ])
+        unsubscribe()
+    })
+
+    it('reports chats removed by direct array truncation', () => {
+        setDatabaseLite(database({
+            characters: [{
+                chaId: 'A',
+                chatPage: 0,
+                chats: [
+                    { id: 'chat-0', message: [] },
+                    { id: 'chat-1', message: [] },
+                    { id: 'chat-2', message: [] },
+                ],
+            }] as Database['characters'],
+        }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.characters[0].chats.length = 1
+
+        expect(listener.mock.calls.map(([info]) => ({ path: info.path, oldValue: info.oldValue }))).toEqual([
+            { path: ['characters', 0, 'chats', 2], oldValue: expect.objectContaining({ id: 'chat-2' }) },
+            { path: ['characters', 0, 'chats', 1], oldValue: expect.objectContaining({ id: 'chat-1' }) },
+            { path: ['characters', 0, 'chats', 'length'], oldValue: 3 },
+        ])
+        unsubscribe()
+    })
+
+    it('does not duplicate deletion events from pop', () => {
+        const makeCharacter = (chaId: string) => ({ chaId, chatPage: 0, chats: [{ id: `${chaId}-chat`, message: [] }] })
+        setDatabaseLite(database({
+            characters: [makeCharacter('A'), makeCharacter('B')] as Database['characters'],
+        }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.characters.pop()
+
+        expect(listener.mock.calls.filter(([info]) => info.type === 'delete')).toHaveLength(1)
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+            path: ['characters', 1],
+            oldValue: expect.objectContaining({ chaId: 'B' }),
+            type: 'delete',
+        }))
+        unsubscribe()
+    })
+
+    it('exposes database replacement as shallow-readonly', () => {
+        if (false) {
+            // @ts-expect-error Database replacement must use setDatabaseLite().
+            DBState.db = database()
+        }
+        DBState.db.characters.push({} as Database['characters'][number])
+    })
+})

--- a/src/ts/storage/databaseState.svelte.test.ts
+++ b/src/ts/storage/databaseState.svelte.test.ts
@@ -221,7 +221,7 @@ describe('database proxy layering', () => {
         unsubscribe()
     })
 
-    it('tracks an old value after it is re-accessed through the active root', () => {
+    it('tracks a retained proxy after it is attached to the active root', () => {
         setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
         const retained = DBState.db.pluginCustomStorage.retained
         setDatabaseLite(database({ pluginCustomStorage: {} }))
@@ -233,10 +233,160 @@ describe('database proxy layering', () => {
         retained.value = 1
         DBState.db.pluginCustomStorage.reattached.value = 2
 
-        expect(listener).toHaveBeenCalledOnce()
-        expect(listener).toHaveBeenCalledWith(expect.objectContaining({
-            path: ['pluginCustomStorage', 'reattached', 'value'],
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'reattached', 'value'],
+            ['pluginCustomStorage', 'reattached', 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('tracks a retained child after replacing and reordering its container', () => {
+        setDatabaseLite(database({
+            pluginCustomStorage: {
+                container: { items: [{ value: 0 }, { value: 1 }] },
+            },
         }))
+        const retained = DBState.db.pluginCustomStorage.container.items[1]
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.pluginCustomStorage.container = { items: [retained, { value: 2 }] }
+        listener.mockClear()
+        retained.value = 3
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'container', 'items', 0, 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('eagerly connects retained proxies through newly attached intermediate objects', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
+        const retained = DBState.db.pluginCustomStorage.retained
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        DBState.db.pluginCustomStorage = { wrapper: { nested: { retained } } }
+        listener.mockClear()
+        retained.value = 1
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'wrapper', 'nested', 'retained', 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('eagerly connects retained proxies during root replacement', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
+        const retained = DBState.db.pluginCustomStorage.retained
+
+        setDatabaseLite(database({
+            pluginCustomStorage: { wrapper: { nested: { retained } } },
+        }))
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        retained.value = 1
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'wrapper', 'nested', 'retained', 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('keeps deeply reattached proxies serializable at snapshot and save boundaries', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
+        const retained = DBState.db.pluginCustomStorage.retained
+
+        DBState.db.pluginCustomStorage = { wrapper: { nested: { retained } } }
+        retained.value = 1
+
+        const snapshot = structuredClone(getDatabase({ snapshot: true }))
+        const serialized = JSON.parse(JSON.stringify(getDatabase()))
+
+        expect(snapshot.pluginCustomStorage.wrapper.nested.retained.value).toBe(1)
+        expect(serialized.pluginCustomStorage.wrapper.nested.retained.value).toBe(1)
+    })
+
+    it('emits every active path for a shared retained proxy', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { first: { value: 0 } } }))
+        const shared = DBState.db.pluginCustomStorage.first
+        DBState.db.pluginCustomStorage.second = shared
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        shared.value = 1
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'first', 'value'],
+            ['pluginCustomStorage', 'second', 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('removes only the replaced edge to a shared retained proxy', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { first: { value: 0 } } }))
+        const shared = DBState.db.pluginCustomStorage.first
+        DBState.db.pluginCustomStorage.second = shared
+        delete DBState.db.pluginCustomStorage.first
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        shared.value = 1
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'second', 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('does not emit from a detached retained proxy', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
+        const retained = DBState.db.pluginCustomStorage.retained
+        delete DBState.db.pluginCustomStorage.retained
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        retained.value = 1
+
+        expect(listener).not.toHaveBeenCalled()
+        unsubscribe()
+    })
+
+    it('does not duplicate propagation after repeated container replacements', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
+        const retained = DBState.db.pluginCustomStorage.retained
+        DBState.db.pluginCustomStorage = { wrapper: { retained } }
+        DBState.db.pluginCustomStorage = { wrapper: { retained } }
+        DBState.db.pluginCustomStorage = { wrapper: { retained } }
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        retained.value = 1
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'wrapper', 'retained', 'value'],
+        ])
+        unsubscribe()
+    })
+
+    it('disconnects array elements removed by length shrink', () => {
+        setDatabaseLite(database({
+            pluginCustomStorage: {
+                items: [{ value: 0 }, { value: 1 }, { value: 2 }],
+            },
+        }))
+        const retained = DBState.db.pluginCustomStorage.items[2]
+        DBState.db.pluginCustomStorage.items.length = 1
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        retained.value = 3
+        DBState.db.pluginCustomStorage.items[0].value = 4
+
+        expect(listener.mock.calls.map(([info]) => info.path)).toEqual([
+            ['pluginCustomStorage', 'items', 0, 'value'],
+        ])
         unsubscribe()
     })
 

--- a/src/ts/storage/databaseState.svelte.ts
+++ b/src/ts/storage/databaseState.svelte.ts
@@ -12,15 +12,25 @@ export interface DatabaseUpdateInfo {
 const databaseUpdateListeners = new Set<(info: DatabaseUpdateInfo) => void>()
 const mutableDBState = $state({ db: {} as Database })
 
-interface DatabaseProxyMetadata {
-    target: object
-    parent: DatabaseProxyMetadata | null
-    key: PropertyKey | null
-    children: Map<PropertyKey, { target: object, proxy: object }>
+type DatabaseProxyListener = (info: DatabaseUpdateInfo) => void
+
+interface DatabaseProxyChild {
+    state: DatabaseProxyState
+    unsubscribe?: () => void
 }
 
-const databaseProxyMetadata = new WeakMap<object, DatabaseProxyMetadata>()
-let activeRoot: DatabaseProxyMetadata | null = null
+// Database values must form an acyclic, JSON-compatible graph. Shared targets
+// are supported, but cycles are invalid for both event propagation and saving.
+interface DatabaseProxyState {
+    target: object
+    proxy: object
+    listeners: Set<DatabaseProxyListener>
+    children: Map<PropertyKey, DatabaseProxyChild>
+}
+
+const databaseProxyStates = new WeakMap<object, DatabaseProxyState>()
+const databaseProxyCache = new WeakMap<object, DatabaseProxyState>()
+let unsubscribeActiveRoot: (() => void) | undefined
 
 export const DBState: { readonly db: Database } = mutableDBState
 
@@ -56,106 +66,177 @@ function unwrapDatabaseProxy<T>(value: T): T {
     if (!value || typeof value !== 'object') {
         return value
     }
-    return (databaseProxyMetadata.get(value)?.target ?? value) as T
+    return (databaseProxyStates.get(value)?.target ?? value) as T
 }
 
-function resolveProxyPath(metadata: DatabaseProxyMetadata): DatabaseUpdatePathKey[] | null {
-    const chain: DatabaseProxyMetadata[] = []
-    let root = metadata
-    while (root.parent) {
-        chain.push(root)
-        root = root.parent
+function notifyDatabaseProxy(state: DatabaseProxyState, info: DatabaseUpdateInfo) {
+    for (const listener of state.listeners) {
+        listener(info)
     }
-    if (root !== activeRoot) {
-        return null
-    }
+}
 
-    const path: DatabaseUpdatePathKey[] = []
-    for (const child of chain.reverse()) {
-        const parent = child.parent!
-        let key = child.key
-        if (key === null || unwrapDatabaseProxy(Reflect.get(parent.target, key)) !== child.target) {
-            key = Reflect.ownKeys(parent.target).find((candidate) =>
-                unwrapDatabaseProxy(Reflect.get(parent.target, candidate)) === child.target
-            ) ?? null
-            if (key === null) {
-                return null
-            }
-            child.key = key
+function subscribeDatabaseProxyChild(state: DatabaseProxyState, prop: PropertyKey, child: DatabaseProxyChild) {
+    child.unsubscribe = subscribeDatabaseProxy(child.state, (info) => {
+        notifyDatabaseProxy(state, {
+            ...info,
+            path: [normalizePathKey(state.target, prop), ...info.path],
+        })
+    })
+}
+
+function subscribeDatabaseProxy(state: DatabaseProxyState, listener: DatabaseProxyListener) {
+    const activateChildren = state.listeners.size === 0
+    state.listeners.add(listener)
+
+    if (activateChildren) {
+        for (const [prop, child] of state.children) {
+            subscribeDatabaseProxyChild(state, prop, child)
         }
-        path.push(normalizePathKey(parent.target, key))
     }
-    return path
+
+    return () => {
+        if (!state.listeners.delete(listener) || state.listeners.size !== 0) {
+            return
+        }
+        for (const child of state.children.values()) {
+            child.unsubscribe?.()
+            child.unsubscribe = undefined
+        }
+    }
 }
 
-function createDatabaseProxy<T>(target: T, parent: DatabaseProxyMetadata | null = null, key: PropertyKey | null = null): T {
+function removeDatabaseProxyChild(state: DatabaseProxyState, prop: PropertyKey) {
+    const child = state.children.get(prop)
+    if (child) {
+        state.children.delete(prop)
+        child.unsubscribe?.()
+    }
+}
+
+function addDatabaseProxyChild(state: DatabaseProxyState, prop: PropertyKey, value: unknown) {
+    removeDatabaseProxyChild(state, prop)
+    const childProxy = createDatabaseProxy(unwrapDatabaseProxy(value))
+    if (!isProxyableDatabaseValue(childProxy)) {
+        return
+    }
+
+    const childState = databaseProxyStates.get(childProxy)
+    if (!childState) {
+        return
+    }
+
+    const child: DatabaseProxyChild = { state: childState }
+    state.children.set(prop, child)
+    if (state.listeners.size !== 0) {
+        subscribeDatabaseProxyChild(state, prop, child)
+    }
+}
+
+function readDatabaseProxyChild(target: object, prop: PropertyKey, receiver: object = target) {
+    let value = Reflect.get(target, prop, receiver)
+    if (value && typeof value === 'object') {
+        const childState = databaseProxyStates.get(value)
+        if (childState) {
+            // A new plain container may contain a retained database proxy. Keep
+            // the Svelte target in state so tracking proxies are never persisted.
+            Reflect.set(target, prop, childState.target, target)
+            value = Reflect.get(target, prop, receiver)
+        }
+    }
+    return unwrapDatabaseProxy(value)
+}
+
+function createDatabaseProxy<T>(target: T): T {
     target = unwrapDatabaseProxy(target)
     if (!isProxyableDatabaseValue(target)) {
         return target
     }
 
-    const metadata: DatabaseProxyMetadata = { target, parent, key, children: new Map() }
+    const cached = databaseProxyCache.get(target)
+    if (cached) {
+        return cached.proxy as T
+    }
+
+    let state: DatabaseProxyState
     const proxy = new Proxy(target, {
         get(obj, prop, receiver) {
-            const value = unwrapDatabaseProxy(Reflect.get(obj, prop, receiver))
-            if (isProxyableDatabaseValue(value)) {
-                const cached = metadata.children.get(prop)
-                if (cached?.target === value) {
-                    return cached.proxy
-                }
-                const childProxy = createDatabaseProxy(value, metadata, prop)
-                metadata.children.set(prop, { target: value, proxy: childProxy })
-                return childProxy
+            const value = readDatabaseProxyChild(obj, prop, receiver)
+            if (!isProxyableDatabaseValue(value)) {
+                removeDatabaseProxyChild(state, prop)
+                return value
             }
-            return value
+
+            const child = state.children.get(prop)
+            if (child?.state.target !== value) {
+                addDatabaseProxyChild(state, prop, value)
+            }
+            return state.children.get(prop)?.state.proxy ?? value
         },
         set(obj, prop, value, receiver) {
-            const oldValue = unwrapDatabaseProxy(Reflect.get(obj, prop, receiver))
+            const oldValue = readDatabaseProxyChild(obj, prop, receiver)
             const newValue = unwrapDatabaseProxy(value)
             const truncatedEntries = Array.isArray(obj) && prop === 'length' &&
                 typeof oldValue === 'number' && typeof value === 'number' &&
                 Number.isInteger(value) && value >= 0 && value < oldValue
                 ? Reflect.ownKeys(obj)
                     .filter((key): key is string => typeof key === 'string' && /^\d+$/.test(key) && Number(key) >= value)
-                    .map((key) => ({ index: Number(key), oldValue: Reflect.get(obj, key) }))
+                    .map((key) => ({ index: Number(key), oldValue: readDatabaseProxyChild(obj, key) }))
                     .sort((a, b) => b.index - a.index)
                 : []
             const result = Reflect.set(obj, prop, newValue, receiver)
-            if (result && !Object.is(oldValue, newValue)) {
-                metadata.children.delete(prop)
-                const path = resolveProxyPath(metadata)
-                if (path === null) {
-                    return result
-                }
+            const assignedValue = result ? readDatabaseProxyChild(obj, prop, receiver) : oldValue
+            if (result && !Object.is(oldValue, assignedValue)) {
+                addDatabaseProxyChild(state, prop, assignedValue)
                 for (const entry of truncatedEntries) {
-                    metadata.children.delete(String(entry.index))
-                    emitDatabaseUpdate({
-                        path: [...path, entry.index],
+                    removeDatabaseProxyChild(state, String(entry.index))
+                    notifyDatabaseProxy(state, {
+                        path: [entry.index],
                         value: undefined,
                         oldValue: entry.oldValue,
                         type: 'delete',
                     })
                 }
-                emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value: newValue, oldValue, type: 'set' })
+                notifyDatabaseProxy(state, {
+                    path: [normalizePathKey(obj, prop)],
+                    value: assignedValue,
+                    oldValue,
+                    type: 'set',
+                })
             }
             return result
         },
         deleteProperty(obj, prop) {
             const existed = Object.prototype.hasOwnProperty.call(obj, prop)
-            const oldValue = unwrapDatabaseProxy(Reflect.get(obj, prop))
+            const oldValue = readDatabaseProxyChild(obj, prop)
             const result = Reflect.deleteProperty(obj, prop)
             if (result && existed) {
-                metadata.children.delete(prop)
-                const path = resolveProxyPath(metadata)
-                if (path !== null) {
-                    emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value: undefined, oldValue, type: 'delete' })
-                }
+                removeDatabaseProxyChild(state, prop)
+                notifyDatabaseProxy(state, {
+                    path: [normalizePathKey(obj, prop)],
+                    value: undefined,
+                    oldValue,
+                    type: 'delete',
+                })
             }
             return result
         },
     })
 
-    databaseProxyMetadata.set(proxy, metadata)
+    state = {
+        target,
+        proxy,
+        listeners: new Set(),
+        children: new Map(),
+    }
+    databaseProxyStates.set(proxy, state)
+    databaseProxyCache.set(target, state)
+
+    // Connect the complete JSON-data subtree eagerly so retained proxies work
+    // immediately after attachment without requiring the new path to be read.
+    for (const prop of Reflect.ownKeys(target)) {
+        addDatabaseProxyChild(state, prop, readDatabaseProxyChild(target, prop))
+    }
+
     return proxy
 }
 
@@ -172,9 +253,15 @@ export function setDatabaseLite(data: Database) {
     }
 
     const oldValue = DBState.db
+    unsubscribeActiveRoot?.()
+    unsubscribeActiveRoot = undefined
     mutableDBState.db = unwrapDatabaseProxy(data)
     const database = createDatabaseProxy(mutableDBState.db)
-    activeRoot = databaseProxyMetadata.get(database) ?? null
+    const rootState = databaseProxyStates.get(database)
+    if (!rootState) {
+        throw new Error('Database root must be proxyable')
+    }
+    unsubscribeActiveRoot = subscribeDatabaseProxy(rootState, emitDatabaseUpdate)
     mutableDBState.db = database
     emitDatabaseUpdate({ path: [], value: DBState.db, oldValue, type: 'set' })
 }

--- a/src/ts/storage/databaseState.svelte.ts
+++ b/src/ts/storage/databaseState.svelte.ts
@@ -10,8 +10,17 @@ export interface DatabaseUpdateInfo {
 }
 
 const databaseUpdateListeners = new Set<(info: DatabaseUpdateInfo) => void>()
-const dbProxyInstances = new WeakSet<object>()
 const mutableDBState = $state({ db: {} as Database })
+
+interface DatabaseProxyMetadata {
+    target: object
+    parent: DatabaseProxyMetadata | null
+    key: PropertyKey | null
+    children: Map<PropertyKey, { target: object, proxy: object }>
+}
+
+const databaseProxyMetadata = new WeakMap<object, DatabaseProxyMetadata>()
+let activeRoot: DatabaseProxyMetadata | null = null
 
 export const DBState: { readonly db: Database } = mutableDBState
 
@@ -43,28 +52,66 @@ function isProxyableDatabaseValue(value: unknown): value is object {
     return prototype === Object.prototype || prototype === null
 }
 
-function createDatabaseProxy<T>(target: T, path: DatabaseUpdatePathKey[] = []): T {
-    if (!isProxyableDatabaseValue(target) || dbProxyInstances.has(target)) {
+function unwrapDatabaseProxy<T>(value: T): T {
+    if (!value || typeof value !== 'object') {
+        return value
+    }
+    return (databaseProxyMetadata.get(value)?.target ?? value) as T
+}
+
+function resolveProxyPath(metadata: DatabaseProxyMetadata): DatabaseUpdatePathKey[] | null {
+    const chain: DatabaseProxyMetadata[] = []
+    let root = metadata
+    while (root.parent) {
+        chain.push(root)
+        root = root.parent
+    }
+    if (root !== activeRoot) {
+        return null
+    }
+
+    const path: DatabaseUpdatePathKey[] = []
+    for (const child of chain.reverse()) {
+        const parent = child.parent!
+        let key = child.key
+        if (key === null || unwrapDatabaseProxy(Reflect.get(parent.target, key)) !== child.target) {
+            key = Reflect.ownKeys(parent.target).find((candidate) =>
+                unwrapDatabaseProxy(Reflect.get(parent.target, candidate)) === child.target
+            ) ?? null
+            if (key === null) {
+                return null
+            }
+            child.key = key
+        }
+        path.push(normalizePathKey(parent.target, key))
+    }
+    return path
+}
+
+function createDatabaseProxy<T>(target: T, parent: DatabaseProxyMetadata | null = null, key: PropertyKey | null = null): T {
+    target = unwrapDatabaseProxy(target)
+    if (!isProxyableDatabaseValue(target)) {
         return target
     }
 
-    const childProxyCache = new Map<PropertyKey, { value: object, proxy: object }>()
+    const metadata: DatabaseProxyMetadata = { target, parent, key, children: new Map() }
     const proxy = new Proxy(target, {
         get(obj, prop, receiver) {
-            const value = Reflect.get(obj, prop, receiver)
+            const value = unwrapDatabaseProxy(Reflect.get(obj, prop, receiver))
             if (isProxyableDatabaseValue(value)) {
-                const cached = childProxyCache.get(prop)
-                if (cached?.value === value) {
+                const cached = metadata.children.get(prop)
+                if (cached?.target === value) {
                     return cached.proxy
                 }
-                const childProxy = createDatabaseProxy(value, [...path, normalizePathKey(obj, prop)])
-                childProxyCache.set(prop, { value, proxy: childProxy })
+                const childProxy = createDatabaseProxy(value, metadata, prop)
+                metadata.children.set(prop, { target: value, proxy: childProxy })
                 return childProxy
             }
             return value
         },
         set(obj, prop, value, receiver) {
-            const oldValue = Reflect.get(obj, prop, receiver)
+            const oldValue = unwrapDatabaseProxy(Reflect.get(obj, prop, receiver))
+            const newValue = unwrapDatabaseProxy(value)
             const truncatedEntries = Array.isArray(obj) && prop === 'length' &&
                 typeof oldValue === 'number' && typeof value === 'number' &&
                 Number.isInteger(value) && value >= 0 && value < oldValue
@@ -73,11 +120,15 @@ function createDatabaseProxy<T>(target: T, path: DatabaseUpdatePathKey[] = []): 
                     .map((key) => ({ index: Number(key), oldValue: Reflect.get(obj, key) }))
                     .sort((a, b) => b.index - a.index)
                 : []
-            const result = Reflect.set(obj, prop, value, receiver)
-            if (result && oldValue !== value) {
-                childProxyCache.delete(prop)
+            const result = Reflect.set(obj, prop, newValue, receiver)
+            if (result && !Object.is(oldValue, newValue)) {
+                metadata.children.delete(prop)
+                const path = resolveProxyPath(metadata)
+                if (path === null) {
+                    return result
+                }
                 for (const entry of truncatedEntries) {
-                    childProxyCache.delete(String(entry.index))
+                    metadata.children.delete(String(entry.index))
                     emitDatabaseUpdate({
                         path: [...path, entry.index],
                         value: undefined,
@@ -85,22 +136,26 @@ function createDatabaseProxy<T>(target: T, path: DatabaseUpdatePathKey[] = []): 
                         type: 'delete',
                     })
                 }
-                emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value, oldValue, type: 'set' })
+                emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value: newValue, oldValue, type: 'set' })
             }
             return result
         },
         deleteProperty(obj, prop) {
-            const oldValue = Reflect.get(obj, prop)
+            const existed = Object.prototype.hasOwnProperty.call(obj, prop)
+            const oldValue = unwrapDatabaseProxy(Reflect.get(obj, prop))
             const result = Reflect.deleteProperty(obj, prop)
-            if (result) {
-                childProxyCache.delete(prop)
-                emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value: undefined, oldValue, type: 'delete' })
+            if (result && existed) {
+                metadata.children.delete(prop)
+                const path = resolveProxyPath(metadata)
+                if (path !== null) {
+                    emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value: undefined, oldValue, type: 'delete' })
+                }
             }
             return result
         },
     })
 
-    dbProxyInstances.add(proxy)
+    databaseProxyMetadata.set(proxy, metadata)
     return proxy
 }
 
@@ -112,6 +167,14 @@ export function onDatabaseUpdate(listener: (info: DatabaseUpdateInfo) => void) {
 
 /** Replace the database while preserving the Svelte -> database proxy invariant. */
 export function setDatabaseLite(data: Database) {
-    mutableDBState.db = data
-    mutableDBState.db = createDatabaseProxy(mutableDBState.db)
+    if (unwrapDatabaseProxy(data) === unwrapDatabaseProxy(DBState.db)) {
+        return
+    }
+
+    const oldValue = DBState.db
+    mutableDBState.db = unwrapDatabaseProxy(data)
+    const database = createDatabaseProxy(mutableDBState.db)
+    activeRoot = databaseProxyMetadata.get(database) ?? null
+    mutableDBState.db = database
+    emitDatabaseUpdate({ path: [], value: DBState.db, oldValue, type: 'set' })
 }

--- a/src/ts/storage/databaseState.svelte.ts
+++ b/src/ts/storage/databaseState.svelte.ts
@@ -52,11 +52,11 @@ function normalizePathKey(target: object, prop: PropertyKey): DatabaseUpdatePath
 }
 
 function isProxyableDatabaseValue(value: unknown): value is object {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
+        return false
+    }
     if (Array.isArray(value)) {
         return true
-    }
-    if (!value || typeof value !== 'object') {
-        return false
     }
     const prototype = Object.getPrototypeOf(value)
     return prototype === Object.prototype || prototype === null

--- a/src/ts/storage/databaseState.svelte.ts
+++ b/src/ts/storage/databaseState.svelte.ts
@@ -1,0 +1,117 @@
+import type { Database } from './database.svelte'
+
+type DatabaseUpdatePathKey = string | number | symbol
+
+export interface DatabaseUpdateInfo {
+    path: DatabaseUpdatePathKey[]
+    value: unknown
+    oldValue: unknown
+    type: 'set' | 'delete'
+}
+
+const databaseUpdateListeners = new Set<(info: DatabaseUpdateInfo) => void>()
+const dbProxyInstances = new WeakSet<object>()
+const mutableDBState = $state({ db: {} as Database })
+
+export const DBState: { readonly db: Database } = mutableDBState
+
+function emitDatabaseUpdate(info: DatabaseUpdateInfo) {
+    for (const listener of databaseUpdateListeners) {
+        try {
+            listener(info)
+        } catch (error) {
+            console.error(error)
+        }
+    }
+}
+
+function normalizePathKey(target: object, prop: PropertyKey): DatabaseUpdatePathKey {
+    if (Array.isArray(target) && typeof prop === 'string' && /^\d+$/.test(prop)) {
+        return Number(prop)
+    }
+    return prop
+}
+
+function isProxyableDatabaseValue(value: unknown): value is object {
+    if (Array.isArray(value)) {
+        return true
+    }
+    if (!value || typeof value !== 'object') {
+        return false
+    }
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+}
+
+function createDatabaseProxy<T>(target: T, path: DatabaseUpdatePathKey[] = []): T {
+    if (!isProxyableDatabaseValue(target) || dbProxyInstances.has(target)) {
+        return target
+    }
+
+    const childProxyCache = new Map<PropertyKey, { value: object, proxy: object }>()
+    const proxy = new Proxy(target, {
+        get(obj, prop, receiver) {
+            const value = Reflect.get(obj, prop, receiver)
+            if (isProxyableDatabaseValue(value)) {
+                const cached = childProxyCache.get(prop)
+                if (cached?.value === value) {
+                    return cached.proxy
+                }
+                const childProxy = createDatabaseProxy(value, [...path, normalizePathKey(obj, prop)])
+                childProxyCache.set(prop, { value, proxy: childProxy })
+                return childProxy
+            }
+            return value
+        },
+        set(obj, prop, value, receiver) {
+            const oldValue = Reflect.get(obj, prop, receiver)
+            const truncatedEntries = Array.isArray(obj) && prop === 'length' &&
+                typeof oldValue === 'number' && typeof value === 'number' &&
+                Number.isInteger(value) && value >= 0 && value < oldValue
+                ? Reflect.ownKeys(obj)
+                    .filter((key): key is string => typeof key === 'string' && /^\d+$/.test(key) && Number(key) >= value)
+                    .map((key) => ({ index: Number(key), oldValue: Reflect.get(obj, key) }))
+                    .sort((a, b) => b.index - a.index)
+                : []
+            const result = Reflect.set(obj, prop, value, receiver)
+            if (result && oldValue !== value) {
+                childProxyCache.delete(prop)
+                for (const entry of truncatedEntries) {
+                    childProxyCache.delete(String(entry.index))
+                    emitDatabaseUpdate({
+                        path: [...path, entry.index],
+                        value: undefined,
+                        oldValue: entry.oldValue,
+                        type: 'delete',
+                    })
+                }
+                emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value, oldValue, type: 'set' })
+            }
+            return result
+        },
+        deleteProperty(obj, prop) {
+            const oldValue = Reflect.get(obj, prop)
+            const result = Reflect.deleteProperty(obj, prop)
+            if (result) {
+                childProxyCache.delete(prop)
+                emitDatabaseUpdate({ path: [...path, normalizePathKey(obj, prop)], value: undefined, oldValue, type: 'delete' })
+            }
+            return result
+        },
+    })
+
+    dbProxyInstances.add(proxy)
+    return proxy
+}
+
+/** Subscribe to successful database property writes and deletions. */
+export function onDatabaseUpdate(listener: (info: DatabaseUpdateInfo) => void) {
+    databaseUpdateListeners.add(listener)
+    return () => databaseUpdateListeners.delete(listener)
+}
+
+/** Replace the database while preserving the Svelte -> database proxy invariant. */
+export function setDatabaseLite(data: Database) {
+    mutableDBState.db = data
+    mutableDBState.db = createDatabaseProxy(mutableDBState.db)
+}

--- a/src/ts/storage/risuSave.ts
+++ b/src/ts/storage/risuSave.ts
@@ -82,7 +82,6 @@ export async function encodeRisuSaveCompressionStream(data:any) {
 
 export type toSaveType = {
     character: string[];
-    chat: [string, string][];
     botPreset: boolean;
     modules: boolean;
     loadouts: boolean;

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -6,6 +6,9 @@ import { moduleUpdate } from "./process/modules";
 import { resetScriptCache } from "./process/scripts";
 import type { hubType } from "./characterCards";
 import type { PluginSafetyErrors } from "./plugins/pluginSafety";
+import { DBState } from "./storage/databaseState.svelte";
+
+export { DBState } from "./storage/databaseState.svelte";
 
 function updateSize(){
     SizeStore.set({
@@ -102,10 +105,6 @@ export function createSimpleCharacter(char:character|groupChat){
 
 updateSize()
 window.addEventListener("resize", updateSize);
-export const DBState = $state({
-    db: {} as any as Database
-});
-
 export const LoadingStatusState = $state({
     text: '',
 })


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [X] Have you added type definitions?
    - [X] Have you tested your changes?
    - [X] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly ai generated[^2], check the following:
    - [ ] Have you understanded what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

Improve database save performance by introducing a proxy-based change detection layer, replacing the snapshot-based approach in `saveDb()` with event-driven change tracking.

## Related Issues

None

## Changes

- Introduced `onDatabaseUpdate()` API in `database.svelte.ts` for reactive database mutation detection.
  The callback receives `DatabaseUpdateInfo` containing `path`, `value`, `oldValue` and `type`
- Refactor `saveDb()`  to manage `changeTracker` using event-based callbacks from `onDatabaseUpdate()` instead of `$state.snapshot` operations.

## Impact

- Snapshot operation on large chat histories are expensive (~1s for 7MB). This refactor reduces change detection complexity from `O(n)` snapshot scanning to `O(1)` reactive event handling 
- The event-based approach is more robust than snapshot-based detection. For example, it now detects changes on unselected characters, which the previous approach missed.

## Additional Notes

Tested on various edge cases, including character/chat/message/prompt/module addition and deletion. Further testing may be beneficial.
