### PR TITLE
fix: Restore inlay explorer languages

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -528,12 +528,15 @@ export const languageChinese = {
     },
     "playground": {
         "playground": "Playground",
+        "inlayDeleteConfirm": "确定要删除\"{name}\"吗？",
+        "inlayDeleteMultipleConfirm": "确定要删除选中的{count}个资源吗？",
         "inlayDeleteSelected": "删除选中项",
         "inlayDeselectAll": "取消全选",
         "inlayEmpty": "没有保存的内联资源",
         "inlayEmptyDesc": "在聊天中附加或生成的图像、音频和视频将显示在这里",
         "inlayExplorer": "内联资源浏览器",
-        "inlaySelectAll": "全选"
+        "inlaySelectAll": "全选",
+        "inlayTotalAssets": "共{count}个资源",
     },
     "confirm": "确定",
     "goback": "返回",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -528,12 +528,15 @@ export const languageGerman = {
     },
     "playground": {
         "playground": "Spielwiese",
+        "inlayDeleteConfirm": "Möchten Sie \"{name}\" wirklich löschen?",
+        "inlayDeleteMultipleConfirm": "Möchten Sie die ausgewählten {count} Ressourcen wirklich löschen?",
         "inlayDeleteSelected": "Ausgewählte löschen",
         "inlayDeselectAll": "Alle abwählen",
         "inlayEmpty": "Keine gespeicherten Inlay-Ressourcen",
         "inlayEmptyDesc": "In Chats angehängte oder generierte Bilder, Audio und Videos werden hier angezeigt",
         "inlayExplorer": "Inlay-Ressourcen-Explorer",
-        "inlaySelectAll": "Alle auswählen"
+        "inlaySelectAll": "Alle auswählen",
+        "inlayTotalAssets": "Insgesamt {count} Ressourcen",
     },
     "confirm": "Bestätigen",
     "goback": "Zurück",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -528,12 +528,15 @@ export const languageSpanish = {
     },
     "playground": {
         "playground": "Playground",
+        "inlayDeleteConfirm": "¿Estás seguro de que deseas eliminar \"{name}\"?",
+        "inlayDeleteMultipleConfirm": "¿Estás seguro de que deseas eliminar los {count} recursos seleccionados?",
         "inlayDeleteSelected": "Eliminar seleccionados",
         "inlayDeselectAll": "Deseleccionar todo",
         "inlayEmpty": "Sin recursos inlay guardados",
         "inlayEmptyDesc": "Las imágenes, audios y videos adjuntos o generados en chats aparecerán aquí",
         "inlayExplorer": "Explorador de Recursos Inlay",
-        "inlaySelectAll": "Seleccionar todo"
+        "inlaySelectAll": "Seleccionar todo",
+        "inlayTotalAssets": "Total {count} recursos",
     },
     "confirm": "Confirmar",
     "goback": "Volver",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -528,12 +528,15 @@ export const languageKorean = {
     },
     "playground": {
         "playground": "플레이그라운드",
+        "inlayDeleteConfirm": "\"{name}\"을(를) 정말 삭제하시겠습니까?",
+        "inlayDeleteMultipleConfirm": "선택한 {count}개의 에셋을 정말 삭제하시겠습니까?",
         "inlayDeleteSelected": "선택 항목 삭제",
         "inlayDeselectAll": "모두 선택 해제",
         "inlayEmpty": "저장된 인레이 에셋이 없습니다",
         "inlayEmptyDesc": "채팅에서 첨부 또는 생성된 이미지, 오디오 및 비디오가 여기에 나타납니다",
         "inlayExplorer": "인레이 에셋 탐색기",
-        "inlaySelectAll": "모두 선택"
+        "inlaySelectAll": "모두 선택",
+        "inlayTotalAssets": "총 {count}개 에셋",
     },
     "confirm": "확인",
     "goback": "뒤로",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -528,12 +528,15 @@ export const languageVietnamese = {
     },
     "playground": {
         "playground": "Playground",
+        "inlayDeleteConfirm": "Bạn có chắc muốn xóa \"{name}\" không?",
+        "inlayDeleteMultipleConfirm": "Bạn có chắc muốn xóa ${count} tài sản được chọn không?",
         "inlayDeleteSelected": "Xóa mục đã chọn",
         "inlayDeselectAll": "Bỏ chọn tất cả",
         "inlayEmpty": "Không có tài sản nội tuyến đã lưu",
         "inlayEmptyDesc": "Hình ảnh, âm thanh và video được đính kèm hoặc tạo trong trò chuyện sẽ xuất hiện ở đây",
         "inlayExplorer": "Trình khám phá Tài sản Inlay",
-        "inlaySelectAll": "Chọn tất cả"
+        "inlaySelectAll": "Chọn tất cả",
+        "inlayTotalAssets": "Tổng cộng ${count} tài sản",
     },
     "confirm": "Xác nhận",
     "goback": "Quay lại",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -528,12 +528,15 @@ export const languageChineseTraditional = {
     },
     "playground": {
         "playground": "Playground",
+        "inlayDeleteConfirm": "確定要刪除\"{name}\"嗎？",
+        "inlayDeleteMultipleConfirm": "確定要刪除選中的{count}個資源嗎？",
         "inlayDeleteSelected": "刪除選中項",
         "inlayDeselectAll": "取消全選",
         "inlayEmpty": "沒有保存的內聯資源",
         "inlayEmptyDesc": "在聊天中附加或生成的圖像、音頻和視頻將顯示在這裡",
         "inlayExplorer": "內聯資源瀏覽器",
-        "inlaySelectAll": "全選"
+        "inlaySelectAll": "全選",
+        "inlayTotalAssets": "共{count}個資源",
     },
     "confirm": "確定",
     "goback": "返回",


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

Some keys were lost.

I don't know why exactly but 9f70e9d1ba90f76e041857a316ff8c2222e9aad7 removed those keys. I guess it's because the lang file exports to a JSON and functions can't be serialized into JSON? (Which is why 0f08035a9221933c10dfc7e6fb4d3041c00c3efd made those keys in the `en.ts` into constants)

## Related Issues

None.

## Changes

Restores `inlayDeleteConfirm`, `inlayDeleteMultipleConfirm`, `inlayTotalAssets`.

## Impact

Nothing negative.

## Additional Notes

I plan to change the explore to use a simple infinite scroll layout, so `inlayLoadMore` can stay as-is (not localized).