### PR TITLE
fix: correct tokenizer dropdown values in Custom Models settings

### DIFF
--- a/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
+++ b/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
@@ -8,6 +8,7 @@
     import OptionInput from "src/lib/UI/GUI/OptionInput.svelte";
     import Accordion from "src/lib/UI/Accordion.svelte";
     import { PlusIcon, TrashIcon, ArrowUp, ArrowDown } from "@lucide/svelte";
+    import type { LLMFlags, LLMFormat, LLMTokenizer } from "src/ts/model/types";
     import { v4 } from "uuid";
 
     let openedModels = $state(new Set<string>());
@@ -17,7 +18,7 @@
     } = $props()
 </script>
 
-{#snippet CustomFlagButton(index:number,name:string,flag:number)}
+{#snippet CustomFlagButton(index:number,name:string,flag:LLMFlags)}
     <Button className="mt-2" onclick={(e) => {
         if(DBState.db.customModels[index].flags.includes(flag)){
             DBState.db.customModels[index].flags = DBState.db.customModels[index].flags.filter((f) => f !== flag)
@@ -91,7 +92,7 @@
             <TextInput size={"sm"} bind:value={DBState.db.customModels[index].url}/>
             <span class="text-textcolor mt-4">{language.tokenizer}</span>
             <SelectInput size={"sm"} value={DBState.db.customModels[index].tokenizer.toString()} onchange={(e) => {
-                DBState.db.customModels[index].tokenizer = parseInt(e.currentTarget.value)
+                DBState.db.customModels[index].tokenizer = parseInt(e.currentTarget.value) as LLMTokenizer
             }}>
                 <OptionInput value="0">Unknown</OptionInput>
                 <OptionInput value="1">tiktokenCl100kBase</OptionInput>
@@ -109,7 +110,7 @@
             </SelectInput>
             <span class="text-textcolor">{language.format}</span>
             <SelectInput size={"sm"} value={DBState.db.customModels[index].format.toString()} onchange={(e) => {
-                DBState.db.customModels[index].format = parseInt(e.currentTarget.value)
+                DBState.db.customModels[index].format = parseInt(e.currentTarget.value) as LLMFormat
             }}>
                 <OptionInput value="0">OpenAICompatible</OptionInput>
                 <OptionInput value="1">OpenAILegacyInstruct</OptionInput>

--- a/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
+++ b/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
@@ -93,18 +93,19 @@
             <SelectInput size={"sm"} value={DBState.db.customModels[index].tokenizer.toString()} onchange={(e) => {
                 DBState.db.customModels[index].tokenizer = parseInt(e.currentTarget.value)
             }}>
-                <OptionInput value="0">tiktokenCl100kBase</OptionInput>
-                <OptionInput value="1">tiktokenO200Base</OptionInput>
-                <OptionInput value="2">Mistral</OptionInput>
-                <OptionInput value="3">Llama</OptionInput>
-                <OptionInput value="4">NovelAI</OptionInput>
-                <OptionInput value="5">Claude</OptionInput>
-                <OptionInput value="6">NovelList</OptionInput>
-                <OptionInput value="7">Llama3</OptionInput>
-                <OptionInput value="8">Gemma</OptionInput>
-                <OptionInput value="9">GoogleCloud</OptionInput>
-                <OptionInput value="10">Cohere</OptionInput>
-                <OptionInput value="12">DeepSeek</OptionInput>
+                <OptionInput value="0">Unknown</OptionInput>
+                <OptionInput value="1">tiktokenCl100kBase</OptionInput>
+                <OptionInput value="2">tiktokenO200Base</OptionInput>
+                <OptionInput value="3">Mistral</OptionInput>
+                <OptionInput value="4">Llama</OptionInput>
+                <OptionInput value="5">NovelAI</OptionInput>
+                <OptionInput value="6">Claude</OptionInput>
+                <OptionInput value="7">NovelList</OptionInput>
+                <OptionInput value="8">Llama3</OptionInput>
+                <OptionInput value="9">Gemma</OptionInput>
+                <OptionInput value="10">GoogleCloud</OptionInput>
+                <OptionInput value="11">Cohere</OptionInput>
+                <OptionInput value="13">DeepSeek</OptionInput>
             </SelectInput>
             <span class="text-textcolor">{language.format}</span>
             <SelectInput size={"sm"} value={DBState.db.customModels[index].format.toString()} onchange={(e) => {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

The tokenizer dropdown in Custom Models settings had all option values off-by-one from the `LLMTokenizer` enum — selecting any tokenizer stored the wrong value.

## Related Issues

Fixes #787

## Changes

**`src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte`**
- Correct all `OptionInput` values to match `LLMTokenizer` enum in `src/ts/model/types.ts` (e.g. `tiktokenCl100kBase` was `0`, should be `1`)
- Add missing `Unknown` option for the default value (`0`)
- Add type casts for `LLMTokenizer`, `LLMFormat`, and `LLMFlags` to resolve `number` type errors