### PR TITLE
fix: prevent localStorage quota overflow in plugin safety cache

### DIFF
--- a/src/ts/plugins/pluginSafety.ts
+++ b/src/ts/plugins/pluginSafety.ts
@@ -57,12 +57,17 @@ export async function checkCodeSafety(code: string): Promise<CheckResult> {
 
     const hashedCode = await hasher(new TextEncoder().encode(code));
     const cacheKey = `safety-${hashedCode}`;
-    const cachedResult = localStorage.getItem(cacheKey);
-    if (cachedResult) {
-        const got =  JSON.parse(cachedResult) as CheckResult;
-        if (got.checkerVersion === checkerVersion) {
-            return got;
+    try {
+        const cachedResult = localStorage.getItem(cacheKey);
+        if (cachedResult) {
+            const got = JSON.parse(cachedResult) as CheckResult;
+            if (got.checkerVersion === checkerVersion) {
+                return got;
+            }
+            localStorage.removeItem(cacheKey);
         }
+    } catch {
+        try { localStorage.removeItem(cacheKey); } catch {}
     }
 
     try {
@@ -150,8 +155,29 @@ export async function checkCodeSafety(code: string): Promise<CheckResult> {
         userAlertKey: 'errorInVerification'
     })
 
-    localStorage.setItem(cacheKey, JSON.stringify({ isSafe: errors.length === 0, errors, checkerVersion, modifiedCode:code }));
-    return { isSafe: errors.length === 0, errors, checkerVersion, modifiedCode: code};
+    const result: CheckResult = { isSafe: errors.length === 0, errors, checkerVersion, modifiedCode: code };
+    try {
+        localStorage.setItem(cacheKey, JSON.stringify(result));
+    } catch {
+        purgeSafetyCache(cacheKey);
+        try { localStorage.setItem(cacheKey, JSON.stringify(result)); } catch {}
+    }
+    return result;
+}
+
+function purgeSafetyCache(keepKey?: string) {
+    try {
+        const toRemove: string[] = [];
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(i);
+            if (key?.startsWith('safety-') && key !== keepKey) {
+                toRemove.push(key);
+            }
+        }
+        for (const key of toRemove) {
+            localStorage.removeItem(key);
+        }
+    } catch {}
 }
 
 function validateNode(node: any, type: DangerousNodeType, name: string | undefined, errors: PluginSafetyErrors[]) {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`checkCodeSafety` in `pluginSafety.ts` stores the full `modifiedCode` in localStorage for each plugin, keyed by code hash (`safety-${hash}`). When plugins are updated, old entries are never removed and new ones accumulate indefinitely. Once localStorage quota is exceeded, the unhandled `QuotaExceededError` from `localStorage.setItem` crashes `checkCodeSafety`, which in turn crashes `loadV2Plugin`, preventing all plugins (including V3) from loading.

This affects all platforms, environments with smaller quotas (e.g. Safari iOS at 5 MB) hit it sooner, but any environment will eventually reach the limit given enough plugin updates.

## Related Issues

None

## Changes

- Wrapped cache read (`localStorage.getItem` + `JSON.parse`) in try-catch; removes stale entry on checkerVersion mismatch or parse failure
- Wrapped cache write (`localStorage.setItem`) in try-catch; on quota error, purges all `safety-*` entries and retries once
- Added `purgeSafetyCache` helper that removes all `safety-*` localStorage entries except an optional keep key

## Impact

- Fixes all-plugins-dead scenario caused by localStorage quota overflow
- No behavioral change in normal operation, try-catch only activates on error
- Worst case after purge: one-time AST re-parse per plugin on next load (cache rebuilds itself)
- Only `safety-*` keys are touched; no other localStorage data is affected

## Additional Notes

The `safety-*` cache entries can be large (hundreds of KB each for big plugins) because they store the entire transformed source code. A single large plugin updated a few times can consume over 1 MB of orphaned cache entries. This fix is reactive (purge on quota error) rather than proactive, keeping the change minimal and preserving the existing caching strategy.
