### PR TITLE
feat: Implement infinite scroll for inlay explorer

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -632,7 +632,6 @@ export const languageEnglish = {
         inlaySelectAll: "Select All",
         inlayDeleteConfirm: "Are you sure you want to delete {name}?",
         inlayDeleteMultipleConfirm: "Are you sure you want to delete the selected {count} assets?",
-        inlayLoadMore: "Load More ({remaining} remaining)",
         inlayTotalAssets: "Total {count} assets",
     },
     confirm: "Confirm",


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x[ Have you checked that it won't break any existing features?

## Summary

Implement infinite scroll UI for the inlay explorer.

## Related Issues

None.

## Changes

Removes Load More button. Scrolling to the bottom will display more assets automatically.

## Impact

Changes are limited to the explorer.
