### PR TITLE
fix: reject empty HypaV3 summary after stripping reasoning tags

### DIFF
--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1721,8 +1721,13 @@ export async function summarize(oaiMessages: OpenAIChat[], isResummarize: boolea
 
         // Remove thoughts content for API
         const thoughtsRegex = /<Thoughts>[\s\S]*?<\/Thoughts>/g;
+        const result = response.result.replace(thoughtsRegex, "").trim();
 
-        return response.result.replace(thoughtsRegex, "").trim();
+        if (result.length === 0) {
+            throw new Error("Empty summary after removing thoughts content");
+        }
+
+        return result;
     }
 
     // Local
@@ -1740,8 +1745,13 @@ export async function summarize(oaiMessages: OpenAIChat[], isResummarize: boolea
 
     // Remove think content
     const thinkRegex = /<think>[\s\S]*?<\/think>/g;
+    const result = content.replace(thinkRegex, "").trim();
 
-    return content.replace(thinkRegex, "").trim();
+    if (result.length === 0) {
+        throw new Error("Empty summary after removing think content");
+    }
+
+    return result;
 }
 
 export function getCurrentHypaV3Preset(): HypaV3Preset {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models, check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

`summarize()` checked for empty responses **before** stripping `<Thoughts>`/`<think>` tags, not after. When a reasoning model (e.g. Claude with thinking, DeepSeek R1) returned only reasoning content with no actual summary text, the tag-removal regex produced an empty string that was stored as `text: ""` in the summary data.

## Related Issues

Partially addresses community reports of `[HypaV3] Similarity search failed: TypeError: Cannot read properties of undefined (reading 'text')` — empty summaries accumulating in stored data degrade HypaV3 memory quality and may contribute to downstream errors.

## Changes

**`src/ts/process/memory/hypav3.ts`**
- Add empty check after `<Thoughts>` regex removal in the API (subModel) path — throw `"Empty summary after removing thoughts content"` instead of storing `""`
- Add empty check after `<think>` regex removal in the local model path — throw `"Empty summary after removing think content"` instead of storing `""`