### PR TITLE
feat: Register `#escape` to CBS doc, add `#escape::keep`

### DIFF
--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -2386,7 +2386,7 @@ Basic operators:
 {{#when::not::A}}...{{/when}} - negates condition, so it will be true if A is false.
 
 Advanced operators:
-{{#when::keep::A}}...{{/when}} - keep whitespace handling, so it will not trim spaces inside block.
+{{#when::keep::A}}...{{/when}} - keeps whitespace inside the block without trimming.
 {{#when::legacy::A}}...{{/when}} - legacy whitespace handling, so it will handle like deprecated #if.
 {{#when::var::A}}...{{/when}} - checks if variable A is truthy.
 {{#when::A::vis::B}}...{{/when}} - checks if variable A is equal to literal B.
@@ -2431,13 +2431,25 @@ Usage:: {{#when condition}}...{{/when}} or {{#when::not::condition}}...{{/when}}
     })
 
     registerFunction({
+        name: '#escape',
+        callback: 'doc_only',
+        alias: [],
+        description: `Escapes curly braces and parentheses, treating content as literal text. Useful for displaying CBS syntax without evaluation.
+
+Operators:
+{{#escape::keep}} - keeps whitespace inside the block without trimming.
+
+Usage:: {{#escape}}...{{/escape}}`,
+    })
+
+    registerFunction({
         name:'#each',
         callback: 'doc_only',
         alias: [':each'],
         description: `Iterates over an array.
 
 Operators:
-{{#each::keep A as V}} - keep whitespace handling, so it will not trim spaces inside block.
+{{#each::keep A as V}} - keeps whitespace inside the block without trimming.
 
 Usage:: {{#each A as V}} ... {{slot::V}} ... {{/each}}`,
     })

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -1428,8 +1428,10 @@ function blockStartMatcher(p1:string,matcherArg:matcherArg):{type:blockMatch,typ
     if(p1 === '#code'){
         return {type:'normalize'}
     }
-    if(p1 === '#escape'){
-        return {type:'escape'}
+    if(p1.startsWith('#escape')){
+        const t2 = p1.substring(7).trim()
+        const mode = t2 === '::keep' ? 'keep' : undefined
+        return {type:'escape', mode}
     }
     if(p1.startsWith('#each')){
         let t2 = p1.substring(5).trim()
@@ -1461,21 +1463,21 @@ function trimLines(p1:string){
 }
 
 function blockEndMatcher(p1:string,type:{type:blockMatch,type2?:string,mode?:string},matcherArg:matcherArg):string{
-    const p1Trimed = p1.trim() 
+    const p1Trimmed = p1.trim() 
     switch(type.type){
         case 'pure':
         case 'pure-display':
         case 'function':{
-            return p1Trimed
+            return p1Trimmed
         }
         case 'parse':{
-            return trimLines(p1Trimed)
+            return trimLines(p1Trimmed)
         }
         case 'each':{
             if(type.mode === 'keep'){
                 return p1
             }
-            return trimLines(p1Trimed)
+            return trimLines(p1Trimmed)
         }
         case 'ifpure':{
             return p1
@@ -1530,7 +1532,7 @@ function blockEndMatcher(p1:string,type:{type:blockMatch,type2?:string,mode?:str
         }
 
         case 'normalize':{
-            return p1Trimed.trim().replaceAll('\n','').replaceAll('\t','')
+            return p1Trimmed.trim().replaceAll('\n','').replaceAll('\t','')
             .replaceAll(/\\u([0-9A-Fa-f]{4})/g, (match, p1) => {
                 return String.fromCharCode(parseInt(p1, 16))
             })
@@ -1558,7 +1560,7 @@ function blockEndMatcher(p1:string,type:{type:blockMatch,type2?:string,mode?:str
             })
         }
         case 'escape':{
-            return risuEscape(p1Trimed)
+            return risuEscape(type.mode === 'keep' ? p1 : p1Trimmed)
         }
         default:{
             return ''

--- a/src/ts/parser/tests/cbs/escapes.test.ts
+++ b/src/ts/parser/tests/cbs/escapes.test.ts
@@ -128,11 +128,19 @@ test('#puredisplay', () => {
   )
 })
 
-describe('#escape', () =>{
+describe('#escape', () => {
   test('escapes any curly braces or parenthesis, trims whitespaces', () => {
     fc.assert(
       fc.property(anythingNotClosing, (a) => {
         expect(parse(`{{#escape}}\n${a}\n{{/}}`)).toBe(a.trim())
+      }),
+    )
+  })
+
+  test('::keep preserves all whitespaces', () => {
+    fc.assert(
+      fc.property(anythingNotClosing, (a) => {
+        expect(parse(`{{#escape::keep}}\n${a}\n{{/}}`)).toBe(`\n${a}\n`)
       }),
     )
   })


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

This PR adds `#escape` test cases with `#escape::keep` added.

`#escape` is not listed in the CBS doc, so that's covered as well.

## Related Issues

None.

## Changes

New: `{{#escape::keep}}`.

## Impact

None, backward compatible.
