### PR TITLE
fix: wrap SafeElement[] returns with SafeClassArray for proper serialization

### DIFF
--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -603,9 +603,9 @@ interface SafeElement {
 
     /**
      * Gets all child elements
-     * @returns Array of child SafeElements
+     * @returns SafeClassArray of child SafeElements
      */
-    getChildren(): Promise<SafeElement[]>;
+    getChildren(): Promise<SafeClassArray<SafeElement>>;
 
     /**
      * Gets the parent element
@@ -616,9 +616,9 @@ interface SafeElement {
     /**
      * Queries all descendant elements matching a selector
      * @param selector - CSS selector
-     * @returns Array of matching SafeElements
+     * @returns SafeClassArray of matching SafeElements
      */
-    querySelectorAll(selector: string): Promise<SafeElement[]>;
+    querySelectorAll(selector: string): Promise<SafeClassArray<SafeElement>>;
 
     /**
      * Queries the first descendant element matching a selector
@@ -637,9 +637,9 @@ interface SafeElement {
     /**
      * Gets elements by class name
      * @param className - Class name
-     * @returns Array of matching SafeElements
+     * @returns SafeClassArray of matching SafeElements
      */
-    getElementsByClassName(className: string): Promise<SafeElement[]>;
+    getElementsByClassName(className: string): Promise<SafeClassArray<SafeElement>>;
 
     /**
      * Checks if element matches a selector

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -145,14 +145,14 @@ class SafeElement {
     public focus() {
         this.#element.focus();
     }
-    public getChildren(): SafeElement[] {
+    public getChildren(): SafeClassArray<SafeElement> {
         const children: SafeElement[] = [];
         this.#element.childNodes.forEach(node => {
             if(node instanceof HTMLElement) {
                 children.push(new SafeElement(node));
             }
         });
-        return children;
+        return new SafeClassArray<SafeElement>(children);
     }
     public getParent(): SafeElement | null {
         if(this.#element.parentElement) {
@@ -184,7 +184,7 @@ class SafeElement {
     public nodeType(): number {
         return this.#element.nodeType;
     }
-    public querySelectorAll(selector: string): SafeElement[] {
+    public querySelectorAll(selector: string): SafeClassArray<SafeElement> {
         const nodeList = this.#element.querySelectorAll(selector);
         const elements: SafeElement[] = [];
         nodeList.forEach(node => {
@@ -192,7 +192,7 @@ class SafeElement {
                 elements.push(new SafeElement(node));
             }
         });
-        return elements;
+        return new SafeClassArray<SafeElement>(elements);
     }
     public querySelector(selector: string): SafeElement | null {
         const element = this.#element.querySelector(selector);
@@ -205,9 +205,8 @@ class SafeElement {
         const element = this.querySelector('#' + id);
         return element;
     }
-    public getElementsByClassName(className: string): SafeElement[] {
-        const nodeList = this.querySelectorAll('.' + className);
-        return nodeList;
+    public getElementsByClassName(className: string): SafeClassArray<SafeElement> {
+        return this.querySelectorAll('.' + className);
     }
     public getClientRects(): DOMRectList {
         return this.#element.getClientRects();


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

V3 plugin API methods that return `SafeElement[]` (`getChildren`, `querySelectorAll`, `getElementsByClassName`) fail silently at the iframe sandbox boundary. The `serialize()` function in `factory.ts` only converts objects with `__classType === 'REMOTE_REQUIRED'` into `REMOTE_REF` plain arrays lack this property, so they fall through and hit `postMessage` as raw `SafeElement` instances, which cannot be structured-cloned (private `#element` field holds an `HTMLElement`).

`querySelector` works correctly because it returns a single `SafeElement` (which has `REMOTE_REQUIRED`), not an array.

## Related Issues

None

## Changes

- `SafeElement.getChildren()`: returns `SafeClassArray<SafeElement>` instead of `SafeElement[]`
- `SafeElement.querySelectorAll()`: returns `SafeClassArray<SafeElement>` instead of `SafeElement[]`
- `SafeElement.getElementsByClassName()`: returns `SafeClassArray<SafeElement>` instead of `SafeElement[]`
- Updated `risuai.d.ts` type definitions for all three methods to `Promise<SafeClassArray<SafeElement>>`

This follows the same pattern already used by `SafeMutationRecord.addedNodes`, which wraps `SafeElement[]` in `SafeClassArray` to pass through serialization correctly.

## Impact

- Fixes three broken V3 plugin API methods that were previously unusable
- No backwards compatibility issues, these methods could never have worked in V3 plugins due to the serialization failure
- Plugin authors can use `risuai.unwarpSafeArray()` to convert to a standard array if needed

## Additional Notes

The root cause is that `factory.ts` `serialize()` does not recurse into arrays to serialize individual elements. `SafeClassArray` is the existing workaround, it is itself a `REMOTE_REQUIRED` class that exposes `at()` and `length()` methods, each of which goes through RPC individually. A recursive serialize approach would also fix this but would require changes to the core sandbox communication layer.
