### PR TITLE
feat: add aws opus 4.5 and 4.6

### DIFF
--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -41,6 +41,34 @@ export const LLMModels: LLMModel[] = [
     ...AnthropicModels,
     // AWS Bedrock Claude models
     {
+        name: "Claude 4.6 Opus v1",
+        id: 'anthropic.claude-opus-4-6-v1',
+        provider: LLMProvider.AWS,
+        format: LLMFormat.AWSBedrockClaude,
+        flags: [
+            LLMFlags.hasPrefill, // actually it doesn't, but leaving it for compatibility
+            LLMFlags.hasImageInput,
+            LLMFlags.hasFirstSystemPrompt,
+            LLMFlags.claudeThinking
+        ],
+        parameters: [...ClaudeParameters, 'thinking_tokens'],
+        tokenizer: LLMTokenizer.Claude,
+    },
+    {
+        name: "Claude 4.5 Opus (20251101) v1",
+        id: 'anthropic.claude-opus-4-5-20251101-v1:0',
+        provider: LLMProvider.AWS,
+        format: LLMFormat.AWSBedrockClaude,
+        flags: [
+            LLMFlags.hasPrefill,
+            LLMFlags.hasImageInput,
+            LLMFlags.hasFirstSystemPrompt,
+            LLMFlags.claudeThinking
+        ],
+        parameters: [...ClaudeParameters, 'thinking_tokens'],
+        tokenizer: LLMTokenizer.Claude
+    },
+    {
         name: 'Claude 4.5 Sonnet (20250929) v1',
         id: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
         provider: LLMProvider.AWS,


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], if true, check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly ai generated[^2], check the following:
    - [ ] Have you understanded what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary
Added support for AWS Opus 4.5 and 4.6 models, which have been tested successfully after build with no issues.

## Related Issues
None

## Changes
model/modelist.ts - added two models
process/request/anthropic.ts - fix regex detection for case of opus 4.6

## Impact
aws users will able to use new models

## Additional Notes
The model ID structure changed in version 4.6, making regex detection slightly more complex. Perhaps in the long term, we may want to consider adding a separate model flag to handle this more cleanly.