### PR TITLE
fix: add crossorigin attribute to manifest link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/logo_16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/logo_32.png" />
     <link rel="icon" type="image/png" sizes="256x256" href="/logo_256.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <link rel="stylesheet" href="/src/styles.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.27/dist/katex.min.css" integrity="sha384-Pu5+C18nP5dwykLJOhd2U4Xen7rjScHN/qusop27hdd2drI+lL5KvX7YntvT8yew" crossorigin="anonymous">
     <meta name="description" content="An AI frontend for both light and core users.">


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

Web app manifests are fetched without credentials by default, which causes access failures when authentication is required.

Added the `crossorigin` attribute to the manifest link to ensure credentials (cookies) are included in the request.

## Related Issues

None

## Changes

- Added `crossorigin="use-credentials"` attribute to the `<link rel="manifest" ...>` tag in the HTML head.

## Impact

- The manifest request will now be successfully fetched in environments where cookie-based authentication is required to access static assets.

## Additional Notes

- This issue was encountered while using Cloudflare Access, where the manifest file was unreachable due to missing credentials. Honestly, it doesn't affect functionality, but the constant console errors were bothering me.
- Reference: https://web.dev/articles/add-manifest#link-manifest