### PR TITLE
fix: unify file picker flows and harden DOM fallback for WebKit/Tauri

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleAllowMixedLocalizations</key>
+    <true/>
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>en</string>
+        <string>ko</string>
+        <string>zh-Hans</string>
+        <string>zh-Hant</string>
+        <string>vi</string>
+        <string>de</string>
+        <string>es</string>
+    </array>
+</dict>
+</plist>

--- a/src-tauri/capabilities/migrated.json
+++ b/src-tauri/capabilities/migrated.json
@@ -22,7 +22,14 @@
         "$APPDATA",
         "$APPDATA/*",
         "$APPDATA/**/*",
+        "$HOME/*",
+        "$HOME/**/*",
+        "$DESKTOP/*",
+        "$DESKTOP/**/*",
+        "$DOCUMENT/*",
+        "$DOCUMENT/**/*",
         "$DOWNLOAD/*",
+        "$DOWNLOAD/**/*",
         "/data/**/*",
         "$RESOURCE/*"
       ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,12 @@
     "resources": [
       "src-python/*"
     ],
+    "macOS": {
+      "infoPlist": {
+        "CFBundleAllowMixedLocalizations": true,
+        "CFBundleLocalizations": ["en", "ko", "zh-Hans", "zh-Hant", "vi", "de", "es"]
+      }
+    },
     "targets": ["deb", "rpm", "appimage", "nsis", "app", "dmg"],
     "createUpdaterArtifacts": true,
     "fileAssociations": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,12 +17,6 @@
     "resources": [
       "src-python/*"
     ],
