### PR TITLE
refactor: Separate OpenAI types out of requests.ts

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -52,21 +52,6 @@ export interface MultiModal{
     width?:number
 }
 
-export interface OpenAIChatFull extends OpenAIChat{
-    function_call?: {
-        name: string
-        arguments:string
-    }
-    tool_calls?:{
-        function: {
-            name: string
-            arguments:string
-        }
-        id:string
-        type:'function'
-    }[]
-}
-
 export interface requestTokenPart{
     name:string
     tokens:number

--- a/src/ts/process/request/openAI/index.ts
+++ b/src/ts/process/request/openAI/index.ts
@@ -1,0 +1,1 @@
+export { requestOpenAI, requestOpenAILegacyInstruct, requestOpenAIResponseAPI } from './requests'

--- a/src/ts/process/request/openAI/types.ts
+++ b/src/ts/process/request/openAI/types.ts
@@ -1,0 +1,88 @@
+import type { MultiModal, OpenAIChat } from '../../index.svelte'
+
+export interface ResponseInputItem {
+    content: (
+        | {
+              type: 'input_text'
+              text: string
+          }
+        | {
+              detail: 'high' | 'low' | 'auto'
+              type: 'input_image'
+              image_url: string
+          }
+        | {
+              type: 'input_file'
+              file_data: string
+              filename?: string
+          }
+    )[]
+    role: 'user' | 'system' | 'developer'
+}
+
+export interface ResponseOutputItem {
+    content: {
+        type: 'output_text'
+        text: string
+        annotations: []
+    }[]
+    type: 'message'
+    status: 'in_progress' | 'complete' | 'incomplete'
+    role: 'assistant'
+}
+
+export type ResponseItem = ResponseInputItem | ResponseOutputItem
+
+interface TextContents {
+    type: 'text'
+    text: string
+}
+
+interface ImageContents {
+    type: 'image' | 'image_url'
+    image_url: {
+        url: string
+        detail: string
+    }
+}
+
+export type Contents = TextContents | ImageContents
+
+export interface ToolCall {
+    function: {
+        name: string
+        arguments: string
+    }
+    id: string
+    type: 'function'
+}
+
+export interface OpenAIChatFull extends OpenAIChat {
+    function_call?: {
+        name: string
+        arguments: string
+    }
+    tool_calls?: ToolCall[]
+}
+
+export interface OpenAIChatExtra {
+    role: 'system' | 'user' | 'assistant' | 'function' | 'developer' | 'tool'
+    content: string | Contents[]
+    memo?: string
+    name?: string
+    removable?: boolean
+    attr?: string[]
+    multimodals?: MultiModal[]
+    thoughts?: string[]
+    prefix?: boolean
+    reasoning_content?: string
+    cachePoint?: boolean
+    function?: {
+        name: string
+        description?: string
+        parameters: any
+        strict: boolean
+    }
+    tool_call_id?: string
+    tool_calls?: ToolCall[]
+}

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -7,7 +7,7 @@ import { pluginProcess, pluginV2 } from "../../plugins/plugins.svelte";
 import { getCurrentCharacter, getCurrentChat, getDatabase, type character } from "../../storage/database.svelte";
 import { tokenizeNum } from "../../tokenizer";
 import { sleep } from "../../util";
-import type { MultiModal, OpenAIChat } from "../index.svelte";
+import type { OpenAIChat } from "../index.svelte";
 import { getTools } from "../mcp/mcp";
 import type { MCPTool } from "../mcp/mcplib";
 import { NovelAIBadWordIds, stringlizeNAIChat } from "../models/nai";
@@ -18,7 +18,7 @@ import { runTransformers } from "../transformers";
 import { runTrigger } from "../triggers";
 import { requestClaude } from './anthropic';
 import { requestGoogleCloudVertex } from './google';
-import { requestOpenAI, requestOpenAILegacyInstruct, requestOpenAIResponseAPI } from "./openAI";
+import { requestOpenAI, requestOpenAILegacyInstruct, requestOpenAIResponseAPI } from "./openAI/requests";
 import { applyParameters, type ModelModeExtended } from './shared';
 
 export type ToolCall = {
@@ -228,52 +228,6 @@ export async function requestChatData(arg:requestDataArgument, model:ModelModeEx
         type: 'fail',
         result: "All models failed"
     }
-}
-
-export interface OpenAITextContents {
-    type: 'text'
-    text: string
-}
-
-export interface OpenAIImageContents {
-    type: 'image'|'image_url'
-    image_url: {
-        url: string
-        detail: string
-    }
-}
-
-export type OpenAIContents = OpenAITextContents|OpenAIImageContents
-
-export interface OpenAIToolCall {
-    id:string,
-    type:'function',
-    function:{
-        name:string,
-        arguments:string
-    },
-}
-
-export interface OpenAIChatExtra {
-    role: 'system'|'user'|'assistant'|'function'|'developer'|'tool'
-    content: string|OpenAIContents[]
-    memo?:string
-    name?:string
-    removable?:boolean
-    attr?:string[]
-    multimodals?:MultiModal[]
-    thoughts?:string[]
-    prefix?:boolean
-    reasoning_content?:string
-    cachePoint?:boolean
-    function?: {
-        name: string
-        description?: string
-        parameters: any
-        strict: boolean
-    }
-    tool_call_id?: string
-    tool_calls?: OpenAIToolCall[]
 }
 
 export function reformater(formated:OpenAIChat[],modelInfo:LLMModel|LLMFlags[]){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.

## Summary

To break circular dependencies between requester files, this PR moves all OpenAI compatible request types into a dedicated file.

`OAI` or `OpenAI` prefixes are stripped. Their usage is limited to the OpenAI requesters, so they are rather 'module local'. 

Exceptions: `OpenAIChatFull` and `OpenAIChatExtra`, since they extend `OpenAICIhat` type which is located in a Svelte component, and is referenced everywhere --- being used more like "OpenAI compatible Risu chat payload".

## Related Issues

None.

## Changes

Types were moved around.

## Impact

None. No runtime code changes, only types and import paths.
