### PR TITLE
fix: accumulate Ollama streaming chunks for correct display

### DIFF
--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -1011,9 +1011,11 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
 
     const readableStream = new ReadableStream<StreamResponseChunk>({
         async start(controller){
+            let text = ''
             for await(const chunk of response){
+                text += chunk.message.content
                 controller.enqueue({
-                    "0": chunk.message.content
+                    "0": text
                 })
             }
             controller.close()


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Fixes Ollama streaming responses only showing the last token instead of the full accumulated response.

## Related Issues

Fixes #587

## Changes

**`src/ts/process/request/request.ts`** — Accumulate streamed chunks in the Ollama request handler.

The Ollama streaming path was enqueueing each chunk's `message.content` (a single token) directly, but the stream consumer in `index.svelte.ts` uses assignment (`result = value`) rather than accumulation (`result += value`). This caused only the last received token to be displayed.

All other streaming providers (OpenAI, Anthropic, Ooba) already accumulate text before enqueueing. This fix aligns the Ollama path with that pattern.

## Additional Notes

An external patch for the same issue was previously shared in #587: https://github.com/orsonteodoro/oiledmachine-overlay/blob/master/games-rpg/RisuAI/files/RisuAI-139.2.0-ollama-fix.patch