### PR TITLE
fix: show create character button in Beta Mobile GUI

### DIFF
--- a/src/lib/Mobile/MobileCharacters.svelte
+++ b/src/lib/Mobile/MobileCharacters.svelte
@@ -7,13 +7,12 @@
     import { MessageSquareIcon, PlusIcon } from "@lucide/svelte";
 
     interface Props {
-        gridMode?: boolean;
         endGrid?: () => void;
     }
 
     const agoFormatter = new Intl.RelativeTimeFormat(navigator.languages, { style: 'short' });
 
-    let {gridMode = false, endGrid = () => {}}: Props = $props();
+    let {endGrid = () => {}}: Props = $props();
 
     function makeAgoText(time:number){
         if(time === 0){
@@ -84,10 +83,8 @@
     {/each}
 </div>
 
-{#if gridMode}
-    <button class="p-4 rounded-full absolute bottom-2 right-2 bg-borderc" onclick={() => {
-        addCharacter()
-    }}>
-        <PlusIcon size={24} />
-    </button>
-{/if}
+<button class="p-4 rounded-full absolute bottom-2 right-2 bg-borderc" onclick={() => {
+    addCharacter()
+}}>
+    <PlusIcon size={24} />
+</button>

--- a/src/lib/Others/GridCatalog.svelte
+++ b/src/lib/Others/GridCatalog.svelte
@@ -157,7 +157,7 @@
                 </div>
             {/each}
         {:else if selected === 3}
-            <MobileCharacters gridMode endGrid={endGrid} />
+            <MobileCharacters endGrid={endGrid} />
         {/if}
     </div>
 </div>


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

The "create character" button (floating `+` icon) was missing in Beta Mobile GUI's character list screen.

## Related Issues

Fixes #686

## Changes

**`src/lib/Mobile/MobileCharacters.svelte`**
- Remove `gridMode` prop and its conditional guard so the create button always renders
- The button was originally unconditional, but was wrapped in `{#if gridMode}` in `b07a9b9d` when adding GridCatalog reuse — this inadvertently hid it in the Mobile GUI path where `gridMode` defaults to `false`

**`src/lib/Others/GridCatalog.svelte`**
- Remove now-unused `gridMode` prop from `MobileCharacters` usage