### PR TITLE
refactor: Playground lazyloading

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -26,13 +26,13 @@
     import { processMultiCommand } from 'src/ts/process/command';
     import { postChatFile } from 'src/ts/process/files/multisend';
     import { getInlayAsset } from 'src/ts/process/files/inlays';
-    import PlaygroundMenu from '../Playground/PlaygroundMenu.svelte';
     import { ConnectionOpenStore } from 'src/ts/sync/multiuser';
     import { coldStorageHeader, preLoadChat } from 'src/ts/process/coldstorage.svelte';
     import Chats from './Chats.svelte';
     import Button from '../UI/GUI/Button.svelte';
     import PluginDefinedIcon from '../Others/PluginDefinedIcon.svelte';
 
+    const loadPlaygroundMenu = () => import('../Playground/PlaygroundMenu.svelte').then(m => m.default);
     
     interface Props {
         openModuleList?: boolean;
@@ -563,7 +563,9 @@
         {#if $PlaygroundStore === 0}
             <MainMenu />
         {:else}
-            <PlaygroundMenu />
+            {#await loadPlaygroundMenu() then PlaygroundMenu}
+                <PlaygroundMenu />
+            {/await}
         {/if}
     {:else}
         <div class="h-full w-full flex flex-col-reverse overflow-y-auto relative default-chat-screen" onscroll={(e) => {

--- a/src/lib/Playground/PlaygroundMenu.svelte
+++ b/src/lib/Playground/PlaygroundMenu.svelte
@@ -14,10 +14,10 @@
     import PlaygroundParser from "./PlaygroundParser.svelte";
     import ToolConversion from "./ToolConversion.svelte";
     import { joinMultiuserRoom } from "src/ts/sync/multiuser";
-  import PlaygroundSubtitle from "./PlaygroundSubtitle.svelte";
-  import PlaygroundImageTrans from "./PlaygroundImageTrans.svelte";
-  import PlaygroundTranslation from "./PlaygroundTranslation.svelte";
-  import PlaygroundMcp from "./PlaygroundMCP.svelte";
+    import PlaygroundSubtitle from "./PlaygroundSubtitle.svelte";
+    import PlaygroundImageTrans from "./PlaygroundImageTrans.svelte";
+    import PlaygroundTranslation from "./PlaygroundTranslation.svelte";
+    import PlaygroundMcp from "./PlaygroundMCP.svelte";
     import PlaygroundDocs from "./PlaygroundDocs.svelte";
 
     let easterEggTouch = $state(0)


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

Playground components aren't needed in normal chats. Loads their entry only when needed.

## Related Issues

None.

## Changes

Simple lazy loading of the component was added in `DefaultChatScreen.svelte`. Bundle size reduced by ~40kb.

## Impact

None.
