### PR TITLE
feat: Record inlay creation timestamp

### DIFF
--- a/src/lib/Playground/PlaygroundInlayExplorer.svelte
+++ b/src/lib/Playground/PlaygroundInlayExplorer.svelte
@@ -5,6 +5,7 @@
   import { language } from 'src/lang'
   import { alertConfirm } from 'src/ts/alert'
   import { getInlayAssetBlob, listInlayAssets, removeInlayAsset, type InlayAsset } from 'src/ts/process/files/inlays'
+  import { DBState } from 'src/ts/stores.svelte'
   import Button from '../UI/GUI/Button.svelte'
   import CheckInput from '../UI/GUI/CheckInput.svelte'
 
@@ -177,6 +178,12 @@
             <span class="px-2 py-1 text-xs rounded bg-darkbutton text-textcolor2">
               {asset.type}
             </span>
+            <span class="ml-auto text-xs text-textcolor2">
+              {#if asset.width && asset.height}
+                <span>{asset.width}x{asset.height} • </span>
+              {/if}
+              <span>{getAssetSize(asset)}</span>
+            </span>
           </div>
           <div class="mb-3">
             {#if asset.type === 'image'}
@@ -204,7 +211,7 @@
             {/if}
           </div>
 
-          <div class="flex justify-between items-start mb-2">
+          <div class="flex justify-between items-start mb-1">
             <div class="flex-1 min-w-0">
               <p class="text-textcolor font-medium truncate" title={asset.name}>{asset.name}</p>
               {#if asset.name !== id}
@@ -212,12 +219,8 @@
               {/if}
             </div>
           </div>
-
           <div class="text-textcolor2 text-sm mb-3">
-            {#if asset.width && asset.height}
-              <span>{asset.width}x{asset.height} • </span>
-            {/if}
-            <span>{getAssetSize(asset)}</span>
+            <span>{asset.created ? new Date(asset.created).toLocaleString(DBState.db.language) : '(unknown date)'}</span>
           </div>
 
           <Button onclick={() => deleteAsset(id, asset.name)} styled="danger" size="sm">Delete</Button>

--- a/src/ts/process/files/inlays.ts
+++ b/src/ts/process/files/inlays.ts
@@ -6,6 +6,8 @@ import { getModelInfo, LLMFlags, LLMFormat } from "src/ts/model/modellist";
 import { asBuffer } from "../../util";
 
 export type InlayAsset = {
+    /** Creation timestamp */
+    created?: number
     data: string | Blob
     /** File extension */
     ext: string
@@ -32,45 +34,48 @@ const inlayStorage = localforage.createInstance({
     storeName: 'inlay'
 })
 
-export async function postInlayAsset(img:{
+export async function postInlayAsset(img: {
     name:string,
     data:Uint8Array
-}){
+}) {
+    const extension = img.name.split('.').at(-1)
 
-    const extention = img.name.split('.').at(-1)
-    const imgObj = new Image()
-
-    if(inlayImageExts.includes(extention)){
-        imgObj.src = URL.createObjectURL(new Blob([asBuffer(img.data)], {type: `image/${extention}`}))
+    if(inlayImageExts.includes(extension)){
+        const imgObj = new Image()
+        imgObj.src = URL.createObjectURL(new Blob([asBuffer(img.data)], {type: `image/${extension}`}))
 
         return await writeInlayImage(imgObj, {
             name: img.name,
-            ext: extention
+            ext: extension
         })
     }
 
-    if(inlayAudioExts.includes(extention)){
-        const audioBlob = new Blob([asBuffer(img.data)], {type: `audio/${extention}`})
+    const now = Date.now()
+
+    if(inlayAudioExts.includes(extension)){
+        const audioBlob = new Blob([asBuffer(img.data)], {type: `audio/${extension}`})
         const imgid = v4()
 
         await inlayStorage.setItem(imgid, {
+            created: now,
             name: img.name,
             data: audioBlob,
-            ext: extention,
+            ext: extension,
             type: 'audio'
         })
 
         return `${imgid}`
     }
 
-    if(inlayVideoExts.includes(extention)){
-        const videoBlob = new Blob([asBuffer(img.data)], {type: `video/${extention}`})
+    if(inlayVideoExts.includes(extension)){
+        const videoBlob = new Blob([asBuffer(img.data)], {type: `video/${extension}`})
         const imgid = v4()
 
         await inlayStorage.setItem(imgid, {
+            created: now,
             name: img.name,
             data: videoBlob,
-            ext: extention,
+            ext: extension,
             type: 'video'
         })
 
@@ -81,9 +86,9 @@ export async function postInlayAsset(img:{
 }
 
 export async function writeInlayImage(imgObj:HTMLImageElement, arg:{name?:string, ext?:string, id?:string} = {}) {
-
     let drawHeight = 0
     let drawWidth = 0
+
     const canvas = document.createElement('canvas')
     const ctx = canvas.getContext('2d')
     await new Promise((resolve) => {
@@ -91,7 +96,7 @@ export async function writeInlayImage(imgObj:HTMLImageElement, arg:{name?:string
             drawHeight = imgObj.height
             drawWidth = imgObj.width
 
-            //resize image to fit inlay, if total pixels exceed 1024*1024
+            // resize image to fit inlay, if total pixels exceed 1024*1024
             const maxPixels = 1024 * 1024
             const currentPixels = drawHeight * drawWidth
             
@@ -109,10 +114,11 @@ export async function writeInlayImage(imgObj:HTMLImageElement, arg:{name?:string
     })
     const imageBlob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
 
-
+    const now = Date.now()
     const imgid = arg.id ?? v4()
 
     await inlayStorage.setItem(imgid, {
+        created: now,
         name: arg.name ?? imgid,
         data: imageBlob,
         ext: 'png',

--- a/src/ts/process/files/tests/inlays.test.ts
+++ b/src/ts/process/files/tests/inlays.test.ts
@@ -281,6 +281,7 @@ describe('postInlayAsset', () => {
 
         const stored = store.get('test-uuid-1234') as InlayAsset
         expect(stored).toMatchObject({
+            created: expect.any(Number),
             data: expect.any(Blob),
             ext: 'mp3',
             name: 'clip.mp3',
@@ -298,6 +299,7 @@ describe('postInlayAsset', () => {
 
         const stored = store.get('test-uuid-1234') as InlayAsset
         expect(stored).toMatchObject({
+            created: expect.any(Number),
             data: expect.any(Blob),
             ext: 'webm',
             name: 'video.webm',
@@ -330,9 +332,14 @@ describe('postInlayAsset', () => {
                     data: new Uint8Array([0x00]),
                 })
                 expect(result).not.toBeNull()
+
                 const stored = store.get(result!) as InlayAsset
-                expect(stored.type).toBe('audio')
-                expect(stored.ext).toBe(ext)
+                expect(stored).toMatchObject({
+                    created: expect.any(Number),
+                    ext,
+                    name: `sound.${ext}`,
+                    type: 'audio',
+                })
             }),
         )
     })
@@ -346,9 +353,14 @@ describe('postInlayAsset', () => {
                     data: new Uint8Array([0x00]),
                 })
                 expect(result).not.toBeNull()
+
                 const stored = store.get(result!) as InlayAsset
-                expect(stored.type).toBe('video')
-                expect(stored.ext).toBe(ext)
+                expect(stored).toMatchObject({
+                    created: expect.any(Number),
+                    name: `clip.${ext}`,
+                    ext,
+                    type: 'video',
+                })
             }),
         )
     })
@@ -368,6 +380,7 @@ describe('writeInlayImage', () => {
 
         const stored = store.get('custom-id') as InlayAsset
         expect(stored).toMatchObject({
+            created: expect.any(Number),
             data: expect.any(Blob),
             ext: 'png',
             height: 100,
@@ -384,6 +397,7 @@ describe('writeInlayImage', () => {
         expect(result).toBe('test-uuid-1234')
 
         const stored = store.get('test-uuid-1234') as InlayAsset
+        expect(stored.created).toEqual(expect.any(Number))
         expect(stored.name).toBe('test-uuid-1234')
     })
 
@@ -450,7 +464,9 @@ describe('set -> get round-trip', () => {
                 async (id, name, ext, width, height) => {
                     store.clear()
                     const blob = new Blob(['data'], { type: 'application/octet-stream' })
+                    const now = Date.now()
                     const asset: InlayAsset = {
+                        created: now,
                         data: blob,
                         ext,
                         height,
@@ -463,6 +479,7 @@ describe('set -> get round-trip', () => {
 
                     const result = await getInlayAsset(id)
                     expect(result).toMatchObject({
+                        created: now,
                         data: expect.any(String),
                         ext,
                         height,


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

<img width="800" alt="image" src="https://github.com/user-attachments/assets/b114ce45-d81d-4e35-a6eb-390d985012fe" />

Records inlay asset creation/attachment timestamps for future utilization. Simply displays them in the explorer for now.

## Related Issues

None.

## Changes

Both `postInlayAsset()` and `writeInlayImage()` records `Date.now()` into the storage.

Also fixes inlay tests as #1250 invalidated the mocking.

## Impact

None; `created` field is optional.

## Additional Notes

Proper utilizations (and display, with better localization) in the explorer will be developed further in subsequent PRs.