### PR TITLE
feat: add settings item type SegmentControl

### DIFF
--- a/src/lib/Setting/SettingRenderer.svelte
+++ b/src/lib/Setting/SettingRenderer.svelte
@@ -11,6 +11,7 @@
     import TextAreaInput from 'src/lib/UI/GUI/TextAreaInput.svelte';
     import SliderInput from 'src/lib/UI/GUI/SliderInput.svelte';
     import SelectInput from 'src/lib/UI/GUI/SelectInput.svelte';
+    import SegmentedControl from 'src/lib/UI/GUI/SegmentedControl.svelte';
     import OptionInput from 'src/lib/UI/GUI/OptionInput.svelte';
     import ColorInput from 'src/lib/UI/GUI/ColorInput.svelte';
     import Button from 'src/lib/UI/GUI/Button.svelte';
@@ -157,6 +158,14 @@
                     <OptionInput value={opt.value}>{opt.label}</OptionInput>
                 {/each}
             </SelectInput>
+        {:else if item.type === 'segmented'}
+            <span class="text-textcolor {item.classes ?? 'mt-4'}">{getLabel(item)}
+                {#if item.helpKey}<Help key={item.helpKey as any}/>{/if}
+            </span>
+            <SegmentedControl
+                bind:value={(DBState.db as any)[item.bindKey]}
+                options={item.options?.segmentOptions ?? []}
+            />
         {:else if item.type === 'color'}
             <div class="flex items-center {item.classes ?? 'mt-2'}">
                 <ColorInput bind:value={(DBState.db as any)[item.bindKey]} />

--- a/src/lib/UI/GUI/SegmentedControl.svelte
+++ b/src/lib/UI/GUI/SegmentedControl.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+    import { tick } from 'svelte';
+    interface SegmentOption {
+        value: string | number;
+        label: string;
+    }
+
+    interface Props {
+        value: string | number;
+        options: SegmentOption[];
+        size?: 'sm' | 'md' | 'lg';
+        className?: string;
+    }
+
+    let {
+        value = $bindable(),
+        options = [],
+        size = 'md',
+        className = '',
+    }: Props = $props();
+
+    let containerRef: HTMLDivElement | undefined = $state();
+    let indicatorStyle = $state('');
+
+    // Compute the active index from the current value
+    let activeIndex = $derived(options.findIndex(opt => opt.value === value));
+
+    function updateIndicator() {
+        if (!containerRef || activeIndex < 0) {
+            indicatorStyle = '';
+            return;
+        }
+        const buttons = containerRef.querySelectorAll<HTMLButtonElement>('[data-segment-btn]');
+        const activeBtn = buttons[activeIndex];
+        if (!activeBtn) {
+            indicatorStyle = '';
+            return;
+        }
+        const containerRect = containerRef.getBoundingClientRect();
+        const btnRect = activeBtn.getBoundingClientRect();
+        const x = btnRect.left - containerRect.left;
+        const width = btnRect.width;
+        indicatorStyle = `transform: translateX(${x}px); width: ${width}px;`;
+    }
+
+    // Re-calculate indicator when activeIndex changes or on mount
+    $effect(() => {
+        void activeIndex;
+        tick().then(() => updateIndicator());
+    });
+
+    function handleSelect(opt: SegmentOption) {
+        value = opt.value;
+    }
+</script>
+
+<div
+    class="segmented-control-container {className}"
+    bind:this={containerRef}
+>
+    <!-- Sliding indicator -->
+    <div
+        class="segmented-indicator"
+        style={indicatorStyle}
+    ></div>
+
+    {#each options as opt (opt.value)}
+        <button
+            data-segment-btn
+            type="button"
+            class="segmented-btn"
+            class:segmented-btn-active={opt.value === value}
+            class:text-xs={size === 'sm'}
+            class:text-sm={size === 'md'}
+            class:text-base={size === 'lg'}
+            class:px-2={size === 'sm'}
+            class:py-1={size === 'sm'}
+            class:px-4={size === 'md'}
+            class:py-2={size === 'md'}
+            class:px-6={size === 'lg'}
+            class:py-3={size === 'lg'}
+            onclick={() => handleSelect(opt)}
+        >
+            {opt.label}
+        </button>
+    {/each}
+</div>
+
+<style>
+    .segmented-control-container {
+        position: relative;
+        display: inline-flex;
+        width: fit-content;
+        align-items: center;
+        border-radius: 0.5rem;
+        background-color: var(--risu-theme-darkbg);
+        border: 1px solid var(--risu-theme-darkborderc);
+        padding: 4px;
+        gap: 2px;
+        user-select: none;
+    }
+
+    .segmented-indicator {
+        position: absolute;
+        left: 0;
+        top: 4px;
+        bottom: 4px;
+        border-radius: 0.375rem;
+        background-color: var(--risu-theme-borderc);
+        transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                    width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        will-change: transform, width;
+        pointer-events: none;
+        z-index: 0;
+    }
+
+    .segmented-btn {
+        position: relative;
+        z-index: 1;
+        border: none;
+        background: transparent;
+        color: var(--risu-theme-textcolor2);
+        font-weight: 500;
+        border-radius: 0.375rem;
+        cursor: pointer;
+        white-space: nowrap;
+        transition: color 0.2s ease;
+        line-height: 1.4;
+    }
+
+    .segmented-btn:hover:not(.segmented-btn-active) {
+        color: var(--risu-theme-textcolor);
+    }
+
+    .segmented-btn-active {
+        color: #fff;
+    }
+
+    .segmented-btn:focus-visible {
+        outline: 2px solid var(--risu-theme-borderc);
+        outline-offset: -2px;
+    }
+</style>

--- a/src/ts/setting/advancedSettingsData.ts
+++ b/src/ts/setting/advancedSettingsData.ts
@@ -84,10 +84,10 @@ export const advancedSettingsItems: SettingItem[] = [
 
     // Request Location (Non-Node/Tauri)
     {
-        id: 'adv.reqLoc', type: 'select', labelKey: 'requestLocation', bindKey: 'requestLocation',
+        id: 'adv.reqLoc', type: 'segmented', labelKey: 'requestLocation', bindKey: 'requestLocation',
         condition: () => !isNodeServer && !isTauri,
         options: {
-            selectOptions: [
+            segmentOptions: [
                 { value: '', label: 'Default' },
                 { value: 'eu', label: 'EU (GDPR)' },
                 { value: 'fedramp', label: 'US (FedRAMP)' }

--- a/src/ts/setting/types.ts
+++ b/src/ts/setting/types.ts
@@ -28,6 +28,7 @@ export type SettingType =
     | 'textarea'   // Multiline text (TextAreaInput)
     | 'slider'     // Slider (SliderInput)
     | 'select'     // Dropdown (SelectInput)
+    | 'segmented'  // Sliding segmented control (SegmentedControl)
     | 'color'      // Color picker (ColorInput)
     | 'header'     // Section header (h2, span, warning)
     | 'button'     // Action button (Button)
@@ -39,6 +40,14 @@ export type SettingType =
  */
 export interface SelectOption {
     value: string;
+    label: string;
+}
+
+/**
+ * Segment option for sliding segmented control
+ */
+export interface SegmentOption {
+    value: string | number;
     label: string;
 }
 
@@ -57,6 +66,9 @@ export interface SettingOptions {
     
     // select
     selectOptions?: SelectOption[];
+    
+    // segmented control
+    segmentOptions?: SegmentOption[];
     
     // text, textarea
     placeholder?: string;


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], if true, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node hosted versions? 
- [x] If your PR is highly ai generated[^2], check the following:
    - [x] Have you understanded what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is is not a huge change?

[^1]: Modifies the behavior of prompting, requesting or handling responses from ai models.
[^2]: Almost over 80% of the code is ai generated.

## Summary

Add a reusable Sliding Segmented Control component and integrate it into the data-driven settings system.

## Related Issues

None

## Changes

- src/lib/UI/GUI/SegmentedControl.svelte: New component with GPU-accelerated sliding indicator (`transform: translateX`), Svelte `class:` directives for size variants (`sm`/`md`/`lg`), and theme-consistent styling using existing CSS variables.
- src/ts/setting/types.ts: Added `'segmented'` to `SettingType`, introduced `SegmentOption` interface, and added `segmentOptions` to `SettingOptions`.
- src/lib/Setting/SettingRenderer.svelte: Added rendering block for the new `'segmented'` type.
- src/ts/setting/advancedSettingsData.ts: Applied segmented control to an existing advanced setting.

## Impact

- No impact on existing functionality. This is a purely additive UI component.
- Existing setting types and rendering remain unchanged.

## Additional Notes

- Uses Svelte `class:` directives (same pattern as `SelectInput.svelte`) to avoid Tailwind JIT / Svelte CSS scoping issues with dynamic classes.
- Indicator animation uses `transform` instead of `left` for GPU-composited rendering, avoiding layout thrashing.