### PR TITLE
fix: apply Content-Type header on Google Cloud requests when streaming is disabled

### DIFF
--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -394,7 +394,11 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
             'TEXT', 'IMAGE'
         ]
         arg.useStreaming = false
-    }    let headers:{[key:string]:string} = {}
+    }
+
+    let headers:{[key:string]:string} = {
+        'Content-Type': 'application/json'
+    }
 
     if(db.gptVisionQuality === 'high'){
         body.generation_config.mediaResolution = "MEDIA_RESOLUTION_MEDIUM"
@@ -626,7 +630,6 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
     }
 
     if((arg.modelInfo.format === LLMFormat.GoogleCloud || arg.modelInfo.format === LLMFormat.VertexAIGemini) && arg.useStreaming){
-        headers['Content-Type'] = 'application/json'
 
         if(arg.previewBody){
             return {


### PR DESCRIPTION
## PR Checklist
- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary
This PR ensures that the `Content-Type: application/json` header is always included in requests sent to Google Cloud and Vertex AI, regardless of whether streaming is enabled or not.

## Related Issues
None.

## Changes
- Moved the assignment of the `Content-Type: application/json` header outside of the streaming condition block in `src/ts/process/request/google.ts`. 
- The header is now applied to all requests by default.

## Impact
Resolves issues where JSON parsing errors occur on the server side because requests sent with streaming turned off were missing the content type header. It guarantees stability when communicating with the API.

## Additional Notes
None.