### PR TITLE
fix: Ignore audio.play() error when it is in fire-and-forget 

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -323,7 +323,7 @@
         $doingChat = false
         if(DBState.db.playMessage){
             const audio = new Audio(sendSound);
-            audio.play();
+            audio.play().catch(() => {});
         }
     }
 

--- a/src/lib/Playground/PlaygroundSubtitle.svelte
+++ b/src/lib/Playground/PlaygroundSubtitle.svelte
@@ -121,7 +121,7 @@
         vttB64 = `data:text/vtt;base64,${Buffer.from(outputText).toString('base64')}`
 
         const audio = new Audio(sendSound);
-        audio.play();
+        audio.play().catch(() => {});
     }
 
     async function runWhisperMode() {
@@ -347,7 +347,7 @@
         vobj = convertWebVTTtoObj(outputText)
 
         const audio = new Audio(sendSound);
-        audio.play();
+        audio.play().catch(() => {});
     }
 
     

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -280,7 +280,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
         const r = await translateLLM(html, {to: tr, from: from, regenerate})
         if(db.playMessageOnTranslateEnd){
             const audio = new Audio(sendSound);
-            audio.play();
+            audio.play().catch(() => {});
         }
 
         return applyEdittransRegex(r, charArg, alwaysExistChar)


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly ai generated[^2], check the following:
    - [x] Have you understanded what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

<img width="757" height="184" alt="image" src="https://github.com/user-attachments/assets/a35d01d2-065d-4c5d-8958-9807cff16525" />
<img width="757" height="184" alt="image" src="https://github.com/user-attachments/assets/dcb8ed49-d400-45b5-a349-f00874c62550" />


Suppress `AbortError` from fire-and-forget `audio.play()` calls by adding `.catch(() => {})`.

## Related Issues

[arca.live post](https://arca.live/b/characterai/148082201?target=all&keyword=play%28%29+request&category=%EC%A7%88%EB%AC%B8&p=1)

## Changes

Added `.catch(() => {})` to all `audio.play()` calls for notification sounds. These are fire-and-forget sounds where the play() Promise rejection doesn't need handling.

## Impact

Eliminates the `"AbortError: The play() request was interrupted because the media was removed from the document."` error dialog that appeared despite the sound playing correctly.

The unhandled Promise rejection was caught by the global `unhandledrejection` handler in `bootstrap.ts` and surfaced as an error alert to users. No change to actual audio playback behavior.

## Additional Notes

`HTMLMediaElement.play()` returns a Promise per the HTML spec. When a notification sound's play request gets interrupted (e.g. by a re-render), the rejected Promise propagated as an unhandled rejection. 

Since these are simple notification sounds with no follow-up actions, silently catching the rejection is the [recommended approach](https://developer.chrome.com/blog/play-request-was-interrupted). This affects all modern browsers, not just Chromium.