### PR TITLE
fix: add null guard for API response content across all providers

### DIFF
--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -323,7 +323,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
                 const msg:OpenAIChatFull = (dat.choices[0].message)
                 return {
                     type: 'success',
-                    result: msg.content
+                    result: msg.content ?? ''
                 }
             } catch (error) {                    
                 return {
@@ -744,7 +744,7 @@ export async function requestHTTPOpenAI(
             return extractJSON(dat.choices[0].message.content, arg.extractJson)
         }
         const msg:OpenAIChatFull = (dat.choices[0].message)
-        let result = msg.content
+        let result = msg.content ?? ''
         if(arg.modelInfo.flags.includes(LLMFlags.deepSeekThinkingOutput)){
             console.log("Checking for reasoning content")
             let reasoningContent = ""
@@ -897,7 +897,7 @@ export async function requestHTTPOpenAI(
                 if(arg.extractJson && (db.jsonSchemaEnabled || arg.schema)){
                     
                     const c = dat.choices.map((v:{message:{content:string}}) => {
-                        const extracted = extractJSON(v.message.content, arg.extractJson)
+                        const extracted = extractJSON(v.message.content ?? '', arg.extractJson)
                         return ["char", extracted]
                     })
                     
@@ -909,7 +909,7 @@ export async function requestHTTPOpenAI(
                 return {
                     type: 'multiline',
                     result: dat.choices.map((v) => {
-                        return ["char", v.message.content]
+                        return ["char", v.message.content ?? '']
                     })
                 }
             }            

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -640,7 +640,7 @@ async function requestOobaLegacy(arg:RequestDataArgumentExtended):Promise<reques
     const dat = res.data as any
     if(res.ok){
         try {
-            let result:string = dat.results[0].text
+            let result:string = dat.results[0].text ?? ''
 
             return {
                 type: 'success',
@@ -723,7 +723,7 @@ async function requestOoba(arg:RequestDataArgumentExtended):Promise<requestDataR
             result: (language.errors.httpError + `${JSON.stringify(response.data)}`)
         }
     }
-    const text:string = response.data.choices[0].text
+    const text:string = response.data.choices[0].text ?? ''
     return {
         type: 'success',
         result: text.replace(/##\n/g, '')
@@ -802,7 +802,7 @@ async function requestPlugin(arg:RequestDataArgumentExtended):Promise<requestDat
         else{
             return {
                 type: 'success',
-                result: d.content,
+                result: d.content ?? '',
                 model: 'custom'
             }
         }   
@@ -1249,7 +1249,7 @@ async function requestHorde(arg:RequestDataArgumentExtended):Promise<requestData
             if(generations && generations.length > 0){
                 return {
                     type: "success",
-                    result: unstringlizeChat(generations[0].text, formated, currentChar?.name ?? '')
+                    result: unstringlizeChat(generations[0].text ?? '', formated, currentChar?.name ?? '')
                 }
             }
             return {
@@ -1289,7 +1289,7 @@ async function requestWebLLM(arg:RequestDataArgumentExtended):Promise<requestDat
     } as any)
     return {
         type: 'success',
-        result: unstringlizeChat(v.generated_text as string, formated, currentChar?.name ?? '')
+        result: unstringlizeChat((v.generated_text as string) ?? '', formated, currentChar?.name ?? '')
     }
 }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models, check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Adds `?? ''` null guard to API response content across all providers. When an API returns `content: null` (e.g. content filters, malformed proxy responses, incomplete generations), downstream code like `reformatContent()` calls `.trim()` on the result, causing `TypeError: Cannot read properties of null (reading 'trim')`.

## Related Issues

Closes #205

## Changes

**`src/ts/process/request/openAI/requests.ts`** — Guard `msg.content` with `?? ''` in 4 locations:
- Non-streaming chat completion response (line 326)
- `processTextResponse` streaming result (line 747)
- Multi-gen with `extractJson` (line 900)
- Multi-gen without `extractJson` (line 912)

**`src/ts/process/request/request.ts`** — Guard response content with `?? ''` in 5 locations:
- Ooba Legacy `dat.results[0].text` (line 643)
- Ooba New `response.data.choices[0].text` (line 726)
- Plugin `d.content` (line 805)
- Horde `generations[0].text` (line 1252)
- WebLLM `v.generated_text` (line 1292)

Already safe (no changes needed): Anthropic (initializes `resText = ''`), Google (array assembly), NovelAI (`!da.data.output` pre-check), Echo (`?? "Echo Message"`), Response API (`!result` pre-check).