### PR TITLE
perf: avoid spread operator for Uint8Array concatenation in stream transform

### DIFF
--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -1208,7 +1208,10 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
 
     return new TransformStream<Uint8Array, StreamResponseChunk>({
         transform(chunk, control) {
-            dataUint = Buffer.from(new Uint8Array([...dataUint, ...chunk]))
+            const combined = new Uint8Array(dataUint.length + chunk.length);
+            combined.set(dataUint, 0);
+            combined.set(chunk, dataUint.length);
+            dataUint = Buffer.from(combined);
             let JSONreaded:{[key:string]:string} = {}
                         try {
                 const datas = dataUint.toString().split('\n')


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This PR optimizes the concatenation of `Uint8Array` chunks within the `TransformStream` used for handling OpenAI streaming responses. It replaces the spread operator (`...`) with a more efficient pre-allocation and `.set()` method to prevent potential memory issues or "Maximum call stack size exceeded" errors when dealing with large chunks.

## Related Issues

None

## Changes

- Modified the `getTranStream` logic in `src/ts/process/request/openAI/requests.ts`:
  - Removed the `[...dataUint, ...chunk]` spread syntax.
  - Allocated a new `Uint8Array` with the exact combined length (`dataUint.length + chunk.length`).
  - Used the `.set()` method to copy the existing data and the new chunk into the pre-allocated array before wrapping it with `Buffer.from()`.

## Impact

- Prevents the "Maximum call stack size exceeded" runtime error that could occur when processing large text streams or chunks.
- Improves overall streaming processing performance by reducing array copy overhead and unnecessary garbage collection.
- Enhances stability without altering the existing functionality.

## Additional Notes

None
