### PR TITLE
fix: sanitize AbortSignal in V3 plugin callback args before postMessage

### DIFF
--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -313,7 +313,7 @@ export class SandboxHost {
             return { __type: 'REMOTE_REF', id } as RemoteRef;
         }
 
-        if(val instanceof Response) {
+        if (val instanceof Response) {
             return {
                 __type: 'CALLBACK_STREAMS',
                 __specialType: 'Response',
@@ -326,7 +326,7 @@ export class SandboxHost {
             };
         }
 
-        if(
+        if (
             val instanceof ReadableStream
             || val instanceof WritableStream
             || val instanceof TransformStream
@@ -351,11 +351,17 @@ export class SandboxHost {
                         const reqId = 'cb_req_' + Math.random().toString(36).substring(2);
                         this.pendingCallbacks.set(reqId, { resolve, reject });
 
+                        // AbortSignal cannot be structured-cloned for postMessage,
+                        // so we need to filter it out before sending
+                        const sanitizedArgs = innerArgs.map(arg =>
+                            arg instanceof AbortSignal ? null : arg
+                        );
+
                         const message = {
                             type: 'INVOKE_CALLBACK',
                             id: cbRef.id,
                             reqId,
-                            args: innerArgs
+                            args: sanitizedArgs
                         };
                         const transferables = this.collectTransferables(message);
                         this.iframe.contentWindow?.postMessage(message, '*', transferables);
@@ -373,8 +379,8 @@ export class SandboxHost {
         });
     }
 
-    public run(container: HTMLElement|HTMLIFrameElement, userCode: string) {
-        if(container instanceof HTMLIFrameElement) {
+    public run(container: HTMLElement | HTMLIFrameElement, userCode: string) {
+        if (container instanceof HTMLIFrameElement) {
             this.iframe = container;
         } else {
             this.iframe = document.createElement('iframe');
@@ -445,7 +451,7 @@ export class SandboxHost {
                 console.log("Original request:", data);
                 console.log('Original response:', response, transferables);
                 try {
-                    this.iframe.contentWindow?.postMessage(response, '*', transferables);                    
+                    this.iframe.contentWindow?.postMessage(response, '*', transferables);
                 } catch (error) {
                     this.iframe.contentWindow?.postMessage({
                         type: 'RESPONSE',


### PR DESCRIPTION
## Problem

When a V3 plugin registers a provider via `addProvider`, the callback is never invoked. Instead, the user sees:

`
Plugin Error from MyProvider: {}
`

## Root Cause

In `factory.ts`, the `deserializeArgs` callback proxy passes `innerArgs` directly to `postMessage`. When `requestPlugin` (in `request.ts`) calls the provider function as `v2Function(args, abortSignal)`, the `AbortSignal` object is included in `innerArgs`.

**`AbortSignal` cannot be structured-cloned** (per the HTML spec), so `postMessage` throws a `DataCloneError`. Since `DOMException` has non-enumerable properties, `JSON.stringify(error)` produces `{}`, resulting in the unhelpful error message.

## Fix

Filter `AbortSignal` to `null` in the callback args before `postMessage`:

`	ypescript
const sanitizedArgs = innerArgs.map(arg =>
    arg instanceof AbortSignal ? null : arg
);
`

This is the minimal change needed. The plugin still receives the full request arguments (`prompt_chat`, `mode`, `max_tokens`, etc.) — only the non-cloneable `AbortSignal` is replaced with `null`.

## Impact

- **All V3 plugins using `addProvider`** are currently broken by this bug
- This fix enables V3 plugin providers to work correctly
- No security implications: `AbortSignal` is a cancellation signal, not sensitive data
- Plugins lose abort/cancel functionality, but gain the ability to function at all