### PR TITLE
fix: close unclosed Thoughts tag in Anthropic response handler

### DIFF
--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -518,8 +518,12 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
                 resText += '\n{{redacted_thinking}}\n'
             }
         }
-    
-    
+
+        if(thinking){
+            resText += "</Thoughts>\n\n"
+        }
+
+
         if(arg.extractJson && db.jsonSchemaEnabled){
             return {
                 type: 'success',
@@ -909,6 +913,12 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
                         await sleep(1)
                     }
                 }
+                if(thinking){
+                    text += "</Thoughts>\n\n"
+                    controller.enqueue({
+                        "0": text
+                    })
+                }
                 controller.close()
             },
             cancel(){
@@ -1064,6 +1074,9 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
         }
     }
 
+    if(thinking){
+        resText += "</Thoughts>\n\n"
+    }
 
     arg.additionalOutput ??= ""
     if(arg.extractJson && db.jsonSchemaEnabled){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models, check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

When an Anthropic reasoning model (Claude with extended thinking) returned a `thinking` or `redacted_thinking` block as the last content block, the `</Thoughts>` closing tag was never appended. This caused all downstream `<Thoughts>` regex consumers to fail to match, leaking reasoning content into chat display, prompts, HypaV3 summaries, and SD image generation.

The batch (message_batch) code path already handled this correctly — the other 3 paths were missing it.

## Related Issues

Partially addresses community reports of reasoning content leaking into responses and HypaV3 summary corruption when using Anthropic reasoning models as the sub-model.

Related to #1373 (SD Thoughts stripping) and #1327 (greedy Thoughts regex).

## Changes

**`src/ts/process/request/anthropic.ts`**
- Add `</Thoughts>` closing tag after the content loop in the non-streaming path when `thinking` is still `true`
- Add `</Thoughts>` closing tag before `controller.close()` in the streaming path when `thinking` is still `true`
- Add `</Thoughts>` closing tag after the content loop in the tool_use fallback path when `thinking` is still `true`