### PR TITLE
feat: colorscheme, texttheme Plugin v3 api

### DIFF
--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -1378,7 +1378,7 @@ interface RisuaiPluginAPI {
 
     /**
      * Change to a preset text theme.
-     * @param name - 'standard' | 'highcontrast' | 'custom'
+     * @param name - 'standard' | 'highcontrast'
      */
     changeTextTheme(name: string): Promise<void>;
 

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -686,7 +686,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
 
         // --- Text Theme APIs ---
         changeTextTheme: (name: string) => {
-            if (!['standard','highcontrast','custom'].includes(name)) {
+            if (!['standard','highcontrast'].includes(name)) {
                 throw new Error(`Invalid text theme: ${name}`)
             }
             const db = DBState.db


### PR DESCRIPTION
add changeColorScheme, setColorScheme, getColorScheme, changeTextTheme, setCustomTextTheme, getTextTheme API

## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

플러그인 V3에 컬러스킴, 텍스트 테마를 조정하는 API를 추가했습니다.

## Related Issues

NONE

## Changes

changeColorScheme: 기존에 세팅되어 있는 'default', 'dark', 'light', 'cherry', 'galaxy', 'nature', 'realblack', 'monokai-light', 'monokai-black' 프리셋 중에 변경합니다.

setColorScheme: ColorScheme 객체를 받아 커스텀 컬러스킴을 설정합니다.
interface ColorScheme {
    bgcolor: string;
    darkbg: string;
    borderc: string;
    selected: string;
    draculared: string;
    textcolor: string;
    textcolor2: string;
    darkBorderc: string;
    darkbutton: string;
    type: 'light' | 'dark';
}

getColorScheme: 현재 컬러스킴과 값을 반환합니다.

changeTextTheme: 기존에 세팅되어 있는 'standard' , 'highcontrast' 프리셋 중에 변경합니다.

setCustomTextTheme: CustomTextTheme 객체를 받아 커스텀 텍스트 컬러 스킴을 설정합니다.

getTextTheme: 현재 텍스트 컬러 스킴과 값을 반환합니다.


## Impact

새 기능을 추가만 했으므로, 없습니다

## Additional Notes

테마 프리셋 플러그인을 만들고 있습니다.
테마와 같이 커스텀 컬러도 변환할 수 있게 만들고 싶어 새 API 들어간 PR 작성했습니다.