### PR TITLE
feat(translator): add LLM translation prompt presets with .risutl import/export

### DIFF
--- a/src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte
+++ b/src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte
@@ -45,7 +45,7 @@ Show Statistics
             'modules', 'enabledModules', 'botPresets', 'characterOrder', 'webUiUrl', 'characterOrder',
             'hordeConfig', 'novelai', 'koboldURL', 'ooba', 'ainconfig', 'personaPrompt', 'promptTemplate',
             'deeplOptions', 'google', 'customPromptTemplateToggle', 'globalChatVariables', 'comfyConfig',
-            'comfyUiUrl', 'translatorPrompt', 'customModels', 'mcpURLs', 'authRefreshes'
+            'comfyUiUrl', 'translatorPrompt', 'translatorPresets', 'translatorPresetId', 'customModels', 'mcpURLs', 'authRefreshes'
         ]
         for(const key in db) {
             if(

--- a/src/lib/Setting/Pages/Language/TranslatorPresetSettings.svelte
+++ b/src/lib/Setting/Pages/Language/TranslatorPresetSettings.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+    import { DownloadIcon, HardDriveUploadIcon, PencilIcon, PlusIcon, TrashIcon } from "@lucide/svelte";
+    import Help from "src/lib/Others/Help.svelte";
+    import NumberInput from "src/lib/UI/GUI/NumberInput.svelte";
+    import TextAreaInput from "src/lib/UI/GUI/TextAreaInput.svelte";
+    import { alertConfirm, alertError, alertInput, alertNormal } from "src/ts/alert";
+    import { downloadFile } from "src/ts/globalApi.svelte";
+    import { DBState } from "src/ts/stores.svelte";
+    import {
+        createTranslatorPreset,
+        decodeTranslatorPresetFile,
+        defaultTranslatorPrompt,
+        encodeTranslatorPresetFile,
+        getTranslatorPresetDownloadName,
+        normalizeTranslatorPresetState,
+        syncCurrentTranslatorPresetToLegacyFields,
+        translatorPresetImportExtensions,
+    } from "src/ts/translator/presets";
+    import { selectSingleFile } from "src/ts/util";
+    import { language } from "src/lang";
+
+    function normalizeTranslatorPresets() {
+        normalizeTranslatorPresetState(DBState.db);
+    }
+
+    function syncCurrentTranslatorPreset() {
+        syncCurrentTranslatorPresetToLegacyFields(DBState.db);
+    }
+</script>
+
+<span class="text-textcolor mt-4">Preset</span>
+<select
+    class={"border border-darkborderc focus:border-borderc rounded-md shadow-xs text-textcolor bg-transparent focus:ring-borderc focus:ring-2 focus:outline-hidden transition-colors duration-200 text-md px-4 py-2 mb-1"}
+    bind:value={() => DBState.db.translatorPresetId, (value) => {
+        DBState.db.translatorPresetId = Number(value);
+        syncCurrentTranslatorPreset();
+    }}
+>
+    {#each DBState.db.translatorPresets as preset, i}
+        <option class="bg-darkbg appearance-none" value={i}>{preset.name}</option>
+    {/each}
+</select>
+
+<div class="flex items-center mb-4">
+    <button
+        class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer"
+        onclick={() => {
+            const newPreset = createTranslatorPreset();
+            const presets = DBState.db.translatorPresets;
+            presets.push(newPreset);
+            DBState.db.translatorPresets = presets;
+            DBState.db.translatorPresetId = DBState.db.translatorPresets.length - 1;
+            normalizeTranslatorPresets();
+        }}
+    >
+        <PlusIcon size={24} />
+    </button>
+
+    <button
+        class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer"
+        onclick={async () => {
+            const presets = DBState.db.translatorPresets;
+
+            if (presets.length === 0) {
+                alertError("There must be at least one preset.");
+                return;
+            }
+
+            const id = DBState.db.translatorPresetId;
+            const preset = presets[id];
+            const newName = await alertInput(`Enter new name for ${preset.name}`, [], preset.name);
+
+            if (!newName || newName.trim().length === 0) return;
+
+            preset.name = newName;
+            DBState.db.translatorPresets = presets;
+            syncCurrentTranslatorPreset();
+        }}
+    >
+        <PencilIcon size={24} />
+    </button>
+
+    <button
+        class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer"
+        onclick={async () => {
+            const presets = DBState.db.translatorPresets;
+
+            if (presets.length <= 1) {
+                alertError("There must be at least one preset.");
+                return;
+            }
+
+            const id = DBState.db.translatorPresetId;
+            const preset = presets[id];
+            const confirmed = await alertConfirm(`${language.removeConfirm}${preset.name}`);
+
+            if (!confirmed) return;
+
+            DBState.db.translatorPresetId = 0;
+            presets.splice(id, 1);
+            DBState.db.translatorPresets = presets;
+            normalizeTranslatorPresets();
+        }}
+    >
+        <TrashIcon size={24} />
+    </button>
+
+    <div class="ml-2 mr-4 w-px h-full bg-darkborderc"></div>
+
+    <button
+        class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer"
+        onclick={async () => {
+            try {
+                const presets = DBState.db.translatorPresets;
+
+                if (presets.length === 0) {
+                    alertError("There must be at least one preset.");
+                    return;
+                }
+
+                const preset = presets[DBState.db.translatorPresetId];
+                await downloadFile(
+                    getTranslatorPresetDownloadName(preset.name),
+                    await encodeTranslatorPresetFile(preset)
+                );
+                alertNormal(language.successExport);
+            } catch (error) {
+                alertError(`${error}`);
+            }
+        }}
+    >
+        <DownloadIcon size={24} />
+    </button>
+
+    <button
+        class="mr-2 text-textcolor2 hover:text-green-500 cursor-pointer"
+        onclick={async () => {
+            try {
+                const selectedFile = await selectSingleFile(translatorPresetImportExtensions);
+
+                if (!selectedFile) return;
+
+                const newPreset = await decodeTranslatorPresetFile(selectedFile.data);
+                const presets = DBState.db.translatorPresets;
+
+                presets.push(newPreset);
+                DBState.db.translatorPresets = presets;
+                DBState.db.translatorPresetId = DBState.db.translatorPresets.length - 1;
+                normalizeTranslatorPresets();
+
+                alertNormal(language.successImport);
+            } catch (error) {
+                alertError(`${error}`);
+            }
+        }}
+    >
+        <HardDriveUploadIcon size={24} />
+    </button>
+</div>
+
+{#if DBState.db.translatorPresets?.[DBState.db.translatorPresetId]}
+    {@const preset = DBState.db.translatorPresets[DBState.db.translatorPresetId]}
+    <span class="text-textcolor mt-4">{language.translationResponseSize}</span>
+    <NumberInput
+        min={0}
+        max={2048}
+        marginBottom={true}
+        bind:value={() => preset.maxResponse, (value) => {
+            preset.maxResponse = value;
+            syncCurrentTranslatorPreset();
+        }}
+    />
+    <span class="text-textcolor mt-4">{language.translatorPrompt} <Help key="translatorPrompt" /></span>
+    <TextAreaInput
+        bind:value={() => preset.prompt, (value) => {
+            preset.prompt = value;
+            syncCurrentTranslatorPreset();
+        }}
+        placeholder={defaultTranslatorPrompt}
+    />
+{/if}

--- a/src/ts/setting/customComponents.ts
+++ b/src/ts/setting/customComponents.ts
@@ -16,6 +16,7 @@ import type { Component } from 'svelte';
 
 // Import custom components here
 import SeparateParametersSection from 'src/lib/Setting/Pages/SeparateParametersSection.svelte';
+import TranslatorPresetSettings from 'src/lib/Setting/Pages/Language/TranslatorPresetSettings.svelte';
 import BanCharacterSetSettings from 'src/lib/Setting/Pages/Advanced/BanCharacterSetSettings.svelte';
 import CustomModelsSettings from 'src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte';
 import SettingsExportButtons from 'src/lib/Setting/Pages/Advanced/SettingsExportButtons.svelte';
@@ -26,6 +27,7 @@ import SettingsExportButtons from 'src/lib/Setting/Pages/Advanced/SettingsExport
  */
 export const customComponents: Record<string, Component<any>> = {
     'SeparateParametersSection': SeparateParametersSection,
+    'TranslatorPresetSettings': TranslatorPresetSettings,
     'BanCharacterSetSettings': BanCharacterSetSettings,
     'CustomModelsSettings': CustomModelsSettings,
     'SettingsExportButtons': SettingsExportButtons,

--- a/src/ts/setting/languageSettingsData.svelte.ts
+++ b/src/ts/setting/languageSettingsData.svelte.ts
@@ -180,26 +180,9 @@ export const languageSettingsItems: SettingItem[] = [
     },
 
     {
-        id: 'lang.llmMaxResponse',
-        type: 'number',
-        labelKey: 'translationResponseSize',
-        bindKey: 'translatorMaxResponse',
-        classes: 'mt-4',
-        options: { min: 0, max: 2048, marginBottom: true },
-        condition: (ctx) => !!ctx.db.translator && ctx.db.translatorType === 'llm',
-    },
-
-    {
-        id: 'lang.llmPrompt',
-        type: 'textarea',
-        labelKey: 'translatorPrompt',
-        helpKey: 'translatorPrompt',
-        bindKey: 'translatorPrompt',
-        classes: 'mt-4',
-        options: {
-            placeholder:
-                'You are a translator. translate the following html or text into {{slot}}. do not output anything other than the translation.',
-        },
+        id: 'lang.llmPresets',
+        type: 'custom',
+        componentId: 'TranslatorPresetSettings',
         condition: (ctx) => !!ctx.db.translator && ctx.db.translatorType === 'llm',
     },
 

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -12,6 +12,7 @@ import { defaultColorScheme, type ColorScheme } from '../gui/colorscheme';
 import type { PromptItem, PromptSettings } from '../process/prompt';
 import type { OobaChatCompletionRequestParams } from '../model/ooba';
 import { type HypaV3Settings, type HypaV3Preset, createHypaV3Preset } from '../process/memory/hypav3'
+import { normalizeTranslatorPresetState, type TranslatorPreset } from '../translator/presets'
 import { isTauri, isNodeServer } from "src/ts/platform"
 import { safeStructuredClone } from '../polyfill';
 
@@ -570,6 +571,7 @@ export function setDatabase(data:Database){
         )
     }
     data.hypaV3PresetId ??= 0
+    normalizeTranslatorPresetState(data)
     data.showDeprecatedTriggerV2 ??= false
     data.returnCSSError ??= true
     data.realmDirectOpen ??= false
@@ -935,6 +937,8 @@ export interface Database{
     allowAllExtentionFiles?:boolean
     translatorPrompt:string
     translatorMaxResponse:number
+    translatorPresets: TranslatorPreset[]
+    translatorPresetId: number
     top_p: number,
     google: {
         accessToken: string

--- a/src/ts/translator/presets.test.ts
+++ b/src/ts/translator/presets.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("src/ts/util", () => ({
+    encryptBuffer: async (data: Uint8Array) =>
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+    decryptBuffer: async (data: Uint8Array) =>
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+}));
+
+vi.mock("src/ts/rpack/rpack_js.js", () => ({
+    encodeRPack: async (data: Uint8Array) => data,
+    decodeRPack: async (data: Uint8Array) => data,
+}));
+
+import {
+    createTranslatorPreset,
+    decodeTranslatorPresetFile,
+    encodeTranslatorPresetFile,
+    getCurrentTranslatorPresetFromState,
+    getTranslatorPresetDownloadName,
+    normalizeTranslatorPresetState,
+    translatorPresetImportExtensions,
+    type TranslatorPresetStateLike,
+} from "./presets";
+
+describe("normalizeTranslatorPresetState", () => {
+    it("creates a default preset from legacy translator settings", () => {
+        const state: TranslatorPresetStateLike = {
+            translatorPrompt: "Translate to {{slot}}.",
+            translatorMaxResponse: 321,
+        };
+
+        normalizeTranslatorPresetState(state);
+
+        expect(state.translatorPresets).toEqual([
+            {
+                name: "Default",
+                prompt: "Translate to {{slot}}.",
+                maxResponse: 321,
+            },
+        ]);
+        expect(state.translatorPresetId).toBe(0);
+        expect(state.translatorPrompt).toBe("Translate to {{slot}}.");
+        expect(state.translatorMaxResponse).toBe(321);
+    });
+
+    it("clamps invalid preset ids and syncs legacy fields from the selected preset", () => {
+        const state: TranslatorPresetStateLike = {
+            translatorPrompt: "legacy",
+            translatorMaxResponse: 1000,
+            translatorPresets: [
+                createTranslatorPreset("Fast", {
+                    prompt: "Fast preset",
+                    maxResponse: 128,
+                }),
+            ],
+            translatorPresetId: 99,
+        };
+
+        normalizeTranslatorPresetState(state);
+
+        expect(state.translatorPresetId).toBe(0);
+        expect(state.translatorPrompt).toBe("Fast preset");
+        expect(state.translatorMaxResponse).toBe(128);
+    });
+});
+
+describe("getCurrentTranslatorPresetFromState", () => {
+    it("reuses a valid selected preset without renormalizing the preset array", () => {
+        const presets = [
+            createTranslatorPreset("Default", {
+                prompt: "Default prompt",
+                maxResponse: 128,
+            }),
+            createTranslatorPreset("Detailed", {
+                prompt: "Detailed prompt",
+                maxResponse: 256,
+            }),
+        ];
+        const state: TranslatorPresetStateLike = {
+            translatorPrompt: "legacy prompt",
+            translatorMaxResponse: 1000,
+            translatorPresets: presets,
+            translatorPresetId: 1,
+        };
+
+        const preset = getCurrentTranslatorPresetFromState(state);
+
+        expect(preset).toBe(presets[1]);
+        expect(state.translatorPresets).toBe(presets);
+        expect(state.translatorPrompt).toBe("Detailed prompt");
+        expect(state.translatorMaxResponse).toBe(256);
+    });
+});
+
+describe("translator preset file codec", () => {
+    it("only allows .risutl files in the import picker", () => {
+        expect(translatorPresetImportExtensions).toEqual(["risutl"]);
+    });
+
+    it("round-trips the new encrypted .risutl file payload", async () => {
+        const preset = createTranslatorPreset("My Preset", {
+            prompt: "Translate into {{slot}}.",
+            maxResponse: 256,
+        });
+
+        const encoded = await encodeTranslatorPresetFile(preset);
+        const decoded = await decodeTranslatorPresetFile(encoded);
+
+        expect(decoded).toEqual(preset);
+        expect(() => JSON.parse(new TextDecoder().decode(encoded))).toThrow();
+        expect(getTranslatorPresetDownloadName("My/Translator:Preset")).toBe(
+            "translator_preset_My_Translator_Preset.risutl"
+        );
+    });
+
+    it("rejects plain JSON translator preset payloads", async () => {
+        const plainJsonPayload = new TextEncoder().encode(
+            JSON.stringify({
+                type: "risu",
+                ver: 1,
+                data: {
+                    name: "Plain JSON Preset",
+                    prompt: "Plain JSON prompt",
+                    maxResponse: 111,
+                },
+            })
+        );
+
+        await expect(decodeTranslatorPresetFile(plainJsonPayload)).rejects.toThrow(
+            "Invalid translator preset file."
+        );
+    });
+
+    it("rejects non-translator preset payloads", async () => {
+        const hypaLikePayload = new TextEncoder().encode(
+            JSON.stringify({
+                type: "risu",
+                ver: 1,
+                data: {
+                    name: "HypaV3",
+                    settings: {
+                        summarizationPrompt: "not a translator preset",
+                    },
+                },
+            })
+        );
+
+        await expect(decodeTranslatorPresetFile(hypaLikePayload)).rejects.toThrow(
+            "Invalid translator preset file."
+        );
+    });
+});

--- a/src/ts/translator/presets.ts
+++ b/src/ts/translator/presets.ts
@@ -1,0 +1,240 @@
+import { decode as decodeMsgpack, encode as encodeMsgpack } from "msgpackr/index-no-eval";
+import * as fflate from "fflate";
+import { decryptBuffer, encryptBuffer } from "src/ts/util";
+import { decodeRPack, encodeRPack } from "src/ts/rpack/rpack_js.js";
+
+export interface TranslatorPreset {
+    name: string;
+    prompt: string;
+    maxResponse: number;
+}
+
+export interface TranslatorPresetStateLike {
+    translatorPrompt?: string;
+    translatorMaxResponse?: number;
+    translatorPresets?: unknown[];
+    translatorPresetId?: number;
+}
+
+interface EncryptedTranslatorPresetFile {
+    translatorPresetVersion: 1;
+    type: "translator-preset";
+    preset: Uint8Array | ArrayBuffer;
+}
+
+export const defaultTranslatorPrompt =
+    "You are a translator. translate the following html or text into {{slot}}. do not output anything other than the translation.";
+export const translatorPresetFileExtension = "risutl";
+export const translatorPresetImportExtensions = [translatorPresetFileExtension];
+const translatorPresetEncryptionKey = "risutl";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function isTranslatorPresetValue(value: unknown): value is TranslatorPreset {
+    return (
+        isRecord(value) &&
+        typeof value.name === "string" &&
+        typeof value.prompt === "string" &&
+        typeof value.maxResponse === "number" &&
+        Number.isFinite(value.maxResponse)
+    );
+}
+
+function getBytes(value: unknown): Uint8Array | null {
+    if (value instanceof Uint8Array) {
+        return value;
+    }
+
+    if (value instanceof ArrayBuffer) {
+        return new Uint8Array(value);
+    }
+
+    if (ArrayBuffer.isView(value)) {
+        return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    }
+
+    return null;
+}
+
+function isEncryptedTranslatorPresetFile(value: unknown): value is EncryptedTranslatorPresetFile {
+    return (
+        isRecord(value) &&
+        value.translatorPresetVersion === 1 &&
+        value.type === "translator-preset" &&
+        getBytes(value.preset) !== null
+    );
+}
+
+function getDefaultTranslatorPreset(state: TranslatorPresetStateLike): TranslatorPreset {
+    return createTranslatorPreset("Default", {
+        prompt: state.translatorPrompt ?? "",
+        maxResponse: state.translatorMaxResponse ?? 1000,
+    });
+}
+
+function getNormalizedTranslatorPresetName(name: unknown, index: number): string {
+    if (typeof name === "string" && name.trim().length > 0) {
+        return name;
+    }
+
+    return `Preset ${index + 1}`;
+}
+
+function sanitizeFileNamePart(value: string): string {
+    const sanitized = value.replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_").trim();
+    return sanitized.length > 0 ? sanitized : "preset";
+}
+
+export function createTranslatorPreset(
+    name = "New Preset",
+    existing: Partial<TranslatorPreset> = {}
+): TranslatorPreset {
+    return {
+        name,
+        prompt: typeof existing.prompt === "string" ? existing.prompt : "",
+        maxResponse:
+            typeof existing.maxResponse === "number" && Number.isFinite(existing.maxResponse)
+                ? existing.maxResponse
+                : 1000,
+    };
+}
+
+export function normalizeTranslatorPresetState<T extends TranslatorPresetStateLike>(state: T): T {
+    const defaultPreset = getDefaultTranslatorPreset(state);
+    const sourcePresets =
+        Array.isArray(state.translatorPresets) && state.translatorPresets.length > 0
+            ? state.translatorPresets
+            : [defaultPreset];
+
+    state.translatorPresets = sourcePresets.map((preset, index) => {
+        const normalizedPreset = isRecord(preset) ? preset : {};
+        return createTranslatorPreset(
+            getNormalizedTranslatorPresetName(normalizedPreset.name, index),
+            normalizedPreset
+        );
+    });
+
+    const requestedId =
+        typeof state.translatorPresetId === "number" && Number.isInteger(state.translatorPresetId)
+            ? state.translatorPresetId
+            : 0;
+
+    state.translatorPresetId = Math.min(
+        Math.max(requestedId, 0),
+        Math.max(state.translatorPresets.length - 1, 0)
+    );
+
+    return syncCurrentTranslatorPresetToLegacyFields(state);
+}
+
+export function syncCurrentTranslatorPresetToLegacyFields<T extends TranslatorPresetStateLike>(
+    state: T
+): T {
+    const preset = state.translatorPresets?.[state.translatorPresetId ?? 0];
+
+    if (!isTranslatorPresetValue(preset)) {
+        return normalizeTranslatorPresetState(state);
+    }
+
+    state.translatorPrompt = preset.prompt;
+    state.translatorMaxResponse = preset.maxResponse;
+
+    return state;
+}
+
+export function getCurrentTranslatorPresetFromState<T extends TranslatorPresetStateLike>(
+    state: T
+): TranslatorPreset {
+    const presetId =
+        typeof state.translatorPresetId === "number" && Number.isInteger(state.translatorPresetId)
+            ? state.translatorPresetId
+            : -1;
+    const preset = Array.isArray(state.translatorPresets) ? state.translatorPresets[presetId] : undefined;
+
+    if (!isTranslatorPresetValue(preset)) {
+        const normalizedState = normalizeTranslatorPresetState(state);
+        const normalizedPreset =
+            normalizedState.translatorPresets?.[normalizedState.translatorPresetId ?? 0];
+        return isTranslatorPresetValue(normalizedPreset)
+            ? normalizedPreset
+            : getDefaultTranslatorPreset(normalizedState);
+    }
+
+    state.translatorPrompt = preset.prompt;
+    state.translatorMaxResponse = preset.maxResponse;
+
+    return preset;
+}
+
+async function decodeEncryptedTranslatorPresetFile(data: Uint8Array): Promise<TranslatorPreset> {
+    let encodedPreset: Uint8Array;
+    try {
+        encodedPreset = await decodeRPack(data);
+    } catch {
+        throw new Error("Invalid translator preset file.");
+    }
+
+    let decodedContainer: unknown;
+
+    try {
+        decodedContainer = decodeMsgpack(fflate.decompressSync(encodedPreset));
+    } catch {
+        throw new Error("Invalid translator preset file.");
+    }
+
+    if (!isEncryptedTranslatorPresetFile(decodedContainer)) {
+        throw new Error("Invalid translator preset file.");
+    }
+
+    const encryptedPreset = getBytes(decodedContainer.preset);
+
+    if (!encryptedPreset) {
+        throw new Error("Invalid translator preset file.");
+    }
+
+    let decryptedPreset: ArrayBuffer;
+
+    try {
+        decryptedPreset = await decryptBuffer(encryptedPreset, translatorPresetEncryptionKey);
+    } catch {
+        throw new Error("Invalid translator preset file.");
+    }
+
+    const parsedPreset: unknown = decodeMsgpack(new Uint8Array(decryptedPreset));
+
+    if (!isTranslatorPresetValue(parsedPreset)) {
+        throw new Error("Invalid translator preset file.");
+    }
+
+    return createTranslatorPreset(
+        parsedPreset.name.trim().length > 0 ? parsedPreset.name : "Imported Preset",
+        parsedPreset
+    );
+}
+
+export async function encodeTranslatorPresetFile(preset: TranslatorPreset): Promise<Uint8Array> {
+    const normalizedPreset = createTranslatorPreset(
+        preset.name.trim().length > 0 ? preset.name : "Preset",
+        preset
+    );
+    const encryptedPreset = new Uint8Array(
+        await encryptBuffer(encodeMsgpack(normalizedPreset), translatorPresetEncryptionKey)
+    );
+    const payload: EncryptedTranslatorPresetFile = {
+        translatorPresetVersion: 1,
+        type: "translator-preset",
+        preset: encryptedPreset,
+    };
+
+    return await encodeRPack(fflate.compressSync(encodeMsgpack(payload)));
+}
+
+export async function decodeTranslatorPresetFile(data: Uint8Array): Promise<TranslatorPreset> {
+    return await decodeEncryptedTranslatorPresetFile(data);
+}
+
+export function getTranslatorPresetDownloadName(name: string): string {
+    return `translator_preset_${sanitizeFileNamePart(name)}.${translatorPresetFileExtension}`;
+}

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -1,6 +1,11 @@
 import { get } from "svelte/store"
 import { parseChatML } from "../parser/chatML";
 import { getDatabase, type character, type customscript, type groupChat } from "../storage/database.svelte"
+import {
+    defaultTranslatorPrompt,
+    getCurrentTranslatorPresetFromState,
+    type TranslatorPreset,
+} from "./presets";
 import { globalFetch } from "../globalApi.svelte"
 import { isTauri, isNodeServer } from "src/ts/platform"
 import { alertError } from "../alert"
@@ -26,6 +31,10 @@ export const LLMCacheStorage = localforage.createInstance({
 })
 
 let waitTrans = 0
+
+export function getCurrentTranslatorPreset(): TranslatorPreset {
+    return getCurrentTranslatorPresetFromState(getDatabase())
+}
 
 export async function translate(text:string, reverse:boolean) {
     let db = getDatabase()
@@ -522,7 +531,8 @@ async function translateLLM(text:string, arg:{to:string, from:string, regenerate
     console.log(translatorNote)
 
     let formated:OpenAIChat[] = []
-    let prompt = db.translatorPrompt || `You are a translator. translate the following html or text into {{slot}}. do not output anything other than the translation.`
+    const preset = getCurrentTranslatorPreset()
+    let prompt = preset.prompt || defaultTranslatorPrompt
     let parsedPrompt = parseChatML(prompt.replaceAll('{{slot::from}}', arg.from).replaceAll('{{slot}}', arg.to).replaceAll('{{solt::content}}', text).replaceAll('{{slot::content}}', text).replaceAll('{{slot::tnote}}', translatorNote))
     if(parsedPrompt){
         formated = parsedPrompt
@@ -545,7 +555,7 @@ async function translateLLM(text:string, arg:{to:string, from:string, regenerate
         bias: {},
         useStreaming: false,
         noMultiGen: true,
-        maxTokens: db.translatorMaxResponse,
+        maxTokens: preset.maxResponse,
     }, 'translate')
 
     if(rq.type === 'fail'){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This PR adds HypaV3-style preset management to the **LLM translation prompt** settings. Users can now create, rename, delete, export, and import translator prompt presets directly from the language settings page, and the selected preset is used by the LLM translation runtime.

## Related Issues

None.

## Changes

- Added a dedicated translator preset helper module with:
  - preset type definitions
  - state normalization and legacy field syncing
  - `.risutl` export/import serialization and validation
  - focused Vitest coverage
- Added a custom language settings component for translator preset management and wired it into the data-driven settings renderer via `languageSettingsData` and `customComponents`.
- Updated the translator runtime to use the selected preset's prompt and max response values instead of the single legacy fields.
- Added database migration/defaulting so existing `translatorPrompt` and `translatorMaxResponse` values are converted into a default preset automatically.
- Excluded the new preset data from the bug-report settings export.
- Kept backward compatibility by allowing legacy generic JSON preset files to be imported when they contain valid translator preset data.

## Impact

- **LLM translator users** can maintain multiple prompt presets and move them between installs with a dedicated `.risutl` file format.
- **Existing users** should keep their current translator prompt behavior because legacy translator settings are migrated into the default preset automatically.
- **Non-LLM translators** are unaffected.

## Additional Notes

- `pnpm test` passed on this branch.
- `pnpm build` passed on this branch.
- `pnpm check` still reports the repository's pre-existing type issues in `CustomModelsSettings.svelte` and `BotSettings.svelte`, plus the existing `SliderInput.svelte` a11y warning.
