### PR TITLE
fix: remove hardcoded Windows target from .cargo/config.toml

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,4 +1,3 @@
 [build]
-target = 'x86_64-pc-windows-msvc'
 
 [target]


### PR DESCRIPTION
## Problem

`src-tauri/.cargo/config.toml` has a hardcoded build target:

```toml
[build]
target = 'x86_64-pc-windows-msvc'
```

This forces Cargo to cross-compile to Windows MSVC on every invocation, regardless of the host platform. Non-Windows developers hit:

```
error[E0463]: can't find crate for `core`
  = note: the `x86_64-pc-windows-msvc` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-pc-windows-msvc`

error: could not compile `windows-link` (lib) due to 1 previous error
error: could not compile `cfg-if` (lib) due to 1 previous error
```

This prevents macOS and Linux developers from running ``pnpm tauri dev`` or ``pnpm tauri build`` without manually installing the Windows MSVC target (which is essentially useless for them on their native platform).

## Root Cause

Per ``git blame``, this line has existed since the first commit (``2c5c7d269``, 2023-05-07) and was never revisited. It was almost certainly a local configuration that got committed inadvertently.

## Fix

Remove the ``target`` line. Cargo will then use the host's default target automatically:
- macOS Apple Silicon → ``aarch64-apple-darwin``
- macOS Intel → ``x86_64-apple-darwin``
- Linux x86_64 → ``x86_64-unknown-linux-gnu``
- Windows → ``x86_64-pc-windows-msvc`` (the original intent, still works)

Developers who explicitly need Windows cross-compilation can pass it as a CLI flag:
```bash
cargo build --target x86_64-pc-windows-msvc
```

## Verification

**Before the fix** (macOS Apple Silicon, Rust 1.91.1):
```
error[E0463]: can't find crate for `core`
error: could not compile `windows-link` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `cfg-if` (lib) due to 1 previous error
```

**After the fix**:
```
Compiling risuai v0.0.0 (.../src-tauri)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.42s
```

Tested on:
- macOS 26.5 (Apple Silicon, arm64)
- Rust 1.91.1 (Homebrew)
- Tauri 2.10.3 + all plugins (fs, os, dialog, process, shell, http, updater, deep-link, single-instance)

## Impact

Zero behavioral change for Windows developers (they still get their native target automatically). Unblocks all non-Windows developers who want to build Tauri locally.