### PR TITLE
fix: add performance and animation APIs to plugin v2.1

### DIFF
--- a/src/ts/plugins/plugins.svelte.ts
+++ b/src/ts/plugins/plugins.svelte.ts
@@ -575,6 +575,7 @@ export const getV2PluginAPIs = () => {
                 'TextDecoder',
                 'URL',
                 'URLSearchParams',
+                'performance',
             ]
             for (const key of keys) {
                 if(allowedKeys.includes(key)){
@@ -607,6 +608,14 @@ export const getV2PluginAPIs = () => {
             safeGlobal.clearTimeout = (...args: any[]) => {
                 //@ts-expect-error spreading any[] into clearTimeout - first arg should be number | undefined
                 return globalThis.clearTimeout(...args);
+            }
+            safeGlobal.requestAnimationFrame = (...args: any[]) => {
+                //@ts-expect-error spreading any[] into requestAnimationFrame - first arg should be FrameRequestCallback
+                return globalThis.requestAnimationFrame(...args);
+            }
+            safeGlobal.cancelAnimationFrame = (...args: any[]) => {
+                //@ts-expect-error spreading any[] into cancelAnimationFrame - first arg should be number
+                return globalThis.cancelAnimationFrame(...args);
             }
             safeGlobal.alert = globalThis.alert;
             safeGlobal.confirm = globalThis.confirm;


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [X] Have you tested your changes?
    - [X] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [X] If your PR is highly ai generated[^2], check the following:
    - [X] Have you understanded what the code does?
    - [X] Have you cleaned up any unnecessary or redundant code?
    - [X] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary
Added `performances` and `animationFrame` to plugin v2.1 whitelist 

## Related Issues
None

## Changes
- Updated plugin v2.1 sandbox whitelist in `plugins.svelte.ts` to include `performance` API
- Added `requestAnimationFrame` and `cancelAnimationFrame` handlers to the `safeGlobalThis` object for plugin v2.1

## Impact
Enables support for rich UI animations and transitions
Fixed an issue where plugins using UI frameworks like Svelte would crash when attempting to use built-in animations or transitions
