### PR TITLE
fix: replace indexOf with findIndex by id in SideChatList

### DIFF
--- a/src/lib/SideBars/SideChatList.svelte
+++ b/src/lib/SideBars/SideChatList.svelte
@@ -67,7 +67,7 @@
                         }
                     })
 
-                    changeChatTo(newChats.indexOf(chara.chats[currentChatPage]))
+                    changeChatTo(newChats.findIndex(c => c.id === chara.chats[currentChatPage]?.id))
                     chara.chats = newChats
 
                     try {
@@ -107,7 +107,7 @@
                 })
                 
                 chara.chatFolders = newFolders
-                changeChatTo(newChats.indexOf(chara.chats[currentChatPage]))
+                changeChatTo(newChats.findIndex(c => c.id === chara.chats[currentChatPage]?.id))
                 chara.chats = newChats
                 try {
                     folderStb.destroy()
@@ -244,12 +244,13 @@
                     <div></div>
                     {:else}
                     {#each chara.chats.filter(chat => chat.folderId == chara.chatFolders[i].id) as chat}
-                    <button data-risu-chat-idx={chara.chats.indexOf(chat)} onclick={() => {
+                    {@const chatIdx = chara.chats.findIndex(c => c.id === chat.id)}
+                    <button data-risu-chat-idx={chatIdx} onclick={() => {
                         if(!editMode){
-                            changeChatTo(chara.chats.indexOf(chat))
+                            changeChatTo(chatIdx)
                             $ReloadGUIPointer += 1
                         }
-                    }} class="risu-chats flex items-center text-textcolor border-solid border-0 border-darkborderc p-2 cursor-pointer rounded-md"class:bg-selected={chara.chats.indexOf(chat) === chara.chatPage}>
+                    }} class="risu-chats flex items-center text-textcolor border-solid border-0 border-darkborderc p-2 cursor-pointer rounded-md"class:bg-selected={chatIdx === chara.chatPage}>
                         {#if editMode}
                             <TextInput bind:value={chat.name} className="grow min-w-0" padding={false}/>
                         {:else}
@@ -264,7 +265,8 @@
                                 const option = await alertChatOptions()
                                 switch(option){
                                     case 0:{
-                                        const newChat = $state.snapshot(chara.chats[chara.chats.indexOf(chat)])
+                                        if (chatIdx === -1) break
+                                        const newChat = $state.snapshot(chara.chats[chatIdx])
                                         newChat.name = createChatCopyName(newChat.name, 'Copy')
                                         newChat.id = v4()
                                         chara.chats.unshift(newChat)
@@ -294,7 +296,7 @@
                                         break
                                     }
                                     case 2:{
-                                        changeChatTo(chara.chats.indexOf(chat))
+                                        changeChatTo(chatIdx)
                                         createMultiuserRoom()
                                     }
                                 }
@@ -316,7 +318,7 @@
                                 }
                             }} class="text-textcolor2 hover:text-green-500 mr-1 cursor-pointer" onclick={async (e) => {
                                 e.stopPropagation()
-                                exportChat(chara.chats.indexOf(chat))
+                                exportChat(chatIdx)
                             }}>
                                 <DownloadIcon size={18}/>
                             </div>
@@ -332,10 +334,11 @@
                                 }
                                 const d = await alertConfirm(`${language.removeConfirm}${chat.name}`)
                                 if(d){
+                                    if (chatIdx === -1) return
                                     changeChatTo(0)
                                     $ReloadGUIPointer += 1
                                     let chats = chara.chats
-                                    chats.splice(chara.chats.indexOf(chat), 1)
+                                    chats.splice(chatIdx, 1)
                                     chara.chats = chats
                                 }
                             }}>


### PR DESCRIPTION
## Summary

Replace all `Array.indexOf(chat)` calls with `findIndex(c => c.id === chat.id)` in `SideChatList.svelte` to fix Svelte 5 proxy reference equality issues.

Svelte 5's `$state` proxy wraps array elements, so reference equality (`===`) used by `Array.indexOf()` can fail when comparing proxy-wrapped objects across different reactive scopes. This causes `indexOf` to return `-1`, leading to:

- `splice(-1, 1)` silently deleting the **last** chat instead of the intended one
- `changeChatTo(-1)` losing the active chat after drag-sort
- `data-risu-chat-idx="-1"` breaking folder chat rendering and selection

## Changes

- Replace all 8 occurrences of `indexOf(chat)` with `findIndex(c => c.id === chat.id)` to compare by stable UUID instead of object reference
- Add `-1` guard on the `splice` call site (line 338) to prevent silent deletion of the wrong chat when lookup fails
- Add `-1` guard on the `$state.snapshot` copy site (line 267) to prevent `snapshot(undefined)` crash

## Impact

- Fixes chat deletion occasionally removing the wrong chat
- Fixes chat drag-sort occasionally losing the active chat selection
- No behavior change when `indexOf` would have returned the correct index (which is most of the time — the bug is intermittent and depends on proxy wrapping state)

## Test plan

- [ ] Delete a chat from a folder — verify the correct chat is removed
- [ ] Drag-sort chats within a folder — verify active chat selection is preserved
- [ ] Copy a chat from a folder — verify the copy is created correctly
- [ ] Create multiuser room from a foldered chat — verify correct chat is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)