### PR TITLE
feat: add gpt-5.4 model series

### DIFF
--- a/src/ts/model/providers/openai.ts
+++ b/src/ts/model/providers/openai.ts
@@ -1,6 +1,72 @@
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, GPT5Parameters, type LLMModel } from '../types'
 
 export const OpenAIModels: LLMModel[] = [
+    // GPT-5.4 (March 2026)
+    {
+        id: 'gpt-5.4',
+        internalID: 'gpt-5.4',
+        name: 'GPT 5.4',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5Parameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base,
+        recommended: true
+    },
+    {
+        id: 'gpt-5.4-2026-03-05',
+        internalID: 'gpt-5.4-2026-03-05',
+        name: 'GPT 5.4 (2026-03-05)',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5Parameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base
+    },
+    {
+        id: 'gpt-5.4-pro',
+        internalID: 'gpt-5.4-pro',
+        name: 'GPT 5.4 Pro',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5Parameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base
+    },
+    {
+        id: 'gpt-5.4-pro-2026-03-05',
+        internalID: 'gpt-5.4-pro-2026-03-05',
+        name: 'GPT 5.4 Pro (2026-03-05)',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5Parameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base
+    },
     // GPT-5.2 (December 2025)
     {
         id: 'gpt-5.2',


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Added GPT-5.4 and GPT-5.4 pro models, with timestamp endpoints too.

## Related Issues

None

## Changes

Users are now able to use GPT-5.4.

## Impact

GPT-5.4 is a drop-in replacement to GPT-5.2 [according to their documentation](https://developers.openai.com/api/docs/guides/latest-model#migration-guidance) so there won't be any conflicts.

UI now looks like this. Not recommended settings OFF / ON.

<img width="372" height="265" alt="image" src="https://github.com/user-attachments/assets/73e7e844-fc23-4781-8865-038d8f79faf0" />

<img width="373" height="450" alt="image" src="https://github.com/user-attachments/assets/8a232be2-07e8-4ad4-b041-5d596b11e748" />


## Additional Notes

I haven't add mini and nano variants of the model to the model list, as conventionally did.
Also, there is a update on the endpoint that adds `"reasoning": {"effort": "none"}` and this PR does not implement this.