### PR TITLE
fix: ensure system message comes first for WebLLM summarization models

### DIFF
--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1724,7 +1724,13 @@ export async function summarize(oaiMessages: OpenAIChat[], isResummarize: boolea
         return response.result.replace(thoughtsRegex, "").trim();
     }
 
-    // Local
+    // Local — ensure system message comes first for WebLLM models
+    const firstSystemIndex = formated.findIndex(m => m.role === 'system');
+    if (firstSystemIndex > 0) {
+        const [system] = formated.splice(firstSystemIndex, 1);
+        formated.unshift(system);
+    }
+
     const content = await chatCompletion(formated, settings.summarizationModel, {
         max_tokens: 8192,
         temperature: 0,


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models, check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Fixes `SystemMessageOrderError` when using WebLLM local models (Qwen3 1.7B/4B/8B) for HypaV3 summarization with default (empty) summarization prompt.

## Related Issues

Fixes #1051

## Changes

When the summarization prompt is empty, HypaV3 uses a default prompt that produces a `[user, system]` message order. WebLLM requires system messages to be first in the messages array (`SystemMessageOrderError` from `@mlc-ai/web-llm`).

This fix reorders messages to `[system, user]` in the local model (WebLLM) code path only, before passing them to `chatCompletion`. The subModel (external API) path is not affected.

### `hypav3.ts`
- Added system message reordering before `chatCompletion` call in the local model branch
- Only applies when a system message exists but is not already first

## Impact

- **WebLLM models**: Fixes the `SystemMessageOrderError` crash during summarization
- **SubModel (external API)**: No change — the subModel path uses `requestChatData` which already handles message ordering via model flags
- **Custom ChatML prompts**: Not affected — if users write their own ChatML prompt that doesn't start with system, WebLLM will still reject it (existing behavior)