-    "macOS": {
-      "infoPlist": {
-        "CFBundleAllowMixedLocalizations": true,
-        "CFBundleLocalizations": ["en", "ko", "zh-Hans", "zh-Hant", "vi", "de", "es"]
-      }
-    },
     "targets": ["deb", "rpm", "appimage", "nsis", "app", "dmg"],
     "createUpdaterArtifacts": true,
     "fileAssociations": [

--- a/src/lib/Playground/PlaygroundSubtitle.svelte
+++ b/src/lib/Playground/PlaygroundSubtitle.svelte
@@ -7,7 +7,7 @@
     import { DBState } from "src/ts/stores.svelte";
     import { getModelInfo, LLMFlags } from "src/ts/model/modellist";
     import { requestChatData } from "src/ts/process/request/request";
-    import { asBuffer, selectFileByDom, selectSingleFile, sleep } from "src/ts/util";
+    import { asBuffer, selectMultipleFile, selectSingleFile, sleep } from "src/ts/util";
     import { alertError, alertSelect } from "src/ts/alert";
     import { risuChatParser } from "src/ts/parser/parser.svelte";
     import { AppendableBuffer, downloadFile, getLanguageCodes } from "src/ts/globalApi.svelte";
@@ -127,20 +127,21 @@
     async function runWhisperMode() {
         outputText = 'Loading...\n\n'
 
-        const files = await selectFileByDom([
+        const files = await selectMultipleFile([
             'mp3', 'ogg', 'wav', 'flac',
             'mp4', 'webm', 'mkv', 'avi', 'mov'  
 
         ])
 
-        const file = files?.[0]
+        const selected = files?.[0]
 
         let requestFile:File = null
 
-        if(!file){
+        if(!selected){
             outputText = ''
             return
         }
+        const file = new File([asBuffer(selected.data)], selected.name)
         const videos = [
             'mp4', 'webm', 'mkv', 'avi', 'mov'
         ]

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -1146,9 +1146,10 @@
 
                 <button class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer" onclick={async() => {
                     try {
-                        const bytesImport = (await selectSingleFile(['json'])).data
+                        const selectedFile = await selectSingleFile(['json'])
+                        if(!selectedFile) return
 
-                        if(!bytesImport) return
+                        const bytesImport = selectedFile.data
 
                         const objImport = JSON.parse(Buffer.from(bytesImport).toString('utf-8'))
 

--- a/src/lib/Setting/Pages/UserSettings.svelte
+++ b/src/lib/Setting/Pages/UserSettings.svelte
@@ -11,6 +11,7 @@
     import { unMigrationAccount } from "src/ts/storage/accountStorage";
     import { checkDriver } from "src/ts/drive/drive";
     import { LoadLocalBackup, SaveLocalBackup, SavePartialLocalBackup } from "src/ts/drive/backuplocal";
+    import { selectSingleFile } from "src/ts/util";
     import Button from "src/lib/UI/GUI/Button.svelte";
     import { exportAsDataset } from "src/ts/storage/exportAsDataset";
     import { loginToSionyw, testSionywLogin } from "src/ts/sionyw";
@@ -63,8 +64,13 @@
 
 <Button
     onclick={async () => {
+        const selectedFile = await selectSingleFile(['bin'])
+        if(!selectedFile){
+            return
+        }
+
         if((await alertConfirm(language.backupLoadConfirm)) && (await alertConfirm(language.backupLoadConfirm2))){
-            LoadLocalBackup()
+            await LoadLocalBackup(selectedFile)
         }
     }} className="mt-2">
     {language.loadBackupLocal}

--- a/src/lib/SideBars/Scripts/TriggerV2List.svelte
+++ b/src/lib/SideBars/Scripts/TriggerV2List.svelte
@@ -12,6 +12,7 @@
     import { type triggerEffectV2, type triggerEffect, type triggerscript, displayAllowList, requestAllowList, type triggerV2IfAdvanced } from "src/ts/process/triggers";
     import { onDestroy, onMount } from "svelte";
     import { DBState } from "src/ts/stores.svelte";
+    import { selectSingleFile } from "src/ts/util";
 
     interface Props {
         value?: triggerscript[];
@@ -495,43 +496,36 @@
         lastSelectedTriggerIndex = -1
     }
 
-    const importTriggers = () => {
-        const input = document.createElement('input')
-        input.type = 'file'
-        input.accept = '.json'
-        input.onchange = async (event) => {
-            const file = (event.target as HTMLInputElement)?.files?.[0]
-            if (!file) return
-            
-            try {
-                const text = await file.text()
-                const importedTriggers = JSON.parse(text)
-                
-                if (!Array.isArray(importedTriggers)) {
+    const importTriggers = async () => {
+        const file = await selectSingleFile(['json'])
+        if (!file) return
+
+        try {
+            const text = new TextDecoder().decode(file.data)
+            const importedTriggers = JSON.parse(text)
+
+            if (!Array.isArray(importedTriggers)) {
+                return
+            }
+
+            for (const trigger of importedTriggers) {
+                if (!trigger.hasOwnProperty('comment') || 
+                    !trigger.hasOwnProperty('type') ||
+                    !trigger.hasOwnProperty('conditions') ||
+                    !trigger.hasOwnProperty('effect') ||
+                    !Array.isArray(trigger.conditions) ||
+                    !Array.isArray(trigger.effect)) {
                     return
                 }
-                
-                for (const trigger of importedTriggers) {
-                    if (!trigger.hasOwnProperty('comment') || 
-                        !trigger.hasOwnProperty('type') ||
-                        !trigger.hasOwnProperty('conditions') ||
-                        !trigger.hasOwnProperty('effect') ||
-                        !Array.isArray(trigger.conditions) ||
-                        !Array.isArray(trigger.effect)) {
-                        return
-                    }
-                }
-                
-                for (const trigger of importedTriggers) {
-                    value.push(trigger)
-                }
-                
-            } catch (error) {
-                console.error('Import error:', error)
             }
+
+            for (const trigger of importedTriggers) {
+                value.push(trigger)
+            }
+
+        } catch (error) {
+            console.error('Import error:', error)
         }
-        
-        input.click()
     }
 
     const selectTriggerRange = (startIndex: number, endIndex: number) => {

--- a/src/ts/characterCards.ts
+++ b/src/ts/characterCards.ts
@@ -1,7 +1,7 @@
 import { writable, type Writable } from "svelte/store"
 import { alertCardExport, alertConfirm, alertError, alertInput, alertMd, alertNormal, alertStore, alertTOS, alertWait } from "./alert"
 import { defaultSdDataFunc, type character, setDatabase, type customscript, type loreSettings, type loreBook, type triggerscript, importPreset, type groupChat, setCurrentCharacter, getCurrentCharacter, getDatabase, setDatabaseLite, appVer } from "./storage/database.svelte"
-import { checkNullish, decryptBuffer, isKnownUri, selectFileByDom, sleep } from "./util"
+import { checkNullish, decryptBuffer, isKnownUri, selectMultipleFile, sleep } from "./util"
 import { language } from "src/lang"
 import { v4 as uuidv4, v4 } from 'uuid';
 import { characterFormatUpdate } from "./characters"
@@ -31,7 +31,7 @@ export const hubURL = isNodeServer
 
 export async function importCharacter() {
     try {
-        const files = await selectFileByDom(["*"], 'multiple')
+        const files = await selectMultipleFile(["*"])
         if(!files){
             return
         }
@@ -39,7 +39,7 @@ export async function importCharacter() {
         for(const f of files){
             await importCharacterProcess({
                 name: f.name,
-                data: f
+                data: f.data
             })
             checkCharOrder()
         }

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -362,20 +362,18 @@ export async function SavePartialLocalBackup(){
     }
 }
 
-export function LoadLocalBackup(){
-    void (async () => {
-        try {
-            const selectedFile = await selectSingleFile(['bin'])
-            if (!selectedFile) {
-                return
-            }
-
-            await loadBackupFromBytes(selectedFile.data)
-        } catch (error) {
-            console.error(error)
-            alertError('Failed, Is file corrupted?')
+export async function LoadLocalBackup(selectedFile?: { name: string, data: Uint8Array } | null){
+    try {
+        const file = selectedFile ?? await selectSingleFile(['bin'])
+        if (!file) {
+            return
         }
-    })()
+
+        await loadBackupFromBytes(file.data)
+    } catch (error) {
+        console.error(error)
+        alertError('Failed, Is file corrupted?')
+    }
 }
 
 async function loadBackupFromStream(file: Blob) {

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -1,5 +1,4 @@
 import { BaseDirectory, readFile, readDir, writeFile } from "@tauri-apps/plugin-fs";
-import { open } from "@tauri-apps/plugin-dialog";
 import localforage from "localforage";
 import { alertError, alertNormal, alertStore, alertWait, alertMd, alertConfirm } from "../alert";
 import { LocalWriter, forageStorage, requiresFullEncoderReload } from "../globalApi.svelte";
@@ -7,7 +6,7 @@ import { isTauri } from "src/ts/platform"
 import { decodeRisuSave, encodeRisuSaveLegacy } from "../storage/risuSave";
 import { getDatabase, setDatabaseLite } from "../storage/database.svelte";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { sleep } from "../util";
+import { selectSingleFile, sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { language } from "src/lang";
 
@@ -364,50 +363,19 @@ export async function SavePartialLocalBackup(){
 }
 
 export function LoadLocalBackup(){
-    try {
-        if (isTauri) {
-            void (async () => {
-                const selectedPath = await open({
-                    filters: [{
-                        name: 'Risu Backup',
-                        extensions: ['bin']
-                    }],
-                    multiple: false,
-                    directory: false
-                })
-
-                if (!selectedPath || Array.isArray(selectedPath)) {
-                    return
-                }
-
-                const fileData = await readFile(selectedPath)
-                await loadBackupFromStream(new Blob([fileData]))
-            })().catch((error) => {
-                console.error(error)
-                alertError('Failed, Is file corrupted?')
-            })
-            return
-        }
-
-        const input = document.createElement('input');
-        input.type = 'file';
-        input.accept = '.bin';
-        input.onchange = async () => {
-            if (!input.files || input.files.length === 0) {
-                input.remove();
-                return;
+    void (async () => {
+        try {
+            const selectedFile = await selectSingleFile(['bin'])
+            if (!selectedFile) {
+                return
             }
-            const file = input.files[0];
-            input.remove();
 
-            await loadBackupFromStream(file)
-        };
-
-        input.click();
-    } catch (error) {
-        console.error(error);
-        alertError('Failed, Is file corrupted?')
-    }
+            await loadBackupFromBytes(selectedFile.data)
+        } catch (error) {
+            console.error(error)
+            alertError('Failed, Is file corrupted?')
+        }
+    })()
 }
 
 async function loadBackupFromStream(file: Blob) {
@@ -488,4 +456,10 @@ async function loadBackupFromStream(file: Blob) {
     }
 
     alertNormal('Success');
+}
+
+async function loadBackupFromBytes(data: Uint8Array) {
+    const copied = new Uint8Array(data.byteLength)
+    copied.set(data)
+    await loadBackupFromStream(new Blob([copied]))
 }

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -1,4 +1,5 @@
 import { BaseDirectory, readFile, readDir, writeFile } from "@tauri-apps/plugin-fs";
+import { open } from "@tauri-apps/plugin-dialog";
 import localforage from "localforage";
 import { alertError, alertNormal, alertStore, alertWait, alertMd, alertConfirm } from "../alert";
 import { LocalWriter, forageStorage, requiresFullEncoderReload } from "../globalApi.svelte";
@@ -364,6 +365,30 @@ export async function SavePartialLocalBackup(){
 
 export function LoadLocalBackup(){
     try {
+        if (isTauri) {
+            void (async () => {
+                const selectedPath = await open({
+                    filters: [{
+                        name: 'Risu Backup',
+                        extensions: ['bin']
+                    }],
+                    multiple: false,
+                    directory: false
+                })
+
+                if (!selectedPath || Array.isArray(selectedPath)) {
+                    return
+                }
+
+                const fileData = await readFile(selectedPath)
+                await loadBackupFromStream(new Blob([fileData]))
+            })().catch((error) => {
+                console.error(error)
+                alertError('Failed, Is file corrupted?')
+            })
+            return
+        }
+
         const input = document.createElement('input');
         input.type = 'file';
         input.accept = '.bin';
@@ -375,84 +400,7 @@ export function LoadLocalBackup(){
             const file = input.files[0];
             input.remove();
 
-            const reader = file.stream().getReader();
-            const CHUNK_SIZE = 1024 * 1024; // 1MB chunk size
-            let bytesRead = 0;
-            let remainingBuffer = new Uint8Array();
-
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) {
-                    break;
-                }
-
-                bytesRead += value.length;
-                const progress = ((bytesRead / file.size) * 100).toFixed(2);
-                alertWait(`Loading local Backup... (${progress}%)`);
-
-                const newBuffer = new Uint8Array(remainingBuffer.length + value.length);
-                newBuffer.set(remainingBuffer);
-                newBuffer.set(value, remainingBuffer.length);
-                remainingBuffer = newBuffer;
-
-                let offset = 0;
-                while (offset + 4 <= remainingBuffer.length) {
-                    const nameLength = new Uint32Array(remainingBuffer.slice(offset, offset + 4).buffer)[0];
-
-                    if (offset + 4 + nameLength > remainingBuffer.length) {
-                        break;
-                    }
-                    const nameBuffer = remainingBuffer.slice(offset + 4, offset + 4 + nameLength);
-                    const name = new TextDecoder().decode(nameBuffer);
-
-                    if (offset + 4 + nameLength + 4 > remainingBuffer.length) {
-                        break;
-                    }
-                    const dataLength = new Uint32Array(remainingBuffer.slice(offset + 4 + nameLength, offset + 4 + nameLength + 4).buffer)[0];
-
-                    if (offset + 4 + nameLength + 4 + dataLength > remainingBuffer.length) {
-                        break;
-                    }
-                    const data = remainingBuffer.slice(offset + 4 + nameLength + 4, offset + 4 + nameLength + 4 + dataLength);
-
-                    if (name === 'database.risudat') {
-                        const db = new Uint8Array(data);
-                        const dbData = await decodeRisuSave(db);
-                        setDatabaseLite(dbData);
-                        requiresFullEncoderReload.state = true;
-                        if (isTauri) {
-                            await writeFile('database/database.bin', db, { baseDir: BaseDirectory.AppData });
-                            await relaunch();
-                            alertStore.set({
-                                type: "wait",
-                                msg: "Success, Refreshing your app."
-                            });
-                        } else {
-                            await forageStorage.setItem('database/database.bin', db);
-                            location.search = '';
-                            alertStore.set({
-                                type: "wait",
-                                msg: "Success, Refreshing your app."
-                            });
-                        }
-                    } else {
-                        if (isTauri) {
-                            await writeFile(`assets/` + name, data, { baseDir: BaseDirectory.AppData });
-                        } else {
-                            await forageStorage.setItem('assets/' + name, data);
-                        }
-                    }
-                    await sleep(10);
-                    if (forageStorage.isAccount) {
-                        await sleep(1000);
-                    }
-
-                    offset += 4 + nameLength + 4 + dataLength;
-                }
-                remainingBuffer = remainingBuffer.slice(offset);
-            }
-
-            alertNormal('Success');
+            await loadBackupFromStream(file)
         };
 
         input.click();
@@ -460,4 +408,84 @@ export function LoadLocalBackup(){
         console.error(error);
         alertError('Failed, Is file corrupted?')
     }
+}
+
+async function loadBackupFromStream(file: Blob) {
+    const reader = file.stream().getReader();
+    let bytesRead = 0;
+    let remainingBuffer = new Uint8Array();
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+            break;
+        }
+
+        bytesRead += value.length;
+        const progress = ((bytesRead / file.size) * 100).toFixed(2);
+        alertWait(`Loading local Backup... (${progress}%)`);
+
+        const newBuffer = new Uint8Array(remainingBuffer.length + value.length);
+        newBuffer.set(remainingBuffer);
+        newBuffer.set(value, remainingBuffer.length);
+        remainingBuffer = newBuffer;
+
+        let offset = 0;
+        while (offset + 4 <= remainingBuffer.length) {
+            const nameLength = new Uint32Array(remainingBuffer.slice(offset, offset + 4).buffer)[0];
+
+            if (offset + 4 + nameLength > remainingBuffer.length) {
+                break;
+            }
+            const nameBuffer = remainingBuffer.slice(offset + 4, offset + 4 + nameLength);
+            const name = new TextDecoder().decode(nameBuffer);
+
+            if (offset + 4 + nameLength + 4 > remainingBuffer.length) {
+                break;
+            }
+            const dataLength = new Uint32Array(remainingBuffer.slice(offset + 4 + nameLength, offset + 4 + nameLength + 4).buffer)[0];
+
+            if (offset + 4 + nameLength + 4 + dataLength > remainingBuffer.length) {
+                break;
+            }
+            const data = remainingBuffer.slice(offset + 4 + nameLength + 4, offset + 4 + nameLength + 4 + dataLength);
+
+            if (name === 'database.risudat') {
+                const db = new Uint8Array(data);
+                const dbData = await decodeRisuSave(db);
+                setDatabaseLite(dbData);
+                requiresFullEncoderReload.state = true;
+                if (isTauri) {
+                    await writeFile('database/database.bin', db, { baseDir: BaseDirectory.AppData });
+                    await relaunch();
+                    alertStore.set({
+                        type: "wait",
+                        msg: "Success, Refreshing your app."
+                    });
+                } else {
+                    await forageStorage.setItem('database/database.bin', db);
+                    location.search = '';
+                    alertStore.set({
+                        type: "wait",
+                        msg: "Success, Refreshing your app."
+                    });
+                }
+            } else {
+                if (isTauri) {
+                    await writeFile(`assets/` + name, data, { baseDir: BaseDirectory.AppData });
+                } else {
+                    await forageStorage.setItem('assets/' + name, data);
+                }
+            }
+            await sleep(10);
+            if (forageStorage.isAccount) {
+                await sleep(1000);
+            }
+
+            offset += 4 + nameLength + 4 + dataLength;
+        }
+        remainingBuffer = remainingBuffer.slice(offset);
+    }
+
+    alertNormal('Success');
 }

--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -659,10 +659,11 @@ export async function importLoreBook(mode:'global'|'local'|'sglobal'){
     let lore = 
         mode === 'global' ? DBState.db.characters[selectedID].globalLore : 
         DBState.db.characters[selectedID].chats[page].localLore
-    const lorebook = (await selectSingleFile(['json', 'lorebook'])).data
-    if(!lorebook){
+    const selectedFile = await selectSingleFile(['json', 'lorebook'])
+    if(!selectedFile){
         return
     }
+    const lorebook = selectedFile.data
  
 
 

--- a/src/ts/process/scripts.ts
+++ b/src/ts/process/scripts.ts
@@ -40,10 +40,11 @@ export function exportRegex(s?:customscript[]){
 
 export async function importRegex(o?:customscript[]):Promise<customscript[]>{
     o = o ?? []
-    const filedata = (await selectSingleFile(['json'])).data
-    if(!filedata){
+    const selectedFile = await selectSingleFile(['json'])
+    if(!selectedFile){
         return o
     }
+    const filedata = selectedFile.data
     let db = getDatabase()
     try {
         const imported= JSON.parse(Buffer.from(filedata).toString('utf-8'))

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -45,10 +45,20 @@ export function checkNullish(data:any){
     return data === undefined || data === null
 }
 
-export async function selectSingleFile(ext:string[]){
+type SelectedFile = {
+    name: string
+    data: Uint8Array
+}
+
+const FILE_DIALOG_FOCUS_DELAY = 300
+
+export async function selectSingleFile(ext:string[]):Promise<SelectedFile|null>{
     if(!isTauri){
         const v = await selectFileByDom(ext, 'single')
         const file = v[0]
+        if(!file){
+            return null
+        }
         return {name: file.name,data:await readFileAsUint8Array(file)}
     }
 
@@ -67,7 +77,7 @@ export async function selectSingleFile(ext:string[]){
     }
 }
 
-export async function selectMultipleFile(ext:string[]){
+export async function selectMultipleFile(ext:string[]):Promise<SelectedFile[]>{
     if(!isTauri){
         const v = await selectFileByDom(ext, 'multiple')
         let arr:{name:string, data:Uint8Array}[] = []
@@ -91,7 +101,7 @@ export async function selectMultipleFile(ext:string[]){
         }
         return arr
     } else if (selected === null) {
-        return null
+        return []
     } else {
         return [{name: await basename(selected),data:await readFile(selected)}]
     }
@@ -162,11 +172,12 @@ export function getUserIconProtrait(){
     }
 }
 
-export function selectFileByDom(allowedExtensions:string[], multiple:'multiple'|'single' = 'single') {
-    return new Promise<null|File[]>((resolve) => {
+export function selectFileByDom(allowedExtensions:string[], multiple:'multiple'|'single' = 'single'):Promise<File[]> {
+    return new Promise<File[]>((resolve) => {
         const fileInput = document.createElement('input');
         fileInput.type = 'file';
         fileInput.multiple = multiple === 'multiple';
+        fileInput.tabIndex = -1
         const acceptAll = (getDatabase().allowAllExtentionFiles || isIOS() || allowedExtensions[0] === '*')
         if(!acceptAll){
             if (allowedExtensions && allowedExtensions.length) {
@@ -177,25 +188,54 @@ export function selectFileByDom(allowedExtensions:string[], multiple:'multiple'|
             fileInput.accept = '*'
         }
 
-    
-        fileInput.addEventListener('change', (event) => {
-            if (fileInput.files.length === 0) {
-                resolve([]);
+        fileInput.style.position = 'fixed'
+        fileInput.style.left = '-9999px'
+        fileInput.style.top = '0'
+        fileInput.style.width = '1px'
+        fileInput.style.height = '1px'
+        fileInput.style.opacity = '0'
+        fileInput.style.pointerEvents = 'none'
+
+        let settled = false
+        const cleanup = () => {
+            fileInput.remove()
+            window.removeEventListener('focus', handleFocus)
+        }
+        const finish = (files: File[]) => {
+            if(settled){
                 return;
             }
-    
+            settled = true
+            cleanup()
+            resolve(files)
+        }
+
+        fileInput.addEventListener('change', () => {
+            if (!fileInput.files || fileInput.files.length === 0) {
+                finish([])
+                return;
+            }
+
             const files = acceptAll ? Array.from(fileInput.files) :(Array.from(fileInput.files).filter(file => {
-                const fileExtension = file.name.split('.').pop().toLowerCase();
+                const lastDotIndex = file.name.lastIndexOf('.')
+                const fileExtension = lastDotIndex > 0 ? file.name.slice(lastDotIndex + 1).toLowerCase() : ''
                 return !allowedExtensions || allowedExtensions.includes(fileExtension);
             })) 
-    
-            fileInput.remove()
-            resolve(files);
+
+            finish(files)
         });
+
+        const handleFocus = () => {
+            setTimeout(() => {
+                if(!settled && (!fileInput.files || fileInput.files.length === 0)){
+                    finish([])
+                }
+            }, FILE_DIALOG_FOCUS_DELAY)
+        }
     
         document.body.appendChild(fileInput);
+        window.addEventListener('focus', handleFocus, { once: true })
         fileInput.click();
-        fileInput.style.display = 'none'; // Hide the file input element
     });
 }
 

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -45,9 +45,8 @@ export function checkNullish(data:any){
     return data === undefined || data === null
 }
 
-const domSelect = true
 export async function selectSingleFile(ext:string[]){
-    if(domSelect){
+    if(!isTauri){
         const v = await selectFileByDom(ext, 'single')
         const file = v[0]
         return {name: file.name,data:await readFileAsUint8Array(file)}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

fix: unify file picker flows and harden DOM fallback for WebKit/Tauri

## Summary

Migrate all remaining direct DOM file input usages to the shared `selectSingleFile`/`selectMultipleFile` utilities, enable the Tauri native file dialog path, and fix several correctness issues in the DOM fallback.

## Related Issues

Addresses the file selector not appearing on Safari/WebKit and Linux AppImage when clicking "import character" or "load backup locally".
[External bug report](https://arca.live/b/commit/164505075?p=1)
https://github.com/kwaroran/Risuai/issues/584

## Changes

- `selectSingleFile`/`selectMultipleFile` now route to Tauri native dialog when running in Tauri, instead of always using the DOM picker
- Migrated importCharacter (`characterCards.ts`), LoadLocalBackup (`backuplocal.ts`), trigger import (`TriggerV2List.svelte`), and whisper file select (`PlaygroundSubtitle.svelte`) to the shared utilities
- Moved backup file selection before confirmation dialogs so the picker opens directly from the user click, avoiding WebKit gesture restrictions
- Refactored `LoadLocalBackup` into `loadBackupFromStream`/`loadBackupFromBytes` to separate file selection from restore logic
- Fixed `selectSingleFile` DOM path crash on cancel (v[0] on empty array)
- Unified cancel return types: `selectSingleFile` returns `null`, `selectMultipleFile` always returns an array (never null)
- Replaced `display:none` with offscreen positioning for the hidden input
- Fixed extension filtering to use `lastIndexOf('.')` instead of `split('.').pop()` to handle edge cases correctly
- Increased focus-based cancel detection delay from 0ms to 300ms
- Added Tauri FS permissions for $HOME, $DESKTOP, $DOCUMENT directories
- Fixed null-unsafe callers in `scripts.ts`, `lorebook.svelte.ts`, and OtherBotSettings.svelte that would crash on picker cancellation

## Impact

File selection should now work on Tauri desktop builds (macOS, Linux) where it previously failed. Web/Safari users should see fewer cases of the file dialog not appearing. Cancelling a file picker no longer causes runtime errors in any flow.

## Notes

Working on backup file load selection.
Testing on arch linux.