### PR TITLE
fix: strip <Thoughts> blocks from SD submodel output

### DIFF
--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -52,7 +52,7 @@ export async function stableDiff(currentChar:character,prompt:string){
         return false
     }
 
-    const r = rq.result
+    const r = rq.result.replace(/<Thoughts>[\s\S]*?<\/Thoughts>/g, '').trim()
 
 
     const genPrompt = currentChar.newGenData.prompt.replaceAll('{{slot}}', r)


### PR DESCRIPTION
## Problem

When using a reasoning model (Gemini with ``includeThoughts``, DeepSeek R1, Claude with thinking, OpenRouter with reasoning) as the Stable Diffusion submodel, the reasoning content gets embedded directly into the image generation prompt, producing garbage output.

### Example (Gemma 4 via Ollama)

When chatting with a character in ``imggen`` mode, the final prompt sent to Stable Diffusion contains the model's entire chain of thought:

```
<Thoughts>
*   Input: A chat snippet featuring "Eyjafjalla"...
    *   Goal: Output character information in the 8-tag format for NovelAI.
    *   Constraints:
        *   8-tag format.
        *   No curly braces {}.
        *   No thought process in output.
        *   Only necessary tags for character, location, or situation.
    *   Character: Eyjafjalla.
    *   Traits/Personality: Yandere, possessive, nurturing but controlling...
    ...
</Thoughts>
1girl, long hair, school uniform, ...
```

All of this gets substituted into the ``{{slot}}`` placeholder and sent to SD/NovelAI/DALL-E.

## Root Cause

The ``<Thoughts>`` tags are **not emitted by the LLM itself** — they are added by Risuai's own response handlers, which normalize reasoning content from all providers into a single ``<Thoughts>`` wrapper:

- ``src/ts/process/request/google.ts:715`` wraps Gemini ``thought`` parts
- ``src/ts/process/request/openAI/requests.ts:758,764,768`` wraps DeepSeek/OpenRouter reasoning
- ``src/ts/process/request/anthropic.ts:501,508,515`` wraps Claude thinking
- ``src/ts/process/request/google.ts:386,391`` explicitly requests ``includeThoughts: true`` from Gemini

``stableDiff()`` in ``src/ts/process/stableDiff.ts`` then substituted ``rq.result`` directly into the SD prompt template without removing this wrapper, so the whole reasoning block leaked into the final image prompt. No amount of prompt engineering can fix this from the user's side because the tags are added after the LLM responds.

## Fix

Strip ``<Thoughts>...</Thoughts>`` blocks from the submodel output before substitution:

```diff
-    const r = rq.result
+    const r = rq.result.replace(/<Thoughts>[\s\S]*?<\/Thoughts>/g, '').trim()
```

This uses the exact same regex already employed elsewhere in the codebase for the same purpose:

- ``src/ts/process/memory/hypav3.ts:1722-1725`` — HypaV3 memory summarization uses the identical ``/<Thoughts>[\s\S]*?<\/Thoughts>/g`` pattern for the same reason
- ``src/ts/util.ts:1215`` — ``jsonOutputTrimmer`` strips ``<Thoughts>`` before JSON parsing
- ``src/ts/parser/chatML.ts:48`` — ChatML parser handles ``<Thoughts>`` blocks
- ``src/ts/process/index.svelte.ts:919`` — Main chat pipeline strips ``<Thoughts>`` before display

The SD path was the only reasoning-aware consumer that was missing this cleanup step.

## Verification

- **LSP diagnostics on ``stableDiff.ts``**: clean, no new errors/warnings
- **``pnpm check``**: no new errors introduced (the 9 pre-existing errors in ``CustomModelsSettings.svelte`` and ``BotSettings.svelte`` about ``LLMFlags``/``LLMTokenizer``/``LLMFormat`` enum assignments are unrelated)
- **Type safety**: ``rq.result`` is ``string`` after the ``'fail'``/``'streaming'``/``'multiline'`` guards above, and ``string.replace().trim()`` returns ``string``, so ``r`` stays ``string``
- **Regex correctness**: identical to ``hypav3.ts:1723`` which has been in production use

## Impact

Zero behavioral change for non-reasoning submodels (their output has no ``<Thoughts>`` tags, so ``replace`` is a no-op). Unblocks users of Gemini, Gemma (via Gemini API or Ollama OpenAI-compat), DeepSeek R1, Claude with extended thinking, and any OpenRouter reasoning model as SD submodel.