### PR TITLE
fix: handle missing preset and persona when applying loadout

### DIFF
--- a/src/ts/loadout.ts
+++ b/src/ts/loadout.ts
@@ -44,11 +44,17 @@ export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     loadout.lastUsed = Date.now()
     loadout.characterIds.push(getCurrentCharacter()?.chaId)
     if(apply.includes('persona')) {
-        let personaIndex = DBState.db.personas.findIndex(p => p.id === loadout.personaId) || 0
+        let personaIndex = DBState.db.personas.findIndex(p => p.id === loadout.personaId);
+        if(personaIndex === -1) {
+            personaIndex = 0
+        }
         changeUserPersona(personaIndex)
     }
     if(apply.includes('preset')) {
-        let presetIndex = DBState.db.botPresets.findIndex(p => p.name === loadout.presetName) || 0
+        let presetIndex = DBState.db.botPresets.findIndex(p => p.name === loadout.presetName);
+        if(presetIndex === -1) {
+            presetIndex = 0
+        }
         changeToPreset(presetIndex)
     }
     if(apply.includes('modules')) {

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -151,7 +151,7 @@ export function setDatabase(data:Database){
         defaultPreset.name = "Default"
         data.botPresets = [defaultPreset]
     }
-    if(checkNullish(data.botPresetsId)){
+    if(checkNullish(data.botPresets[data.botPresetsId])){
         data.botPresetsId = 0
     }
     if(checkNullish(data.sdProvider)){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fix incorrect findIndex fallback in applyLoadout and strengthen botPresetsId validation on database load.

## Related Issues

kwaroran/RisuAI#1351

## Changes

  - loadout.ts: Fix || 0 fallback not working due to -1 being truthy, replaced with explicit -1 check
  - database.svelte.ts: Validate that botPresetsId matches an actual entry in botPresets

## Impact

  - Users who previously triggered the bug via Loadout will no longer corrupt their preset state.
  - Users who already have corrupted botPresetsId will be automatically recovered on next app load without data loss.

## Additional Notes

  When a Loadout references a deleted/renamed preset, the fallback silently switches to preset 0 without notifying the user. This could cause confusion (e.g. "I set preset 3 in my Loadout, why is preset 1 being applied?").


  <details>
  <summary>한국어</summary>

  ## Summary

  `applyLoadout`의 잘못된 `findIndex` fallback 수정 및 DB 로드 시 `botPresetsId` 검증 강화

## Related Issues

  kwaroran/RisuAI#1351

  ## Changes

  - `loadout.ts`: `-1`이 truthy하여 `|| 0` fallback이 동작하지 않는 문제를 명시적 `-1` 검사로 수정
  - `database.svelte.ts`: `botPresetsId`가 실제 `botPresets`와 매칭되는지 검사하도록 변경

  ## Impact

  - Loadout을 통해 프리셋 상태가 오염되는 문제가 더 이상 발생하지 않습니다.
  - 이미 `botPresetsId`가 오염된 유저도 다음 앱 로드 시 자동 복구됩니다.

  ## Additional Notes

다만 Loadout 관련해 오염된 데이터 변경을 유저에게 알려주고 있지 않아 사용에 혼동을 줄 수 있습니다.
(ex. 나는 프리셋 3을 설정했는데 왜 1로 동작하지..)

  </details>