### PR TITLE
fix: add null guard for alternateGreetings across codebase

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -824,18 +824,18 @@
                         character={createSimpleCharacter(DBState.db.characters[$selectedCharID])}
                         name={DBState.db.characters[$selectedCharID].name}
                         message={DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].fmIndex === -1 ? DBState.db.characters[$selectedCharID].firstMessage :
-                            DBState.db.characters[$selectedCharID].alternateGreetings[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].fmIndex]}
+                            (DBState.db.characters[$selectedCharID].alternateGreetings?.[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].fmIndex] ?? DBState.db.characters[$selectedCharID].firstMessage)}
                         role='char'
                         img={getCharImage(DBState.db.characters[$selectedCharID].image, 'css')}
                         idx={-1}
-                        altGreeting={DBState.db.characters[$selectedCharID].alternateGreetings.length > 0}
+                        altGreeting={(DBState.db.characters[$selectedCharID].alternateGreetings?.length ?? 0) > 0}
                         largePortrait={DBState.db.characters[$selectedCharID].largePortrait}
                         firstMessage={true}
                         onReroll={() => {
                             const cha = DBState.db.characters[$selectedCharID]
                             const chat = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage]
                             if(cha.type !== 'group'){
-                                if (chat.fmIndex >= (cha.alternateGreetings.length - 1)){
+                                if (chat.fmIndex >= ((cha.alternateGreetings?.length ?? 0) - 1)){
                                     chat.fmIndex = -1
                                 }
                                 else{
@@ -849,7 +849,7 @@
                             const chat = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage]
                             if(cha.type !== 'group'){
                                 if (chat.fmIndex === -1){
-                                    chat.fmIndex = (cha.alternateGreetings.length - 1)
+                                    chat.fmIndex = ((cha.alternateGreetings?.length ?? 0) - 1)
                                 }
                                 else{
                                     chat.fmIndex -= 1
@@ -859,7 +859,7 @@
                         }}
                         isLastMemory={false}
                         currentPage={(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].fmIndex ?? -1) + 2}
-                        totalPages={DBState.db.characters[$selectedCharID].alternateGreetings.length + 1}
+                        totalPages={(DBState.db.characters[$selectedCharID].alternateGreetings?.length ?? 0) + 1}
 
                     />
                     {#if (aiLawApplies() && DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length === 0)}

--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -204,7 +204,7 @@ export function registerCBS(arg:CBSRegisterArg) {
                 }
                 pointer--
             }
-            return chat.fmIndex === -1 ? selchar.firstMessage : selchar.alternateGreetings[chat.fmIndex]
+            return chat.fmIndex === -1 ? selchar.firstMessage : (selchar.alternateGreetings?.[chat.fmIndex] ?? selchar.firstMessage)
         },
         alias: ['previouscharchat', 'lastcharmessage'],
         description: 'Returns the last message sent by the character in the current chat. Searches backwards from the current message position to find the most recent character message. If no character messages exist, returns the first message or selected alternate greeting.\n\nUsage:: {{previouscharchat}}',
@@ -225,7 +225,7 @@ export function registerCBS(arg:CBSRegisterArg) {
                     }
                     pointer--
                 }
-                return chat.fmIndex === -1 ? selchar.firstMessage : selchar.alternateGreetings[chat.fmIndex]
+                return chat.fmIndex === -1 ? selchar.firstMessage : (selchar.alternateGreetings?.[chat.fmIndex] ?? selchar.firstMessage)
             }
             return ''
         },
