### PR TITLE
fix: fetchNative and globalFetch properly support plugin

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -627,13 +627,11 @@ export async function globalFetch(url: string, arg: GlobalFetchArgs = {}): Promi
 
         if(arg.interceptor){
             for (const interceptor of bodyIntercepterStore) {
-                if(interceptor.id === arg.interceptor){
-                    try {
-                        arg.body = await interceptor.callback(arg.body, arg.interceptor) || arg.body
-                    }
-                    catch (e) {
-                        console.error(e)
-                    }
+                try {
+                    arg.body = await interceptor.callback(arg.body, arg.interceptor) || arg.body
+                }
+                catch (e) {
+                    console.error(e)
                 }
             }
         }
@@ -1447,13 +1445,11 @@ export async function fetchNative(url: string, arg: {
         let body: string = arg.body
         if(useInterceptor) {
             for (const interceptor of bodyIntercepterStore) {
-                if(interceptor.id === arg.interceptor){
-                    try {
-                        body = await interceptor.callback(body, arg.interceptor) || body
-                    }
-                    catch (e) {
-                        console.error(e)
-                    }
+                try {
+                    body = await interceptor.callback(body, arg.interceptor) || body
+                }
+                catch (e) {
+                    console.error(e)
                 }
             }
         }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], if true, check the following:
    - [x] Have you checked if it works normally in all models?
        - I tested for both streaming / HTTP requests 
    - [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly ai generated[^2], check the following:
    - [x] Have you understanded what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is is not a huge change?
       - We currently do not accept highly ai generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

Changed `fetchNative` behavior related to plugin intercepter.

## Related Issues

No issue, but there are a few related commits.
[fetchNative](https://github.com/kwaroran/Risuai/commit/6d49bfc70d6401686edba70b4a3020b4f40b2d76)
[globalFetch](https://github.com/kwaroran/Risuai/commit/d635f15bde761770a3819ef38e4f88c776caaed7)

## Changes

There were series of commits related to plugin V3 support in recent days.
I found that `globalFetch` changes looked kinda different from `fetchNative` one.



### `fetchNative`
Basically, `fetchNative`'s behavior was like this.
```
let realBody: Uint8Array
realBody = await interceptor.callback(arg.body, arg.interceptor) || realBody  // For all registered intercepters.
realBody = new TextEncoder().encode(arg.body)
```

No matter what `interceptor.callback` do to `realBody`, it is overwritten by `new TextEncoder().encode(arg.body)`.
So, I added local variable `body` and accumulated all modifications of callbacks to it.
Now, it can be summerized to:
```
let realBody: Uint8Array
let body: string = arg.body
body = await interceptor.callback(body, arg.interceptor) || body  // For all registered intercepters.
realBody = new TextEncoder().encode(body)
```



### `globalFetch`
Unlike `fetchNative`, it had an if statement with `interceptor.id === arg.interceptor`
However, `interceptor.id` is UUID version 4 (`registerBodyIntercepter` at `src/ts/plugins/apiV3/v3.svelte.ts:713` makes it) and `arg.interceptor` is handwritten request identifier. Those two will never match. I don't think this would be the expected behavior.

So, for this PR. I removed it completely.


## Impact

Now all `interceptor.callback` is called for each API calls.
The responsibility for filtering the request type for each plugin to process now falls to the developer of that plugin, not RisuAi. I guess this is what would have been expected, though.