### PR TITLE
fix: [node] prevent /api/login crash from undefined writeFileSync

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -1384,7 +1384,7 @@ app.get('/api/oauth_callback', async (req, res) => {
         },
     )
 
-    fs.writeFileSync(authCodePath, tokens.access_token, 'utf-8')
+    writeFileSync(authCodePath, tokens.access_token, 'utf-8')
 
     res.send(tokens)
             

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -1147,7 +1147,7 @@ app.post('/api/login', loginRouteLimiter, async (req, res) => {
     }
     if(req.body.password && req.body.password.trim() === password.trim()){
         knownPublicKeysHashes.push(await hashJSON(req.body.publicKey))
-        fs.writeFileSync(knownPublicKeysPath, JSON.stringify(knownPublicKeysHashes), 'utf-8')
+        writeFileSync(knownPublicKeysPath, JSON.stringify(knownPublicKeysHashes), 'utf-8')
         res.send({status:'success'})
     }
     else{


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Replace the function with one that actually exists.

https://github.com/rndka9-alt/Risuai/blob/32ff3518180119144bbbdc0d9eee2755601a9cf1/server/node/server.cjs#L7-L8
```js
const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
const fs = require('fs/promises')
```


## Related Issues

None.

## Changes

Replace `fsPromises.writeFileSync` (not defined) with `fs.writeFileSync`

## Impact

Fixes the server crash that occurred when typing the password.

## Additional Notes

`fs` is imported from `fs/promises`, which can be misleading — consider renaming the const.