### PR TITLE
fix: clean up leaked resources on V3 plugin unload

### DIFF
--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -861,6 +861,11 @@ interface SafeMutationObserver {
      * @returns Promise that resolves when observer is set up
      */
     observe(element: SafeElement, options: MutationObserverInit): Promise<void>;
+
+    /**
+     * Stops observing all target elements for changes
+     */
+    disconnect(): Promise<void>;
 }
 
 // ============================================================================

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -37,6 +37,7 @@ import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, type LLMModel } from "s
 */
 
 const pluginChannel = new Map<string, Function>();
+const documentEventListeners: Array<{type: string, listener: EventListenerOrEventListenerObject, options: any}> = [];
 
 class SafeElement {
     #element: HTMLElement;
@@ -296,6 +297,7 @@ class SafeElement {
                 listener(trimEvent(event))
             }
             this.#eventIdMap.set(id, modifiedListener)
+            documentEventListeners.push({type, listener: modifiedListener as EventListenerOrEventListenerObject, options: realOptions})
             document.addEventListener(type, modifiedListener, realOptions)
             return id;
         }
@@ -310,6 +312,7 @@ class SafeElement {
                 }, delay);
             }
             this.#eventIdMap.set(id, modifiedListener)
+            documentEventListeners.push({type, listener: modifiedListener as EventListenerOrEventListenerObject, options: realOptions})
             document.addEventListener(type, modifiedListener, realOptions);
             return id;
         }
@@ -323,6 +326,8 @@ class SafeElement {
         if(listener){
             const realOptions = typeof options === 'boolean' ? { capture: options } : options || {};
             document.removeEventListener(type, listener as EventListenerOrEventListenerObject, realOptions);
+            const idx = documentEventListeners.findIndex(e => e.listener === listener);
+            if(idx !== -1) documentEventListeners.splice(idx, 1);
             this.#eventIdMap.delete(id);
         }
     }
@@ -456,6 +461,10 @@ class SafeMutationObserver {
             this.#observer.observe(rawElement, options);
             element.setAttribute('x-identifier', '');
         }
+    }
+
+    disconnect() {
+        this.#observer.disconnect();
     }
 
 }
@@ -917,7 +926,11 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             console.log(`[RisuAI Plugin: ${plugin.name}] ${message}`);
         },
         createMutationObserver(callback: SafeMutationCallback): SafeMutationObserver {
-            return new SafeMutationObserver(callback)
+            const observer = new SafeMutationObserver(callback)
+            addPluginUnloadCallback(plugin.name, () => {
+                observer.disconnect()
+            })
+            return observer
         },
         onUnload: (callback: () => void) => {
             addPluginUnloadCallback(plugin.name, callback);
@@ -1025,6 +1038,9 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
         },
         addPluginChannelListener: (channelName: string, callback: Function) => {
             pluginChannel.set(plugin.name + channelName, callback);
+            addPluginUnloadCallback(plugin.name, () => {
+                pluginChannel.delete(plugin.name + channelName);
+            })
         },
         postPluginChannelMessage: (pluginName: string, channelName: string, message: any) => {
             const callback = pluginChannel.get(pluginName + channelName);
@@ -1046,6 +1062,12 @@ export async function loadV3Plugins(plugins:RisuPlugin[]){
     await Promise.all(v3PluginInstances.map(async (instance) => {
         await unloadV3Plugin(instance.name);
     }));
+
+    for(const entry of documentEventListeners){
+        document.removeEventListener(entry.type, entry.listener, entry.options);
+    }
+    documentEventListeners.length = 0;
+
     const loadPromises = plugins.map(plugin => executePluginV3(plugin));
     await Promise.all(loadPromises);
 }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

When a V3 plugin is unloaded (via `loadV3Plugins()` → `unloadV3Plugin()`), three types of host-side resources are never cleaned up:

1. Document event listeners registered through `SafeElement.addEventListener()` remain on `document` after the plugin's iframe is destroyed. These zombie listeners fire on every user interaction but their RPC callbacks point to a removed iframe.
2. `SafeMutationObserver` has no `disconnect()` method, so plugins cannot stop observing even if they want to, and the framework cannot stop them on unload either.
3. `pluginChannel` entries persist in the global Map after unload, leaving stale callbacks from destroyed plugin instances.

These issues do not occur in V2.1 because `loadV2Plugin()` explicitly clears all handler Sets (`editdisplay`, `editoutput`, etc.) before reloading, and V2.1 plugins run synchronously in the main scope without iframe isolation.

## Related Issues

None

## Changes

Document event listeners (`SafeElement`)
- Added a module-level `documentEventListeners` array to track all listeners registered via `SafeElement.addEventListener()`
- `addEventListener()` pushes to this array when registering on `document`
- `removeEventListener()` splices from this array when the plugin explicitly removes a listener
- `loadV3Plugins()` bulk-clears any remaining entries after all `unloadV3Plugin()` calls complete, following the same pattern as V2.1's `pluginV2.editdisplay.clear()` etc.

SafeMutationObserver
- Added `disconnect()` method wrapping native `MutationObserver.disconnect()`
- `createMutationObserver()` now auto-registers an `addPluginUnloadCallback` that calls `disconnect()`, following the same pattern as `registerButton()` / `registerSetting()`
- Updated `risuai.d.ts` type definition accordingly

pluginChannel
- `addPluginChannelListener()` now auto-registers an `addPluginUnloadCallback` that deletes the channel entry, following the same pattern as `registerButton()` / `registerSetting()`

## Impact

- Prevents zombie document event listeners from accumulating after plugin reload cycles
- Prevents MutationObservers from running indefinitely after their plugin is destroyed
- Prevents stale pluginChannel callbacks from being invoked after unload
- No breaking changes — all existing plugin APIs remain the same, `disconnect()` is a new addition only
- All cleanup operations are idempotent (safe to call multiple times, no-op if already cleaned)

## Additional Notes

The `SafeElement` class does not know which plugin it belongs to, so per-plugin tracking of document event listeners is not feasible without architectural changes to `SafeElement`. Instead, a bulk-clear approach is used in `loadV3Plugins()` as a safety net, consistent with V2.1's reload strategy. Plugins that properly clean up via `onUnload` will have already removed their listeners before this point — the bulk-clear only catches leaked ones.
