### PR TITLE
fix: correct Kobold default URL and error display

### DIFF
--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -884,7 +884,7 @@ async function requestKobold(arg:RequestDataArgumentExtended):Promise<requestDat
     if(!da.ok){
         return {
             type: "fail",
-            result: da.data,
+            result: (typeof da.data === 'string') ? da.data : JSON.stringify(da.data),
             noRetry: true
         }
     }

--- a/src/ts/process/templates/templates.ts
+++ b/src/ts/process/templates/templates.ts
@@ -252,7 +252,7 @@ export const prebuiltPresets = {
     "forceReplaceUrl2": "",
     "promptPreprocess": false,
     "bias": [],
-    "koboldURL": "http://localho.st:5001/api/v1",
+    "koboldURL": "http://localhost:5001/api/v1",
     "proxyKey": "",
     "ooba": {
       "max_new_tokens": 180,


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Fixes two Kobold API issues: a default URL typo and unreadable error messages.

## Related Issues

Partially addresses #242

## Changes

**`src/ts/process/templates/templates.ts`**
- Fixed default Kobold URL typo: `localho.st` → `localhost`

**`src/ts/process/request/request.ts`**
- Stringify Kobold error response before returning, preventing `[object Object]` display

## Notes

Other issues reported in #242:
- CPU inference timeout → resolved by #1313 (Local Network Mode)
- Gemma chat formatting "roles must alternate" error → not Kobold-specific, remains open