### PR TITLE
feat: Prioritize user's UI language in Realm commentary and list preview

### DIFF
--- a/src/lib/UI/GUI/MultiLangDisplay.svelte
+++ b/src/lib/UI/GUI/MultiLangDisplay.svelte
@@ -2,6 +2,7 @@
     import { ColorSchemeTypeStore } from "src/ts/gui/colorscheme";
     import { ParseMarkdown } from "src/ts/parser/parser.svelte";
     import { parseMultilangString, toLangName } from "src/ts/util";
+    import { DBState } from "src/ts/stores.svelte";
 
     interface Props {
         value: string;
@@ -10,17 +11,45 @@
 
     let { value, markdown = false }: Props = $props();
     let valueObject: {[code:string]:string} = $derived(parseMultilangString(value))
-    let selectedLang = $state("en")
+
+    let userLang = $derived(DBState.db.language)
+
+    let defaultLang = $derived.by(() => {
+        if(valueObject[userLang] !== undefined) return userLang
+        if(valueObject["en"] !== undefined) return "en"
+        return "xx"
+    })
+
+    let selectedLang = $state("")
     $effect.pre(() => {
-        if(valueObject["en"] === undefined){
-            selectedLang = "xx"
-        }
+        selectedLang = defaultLang
     });
+
+    let sortedLangs = $derived.by(() => {
+        const keys = Object.keys(valueObject)
+        const prioritized = keys.find(k => k === userLang)
+        if(!prioritized) return { priority: null, rest: keys }
+        return {
+            priority: prioritized,
+            rest: keys.filter(k => k !== prioritized)
+        }
+    })
 </script>
 
 <div class="flex flex-col">
-    <div class="flex flex-wrap max-w-fit p-1 gap-2">
-        {#each Object.keys(valueObject) as lang}
+    <div class="flex flex-wrap max-w-fit p-1 gap-2 items-center">
+        {#if sortedLangs.priority}
+            {#if sortedLangs.priority !== 'xx' || Object.keys(valueObject).length === 1}
+                <button class="bg-bgcolor py-2 rounded-lg px-4" class:ring-1={selectedLang === sortedLangs.priority} onclick={((e) => {
+                    e.stopPropagation()
+                    selectedLang = sortedLangs.priority
+                })}>{toLangName(sortedLangs.priority)}</button>
+            {/if}
+            {#if sortedLangs.rest.length > 0}
+                <div class="border-l border-l-selected h-6"></div>
+            {/if}
+        {/if}
+        {#each sortedLangs.rest as lang}
             {#if lang !== 'xx' || Object.keys(valueObject).length === 1}
                 <button class="bg-bgcolor py-2 rounded-lg px-4" class:ring-1={selectedLang === lang} onclick={((e) => {
                     e.stopPropagation()

--- a/src/lib/UI/Realm/RealmHubIcon.svelte
+++ b/src/lib/UI/Realm/RealmHubIcon.svelte
@@ -26,7 +26,7 @@
     {/if}
     <div class="flex flex-col grow min-w-0">
         <span class="text-textcolor text-lg min-w-0 max-w-full text-ellipsis whitespace-nowrap overflow-hidden text-start">{chara.name}</span>
-        <span class="text-textcolor2 text-xs min-w-0 max-w-full text-ellipsis wrap-break-word max-h-8 whitespace-nowrap overflow-hidden text-start">{parseMultilangString(chara.desc).en ?? parseMultilangString(chara.desc).xx}</span>
+        <span class="text-textcolor2 text-xs min-w-0 max-w-full text-ellipsis wrap-break-word max-h-8 whitespace-nowrap overflow-hidden text-start">{parseMultilangString(chara.desc)[DBState.db.language] ?? parseMultilangString(chara.desc).en ?? parseMultilangString(chara.desc).xx}</span>
         <div class="flex flex-wrap">
             {#each chara.tags as tag, i}
                 {#if i < 4}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

When a Realm character has multi-language descriptions/commentary, the user's current UI language is now automatically prioritized — both in the card list preview and in the detail popup.

## Related Issues

None.

## Changes

### `src/lib/UI/GUI/MultiLangDisplay.svelte`
- Import `DBState` to read the user's current UI language (`DBState.db.language`).
- Default `selectedLang` to the user's UI language when available, falling back to English (`en`) then unknown (`xx`).
- Reorder language selector buttons so the user's language appears first, visually separated from the rest by a vertical divider.

### `src/lib/UI/Realm/RealmHubIcon.svelte`
- Update the description snippet in the Realm list card to prefer the user's UI language, with the same fallback chain (`user lang → en → xx`).

## Impact

- **No breaking changes.** The fallback chain (`user language → en → xx`) preserves existing behavior for users whose UI language has no matching translation.
- `MultiLangDisplay` is a general-purpose component used in multiple places (e.g., Realm popup descriptions, creator notes). All usages benefit from this change automatically.
- The Realm list preview (`RealmHubIcon`) previously always showed English; it now shows the user's language when available.

## Additional Notes

- The `MultiLangDisplay` language button order visually mirrors the priority: `[UserLang] | [OtherLang A] [OtherLang B] ...`
- The vertical divider is only rendered when there are other languages besides the prioritized one.
