### PR TITLE
feat: Prevent importing a HypaV3 preset as a module

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -17,7 +17,7 @@ export const languageChinese = {
         "toomuchtoken": "错误：所需的 Token 数超过了可用的最大上下文大小",
         "unknownModel": "错误：无法识别所选的模型",
         "httpError": "错误：请求发生错误：",
-        "noData": "无法找到文件中的数据，或者文件已经损毁",
+        "noData": "这个文件好像不太对，或者数据已经损坏了。",
         "onlyOneChat": "至少需要一个聊天室",
         "alreadyCharInGroup": "该群组中已经有一个同名角色。",
         "noUserIcon": "请先设置你的个人头像。",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -17,7 +17,7 @@ export const languageGerman = {
         "toomuchtoken": "Fehler: Die Mindestgröße für die Antwort der KI in Tokens, die Sie angegeben haben, übersteigt die maximale Kontextgröße des Modells",
         "unknownModel": "Fehler: Unbekanntes Modell ausgewählt",
         "httpError": "Fehler: Es ist ein Fehler bei der Anfrage aufgetreten:",
-        "noData": "Es befinden sich keine Daten in der Datei oder die Datei ist beschädigt",
+        "noData": "Die Datei scheint nicht gültig zu sein oder die Daten sind beschädigt.",
         "onlyOneChat": "Es muss mindestens ein Chat vorhanden sein",
         "alreadyCharInGroup": "Es gibt bereits einen Charakter mit dem selben Namen in der Gruppe",
         "noUserIcon": "Sie müssen zuerst Ihr Icon festlegen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -17,7 +17,7 @@ export const languageEnglish = {
         toomuchtoken: "Error: The minimum required token is greater than the Max Context Size.",
         unknownModel: "Error: Unknown model selected",
         httpError: "Error: error in request:",
-        noData: "There is no data in file, or the file is corrupted",
+        noData: "The file is invalid, or its data is corrupted.",
         onlyOneChat: "There must be least one chat",
         alreadyCharInGroup: "There is already a character with the same name in the group.",
         noUserIcon: "You must set your icon first.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -17,7 +17,7 @@ export const languageSpanish = {
         "toomuchtoken": "Error: El mínimo requerido de tokens es mayor que el Tamaño Máximo del Contexto.",
         "unknownModel": "Error: Modelo seleccionado desconocido",
         "httpError": "Error: error en la solicitud:",
-        "noData": "No hay datos en el archivo o el archivo está corrupto",
+        "noData": "Ese archivo no parece válido o sus datos están dañados.",
         "onlyOneChat": "Debe haber al menos un chat",
         "alreadyCharInGroup": "Ya hay un personaje con el mismo nombre en el grupo.",
         "noUserIcon": "Debes establecer tu icono primero.",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -17,7 +17,7 @@ export const languageKorean = {
         "toomuchtoken": "에러: 요청에 필요한 최소 토큰이 최대 토큰보다 큽니다.",
         "unknownModel": "에러: 알수없는 모델 선택됨",
         "httpError": "요청 에러:",
-        "noData": "파일에 데이터가 없거나 데이터가 손상됨",
+        "noData": "올바른 파일이 아니거나 데이터가 손상됐습니다.",
         "onlyOneChat": "채팅이 하나 이상 필요합니다",
         "alreadyCharInGroup": "이미 같은 캐릭터가 그룹에 존재합니다.",
         "noUserIcon": "유저 아이콘이 없습니다.",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -17,7 +17,7 @@ export const languageVietnamese = {
         "toomuchtoken": "Lỗi: Mã thông báo bắt buộc tối thiểu lớn hơn Kích thước ngữ cảnh tối đa.",
         "unknownModel": "Lỗi: Đã chọn mô hình không xác định",
         "httpError": "Lỗi: lỗi trong yêu cầu:",
-        "noData": "Không có dữ liệu trong tệp hoặc tệp bị hỏng",
+        "noData": "Tệp này có vẻ không hợp lệ hoặc dữ liệu đã bị hỏng.",
         "onlyOneChat": "Phải có ít nhất một cuộc trò chuyện",
         "alreadyCharInGroup": "Đã có một nhân vật có cùng tên trong nhóm.",
         "noUserIcon": "Bạn phải đặt biểu tượng của mình trước.",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -17,7 +17,7 @@ export const languageChineseTraditional = {
         "toomuchtoken": "錯誤：所需的 Token 數超過了可用的最大上下文大小",
         "unknownModel": "錯誤：無法識別所選的模型",
         "httpError": "錯誤：請求發生錯誤：",
-        "noData": "無法找到檔案中的資料，或者檔案已經損毀",
+        "noData": "這個檔案看起來不太對，或是資料已經損壞了。",
         "onlyOneChat": "至少需要一個聊天室",
         "alreadyCharInGroup": "該群組中已經有一個同名角色。",
         "noUserIcon": "請先設定您的個人頭像。",

--- a/src/ts/process/modules.ts
+++ b/src/ts/process/modules.ts
@@ -239,11 +239,11 @@ export async function importModule(){
             const module = await readModule(buf)
             db.modules.push(module)
             setDatabase(db)
-            return   
         } catch (error) {
             console.error(error)
             alertError(language.errors.noData)
         }
+        return
     }
     try {
         const importData = JSON.parse(Buffer.from(fileData).toString())
@@ -267,7 +267,9 @@ export async function importModule(){
             setDatabase(db)
             return
         }
-        if(importData.type === 'risu' && importData.data){
+        // importData.type === 'risu' in conflict with HypaV3 preset exports
+        // difference: record vs. array
+        if(importData.type === 'risu' && importData.data && Array.isArray(importData.data)){
             const lores:loreBook[] = importData.data
             const importModule = {
                 name: importData.name || 'Imported Lorebook',
@@ -304,8 +306,10 @@ export async function importModule(){
             return
         }
     } catch (error) {
-        alertNormal(language.errors.noData)
+        console.error(error)
     }
+
+    alertNormal(language.errors.noData)
 }
 
 function getModuleById(id:string){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

The notorious save killer, `TypeError: _.map is not a function`, is primarily caused after the user imports HypaV3 preset JSON as a module by mistake. This had been unrecoverable, destroying many saves.

Although #1252 handles the error, it is best to prevent such error from happening at all.

## Related Issues

None.

## Changes

Cause: Exported lorebooks and HypaV3 presets both share `"type": "risu"`.

Since changing the HypaV3 preset's type will be backward-incompatible, this PR checks the data's shape instead.

When importing an exported lorebook JSON, this PR verifies that its data is indeed an Array.

## Impact

Will see an error when trying to import a HypaV3 preset as a module.
