### PR TITLE
fix: rework claude batch API implementation

### DIFF
--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -617,87 +617,148 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
             }
         }
 
-        const resultsUrl = replacerURL + `/batches/${r.id}/results`
         const statusUrl = replacerURL + `/batches/${r.id}`
+        const resultsUrl = replacerURL + `/batches/${r.id}/results`
+        const cancelUrl = replacerURL + `/batches/${r.id}/cancel`
+        const abortSignal = arg.abortSignal
 
-        let received = false
-        while(!received){
-            try {
-                await sleep(3000)
-                if(arg?.abortSignal?.aborted){
-                    return {
-                        type: 'fail',
-                        result: 'Request aborted'
-                    }
-                }
+        // Streaming is used in batch API to apply successful response even after abortSignal is fired
+        // In order to do otherwise, `request.ts` and `index.svelte.ts` should be edited to bypass abort signal check
+        const stream = new ReadableStream<StreamResponseChunk>({
+            async start(controller){
+                const batchStartTime = Date.now()
+                const BATCH_TIMEOUT = 24 * 60 * 60 * 1000 + 600 * 1000 // 24 hours + 10 minutes
+                let cancelRequested = false
 
-                const statusRes = await fetchNative(statusUrl, {
-                    "method": "GET",
-                    "headers": {
-                        "x-api-key": apiKey,
-                        "anthropic-version": "2023-06-01",
-                    },
-                    "signal": arg.abortSignal,
-                    "interceptor": 'anthropic_batching_status'
-                })
-
-                if(statusRes.status !== 200){
-                    return {
-                        type: 'fail',
-                        result: await textifyReadableStream(statusRes.body)
-                    }
-                }
-
-                const statusData = await statusRes.json()
-
-                if(statusData.processing_status !== 'ended'){
-                    continue
-                }
-
-                const batchRes = await fetchNative(resultsUrl, {
-                    "method": "GET",
-                    "headers": {
-                        "x-api-key": apiKey,
-                        "anthropic-version": "2023-06-01",
-                    },
-                    "signal": arg.abortSignal,
-                    "interceptor": 'anthropic_batching_results'
-                })
-
-                if(batchRes.status !== 200){
-                    return {
-                        type: 'fail',
-                        result: await textifyReadableStream(batchRes.body)
-                    }
-                }
-
-                //since jsonl
-                const batchTextData = (await batchRes.text()).split('\n').filter((v) => v.trim() !== ''). map((v) => {
+                while(true){
                     try {
-                        return JSON.parse(v)
+                        await sleep(3000)
+                        if(abortSignal?.aborted && !cancelRequested){
+                            cancelRequested = true
+                            try {
+                                await fetchNative(cancelUrl, {
+                                    "body": "{}",
+                                    "method": "POST",
+                                    "headers": headers,
+                                    "interceptor": 'anthropic_batching_cancel'
+                                })
+                            } catch(e) {
+                                // ignore cancel request errors
+                            }
+                        }
+                        if(Date.now() - batchStartTime > BATCH_TIMEOUT){
+                            controller.error(new Error('Claude batch request timed out after 24 hours'))
+                            return
+                        }
+
+                        const statusRes = await fetchNative(statusUrl, {
+                            "method": "GET",
+                            "headers": headers,
+                            "signal": cancelRequested ? undefined : abortSignal,
+                            "interceptor": 'anthropic_batching_status'
+                        })
+
+                        if(statusRes.status !== 200){
+                            controller.error(new Error(await textifyReadableStream(statusRes.body)))
+                            return
+                        }
+
+                        const statusData = await statusRes.json()
+
+                        if(statusData.processing_status !== 'ended'){
+                            continue
+                        }
+
+                        const batchRes = await fetchNative(resultsUrl, {
+                            "method": "GET",
+                            "headers": headers,
+                            "signal": cancelRequested ? undefined : abortSignal,
+                            "interceptor": 'anthropic_batching_results'
+                        })
+
+                        if(batchRes.status !== 200){
+                            controller.error(new Error(await textifyReadableStream(batchRes.body)))
+                            return
+                        }
+
+                        //since jsonl
+                        const batchTextData = (await batchRes.text()).split('\n').filter((v) => v.trim() !== ''). map((v) => {
+                            try {
+                                return JSON.parse(v)
+                            } catch (error) {
+                                return null
+                            }
+                        }).filter((v) => v !== null)
+                        
+                        for(const batchData of batchTextData){
+                            const type = batchData?.result?.type
+                            console.log('Claude batch result type:', type)
+                            if(batchData?.result?.type === 'succeeded'){
+                                const contents = batchData.result.message.content ?? []
+                                let resText = ''
+                                let thinking = false
+                                for(const content of contents){
+                                    if(content.type === 'text'){
+                                        if(thinking){
+                                            resText += "</Thoughts>\n\n"
+                                            thinking = false
+                                        }
+                                        resText += content.text
+                                    }
+                                    if(content.type === 'thinking'){
+                                        if(!thinking){
+                                            resText += "<Thoughts>\n"
+                                            thinking = true
+                                        }
+                                        resText += content.thinking ?? ''
+                                    }
+                                    if(content.type === 'redacted_thinking'){
+                                        if(!thinking){
+                                            resText += "<Thoughts>\n"
+                                            thinking = true
+                                        }
+                                        resText += '\n{{redacted_thinking}}\n'
+                                    }
+                                }
+
+                                if(thinking){
+                                    resText += "</Thoughts>\n\n"
+                                    thinking = false
+                                }
+
+                                controller.enqueue({ "0": resText })
+                                controller.close()
+                                return
+                            }
+                            if(batchData?.result?.type === 'errored'){
+                                const batchError = batchData.result.error
+
+                                const message = batchError?.error?.message ? 
+                                `${batchError.error.type}: ${batchError.error.message}` : 
+                                JSON.stringify(batchError)
+
+                                controller.error(new Error(message))
+                                return
+                            }
+                            if(batchData?.result?.type === 'canceled'){
+                                controller.close()
+                                return
+                            }
+                            if(batchData?.result?.type === 'expired'){
+                                controller.error(new Error('Claude batch request expired'))
+                                return
+                            }
+                        }
                     } catch (error) {
-                        return null
+                        console.error('Error while waiting for Claude batch results:', error)
                     }
-                }).filter((v) => v !== null)
-                for(const batchData of batchTextData){
-                    const type = batchData?.result?.type
-                    console.log('Claude batch result type:', type)
-                    if(batchData?.result?.type === 'succeeded'){
-                        return {
-                            type: 'success',
-                            result: batchData.result.message.content?.[0]?.text ?? ''
-                        }
-                    }
-                    if(batchData?.result?.type === 'errored'){
-                        return {
-                            type: 'fail',
-                            result:  JSON.stringify(batchData.result.error),
-                        }
-                    }
-                }   
-            } catch (error) {
-                console.error('Error while waiting for Claude batch results:', error)
+                }
             }
+        })
+
+        return {
+            type: 'streaming',
+            result: stream
         }
     }
     


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], if true, check the following:
    - [X] Have you checked if it works normally in all models?
        - It works on all Anthropic variants, both thinking and non-thinking mode.
        - This has also been tested to Adaptive thinking implementation https://github.com/kwaroran/Risuai/pull/1275
    - [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly ai generated[^2], check the following:
    - [x] Have you understanded what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.


## Summary

- Fixed bug when AI message is not parsed correctly when thinking mode is on.
- Now thinking token is also parsed to the message.
- Made cancel UI work with Batch API.

## Related Issues

None

## Changes

Before this change:
- Batch API only returns the first entry of the content or empty string (`batchData.result.message.content?.[0]?.text ?? ''`)
  - This implementation does not handle the case when thinking is turned on, because thinking section is now 0th entry of the `message.content`
    - This behavior is new, and before than it worked just fine. It didn't parse thinking tokens though. More about API format is [in the docs](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#thinking-redaction)
- There was no cancel logic integrated with batch API, so when user press request cancel button (the round rolling thing when it is green), it stops immediately but batch job does not does not cancel under the hood, leading to unexpected billing.

After this change:
- When result arrives, code iteratively look for all blocks, and parse both thinking tokens and text tokens. 
- When user press cancel button, batch cancellation API call (`v1/messages/batches/$MESSAGE_BATCH_ID/cancel`)
  - API invoke to cancel API does not cancel the batch immediately, so polling continues.
  - When batch is cancelled, polling stops and request is cancelled.
  - When batch is successfully ended (generated response), it parses the response and return that.

## Impact

- Now thinking token is included in the response when using batch API.
- Now cancel button takes time to be cancelled before actually stops, instead of being cancelled immediately.
- Now, internally, Anthropic batch API uses streaming(`StreamResponseChunk`) instead of returning plain JSON in order to bypass AbortSignal Check on other parts of the codebase.
  - In order to do otherwise, `request.ts` and `index.svelte.ts` should be edited to bypass abort signal check. That decision seemed risky for this small change since that could cause unexpected failure to abort API request with other model requests.
- Now there is a interceptor flag called `'anthropic_batching_cancel'` passed down to `fetchNative`.

## Additional Notes

I have written very few PR before, so I hope this comment is helpful enough.