@@ -1518,7 +1518,7 @@ export function registerCBS(arg:CBSRegisterArg) {
                 const chat = selchar.chats[selchar.chatPage]
                 return makeArray([{
                     role: 'char',
-                    data: chat.fmIndex === -1 ? selchar.firstMessage : selchar.alternateGreetings[chat.fmIndex]
+                    data: chat.fmIndex === -1 ? selchar.firstMessage : (selchar.alternateGreetings?.[chat.fmIndex] ?? selchar.firstMessage)
                 }].concat(chat.message).map((v) => {
                     v = safeStructuredClone(v)
                     v.data = risuChatParser(v.data, matcherArg)

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -782,7 +782,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     let ms:Message[] = makeMs(currentChat)
 
     if(nowChatroom.type !== 'group' && !msReseted){
-        const firstMsg = currentChat.fmIndex === -1 ? nowChatroom.firstMessage : nowChatroom.alternateGreetings[currentChat.fmIndex]
+        const firstMsg = currentChat.fmIndex === -1 ? nowChatroom.firstMessage : (nowChatroom.alternateGreetings?.[currentChat.fmIndex] ?? nowChatroom.firstMessage)
 
         const chat:OpenAIChat = {
             role: 'assistant',

--- a/src/ts/process/scripts.ts
+++ b/src/ts/process/scripts.ts
@@ -253,7 +253,7 @@ export async function processScriptFull(char:character|groupChat|simpleCharacter
                         const v = outScript.split(' ', 2)[1]
                         const selchar = db.characters[get(selectedCharID)]
                         const chat = selchar.chats[selchar.chatPage]
-                        let lastChat = chat.fmIndex === -1 ? selchar.firstMessage : selchar.alternateGreetings[chat.fmIndex]
+                        let lastChat = chat.fmIndex === -1 ? selchar.firstMessage : (selchar.alternateGreetings?.[chat.fmIndex] ?? selchar.firstMessage)
                         let pointer = chatID - 1
                         while(pointer >= 0){
                             if(chat.message[pointer].role === chat.message[chatID].role){

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -2306,7 +2306,7 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
                     break
                 }
                 case 'v2GetFirstMessage':{
-                    setVar(risuChatParser(effect.outputVar, {chara:char}), chat.fmIndex === -1 ? char.firstMessage : char.alternateGreetings[chat.fmIndex])
+                    setVar(risuChatParser(effect.outputVar, {chara:char}), chat.fmIndex === -1 ? char.firstMessage : (char.alternateGreetings?.[chat.fmIndex] ?? char.firstMessage))
                     break
                 }
                 case 'v2GetAlertInput':{


### PR DESCRIPTION
## Summary

Add optional chaining (`?.`) and nullish coalescing (`?? 0` / `?? firstMessage`) to all 11 unsafe `alternateGreetings` access sites across 5 files.

Characters with `undefined` or `null` `alternateGreetings` crash with `TypeError: Cannot read properties of undefined (reading 'length')` or `TypeError: Cannot read properties of undefined (reading '0')`.

## Root cause

The `character` type declares `alternateGreetings: string[]` (non-optional), but at runtime it can be `undefined` in several scenarios:

1. **Svelte 5 reactivity race**: When switching characters, `$selectedCharID` changes trigger a re-render of `DefaultChatScreen` *before* `characterFormatUpdate()` runs to patch `alternateGreetings` to `[]`. The component accesses `alternateGreetings.length` on the not-yet-patched character.
2. **Old backup restoration**: Backup data from before the `alternateGreetings` field existed may not include it.
3. **External character editing**: JSON-edited characters may omit the field.
4. **V1 CharacterCard edge cases**: Custom import paths may skip the `alternate_greetings ?? []` normalization.

## Changes

| File | Sites | Pattern |
|------|-------|---------|
| `DefaultChatScreen.svelte` | 5 | `?.length ?? 0`, `?.[fmIndex] ?? firstMessage` |
| `cbs.ts` | 3 | `?.[fmIndex] ?? firstMessage` |
| `process/index.svelte.ts` | 1 | `?.[fmIndex] ?? firstMessage` |
| `process/scripts.ts` | 1 | `?.[fmIndex] ?? firstMessage` |
| `process/triggers.ts` | 1 | `?.[fmIndex] ?? firstMessage` |

**Total: 11 sites, +11/-11 lines, pure defensive guards.**

## Impact

- **When `alternateGreetings` exists** (normal case): Zero behavior change. `?.` on a defined object behaves identically to `.`, and `?? 0` never triggers because `.length` is always a number.
- **When `alternateGreetings` is undefined**: Falls back to `firstMessage` (for content) or `0` (for length) instead of crashing. This is semantically correct — "no alternate greetings" should behave like an empty array.
- **Bonus**: If `fmIndex` points beyond array bounds (e.g., an alternate greeting was deleted while another chat references its old index), the new code falls back to `firstMessage` instead of rendering `undefined`.

## Test plan

- [ ] Open a character with alternate greetings — verify reroll works normally
- [ ] Create a character without alternate greetings — verify no crash on chat screen
- [ ] Rapidly switch between characters — verify no crash during transition
- [ ] Import a V1 character card without `alternate_greetings` field — verify chat loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)