### PR TITLE
fix: preserve callback identity across serialization for removeRisuScriptHandler/removeRisuReplacer

### DIFF
--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -39,13 +39,19 @@ const GUEST_BRIDGE_SCRIPT = `
 await (async function() {
     const pendingRequests = new Map();
     const callbackRegistry = new Map();
+    const callbackIdByFunction = new WeakMap();
     const proxyRefRegistry = new Map();
     const abortControllers = new Map();
 
     function serializeArg(arg) {
         if (typeof arg === 'function') {
+            const existingId = callbackIdByFunction.get(arg);
+            if (existingId) {
+                return { __type: 'CALLBACK_REF', id: existingId };
+            }
             const id = 'cb_' + Math.random().toString(36).substring(2);
             callbackRegistry.set(id, arg);
+            callbackIdByFunction.set(arg, id);
             return { __type: 'CALLBACK_REF', id: id };
         }
         if (arg && typeof arg === 'object') {
@@ -290,6 +296,7 @@ export class SandboxHost {
 
     private instanceRegistry = new Map<string, any>();
     private abortControllers = new Map<string, AbortController>();
+    private callbackWrapperCache = new Map<string, Function>();
 
     private pendingCallbacks = new Map<string, { resolve: Function, reject: Function }>();
 
@@ -399,7 +406,10 @@ export class SandboxHost {
             if (arg && arg.__type === 'CALLBACK_REF') {
                 const cbRef = arg as CallbackRef;
 
-                return async (...innerArgs: any[]) => {
+                const cached = this.callbackWrapperCache.get(cbRef.id);
+                if (cached) return cached;
+
+                const wrapper = async (...innerArgs: any[]) => {
                     return new Promise((resolve, reject) => {
                         const reqId = 'cb_req_' + Math.random().toString(36).substring(2);
                         this.pendingCallbacks.set(reqId, { resolve, reject });
@@ -440,6 +450,8 @@ export class SandboxHost {
                         this.iframe.contentWindow?.postMessage(message, '*', transferables);
                     });
                 };
+                this.callbackWrapperCache.set(cbRef.id, wrapper);
+                return wrapper;
             }
             if (arg && arg.__type === 'REMOTE_REF') {
                 const remoteRef = arg as RemoteRef;
@@ -604,6 +616,7 @@ export class SandboxHost {
             this.instanceRegistry.clear();
             this.pendingCallbacks.clear();
             this.abortControllers.clear();
+            this.callbackWrapperCache.clear();
         };
     }
 
@@ -614,5 +627,6 @@ export class SandboxHost {
         this.instanceRegistry.clear();
         this.pendingCallbacks.clear();
         this.abortControllers.clear();
+        this.callbackWrapperCache.clear();
     }
 }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`removeRisuScriptHandler` and `removeRisuReplacer` always fail silently in V3 plugins. The callback passed to the remove function produces a different host-side wrapper than the one stored by the add function, so `Set.delete()` never matches.

## Related Issues

None

## Changes

**Guest side** (`GUEST_BRIDGE_SCRIPT` in `factory.ts`)
- Added `callbackIdByFunction` WeakMap to track function -> callback ID mappings
- `serializeArg()` now reuses the existing callback ID when the same function reference is serialized again, instead of generating a new random ID each time

**Host side** (`SandboxHost` class in `factory.ts`)
- Added `callbackWrapperCache` Map to track callback ID -> wrapper function mappings
- `deserializeArgs()` now returns the cached wrapper when it encounters a previously seen callback ID
- `terminate()` and `run()` cleanup both clear the cache

## Impact

- Fixes `removeRisuScriptHandler` and `removeRisuReplacer` which were completely non-functional in V3 plugins
- No breaking changes -- `addRisuScriptHandler` / `addRisuReplacer` behavior is unchanged, remove functions now actually work
- The same fix applies to any future API that relies on callback reference equality across add/remove pairs
- `addEventListener`/`removeEventListener` are not affected (they use a UUID return approach that bypasses this issue)

## Additional Notes

Root cause trace:

```
add handler:
  plugin: handler -> serializeArg() -> {__type:'CALLBACK_REF', id:'cb_abc'}
  host:   deserializeArgs() -> wrapperA -> Set.add(wrapperA)  // ok

remove handler:
  plugin: same handler -> serializeArg() -> {__type:'CALLBACK_REF', id:'cb_xyz'}  // new ID
  host:   deserializeArgs() -> wrapperB -> Set.delete(wrapperB)  // fail, wrapperA != wrapperB
```

The fix ensures both steps produce the same ID and the same wrapper, so `Set.delete()` succeeds.
