### PR TITLE
add: using position on lorebook prompts

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -459,6 +459,36 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     }
 
     const lorepmt = await loadLoreBookV3Prompt()
+
+    const positionRegex = /{{position::(.+?)}}/g
+    const replaceposition = (text:string):{text:string, replaced:boolean} => {
+        let replaced = false
+        const result = text.replace(positionRegex, (match, p1) => {
+            replaced = true
+            const posMatch = 'pt_' + p1
+            const matchingPrompts: string[] = []
+            for (const v of lorepmt.actives) {
+                if (v.pos === posMatch) {
+                    matchingPrompts.push(v.prompt)
+                }
+            }
+            return matchingPrompts.join('\n')
+        })
+        return {text: result, replaced}
+    }
+
+    // maxDepth controls how many levels of nesting are resolved. Currently set to 5, adjust if needed.
+    const resolvePosition = (text:string, maxDepth:number = 5) => {
+        let result = text
+        for(let i=0; i<maxDepth;i++) {
+            const r = replaceposition(result)
+            result = r.text
+            if(!r.replaced) break
+        }
+        result = result.replace(positionRegex, '')
+        return result
+    }
+
     const normalActives = lorepmt.actives.filter(v => {
         return v.pos === '' && v.inject === null
     })
@@ -467,7 +497,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     for(const lorebook of normalActives){
         unformated.lorebook.push({
             role: lorebook.role,
-            content: risuChatParser(lorebook.prompt, {chara: currentChar})
+            content: risuChatParser(resolvePosition(lorebook.prompt), {chara: currentChar})
         })
     }
 
@@ -478,7 +508,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     for(const lorebook of descActives){
         const c = {
             role: lorebook.role,
-            content: risuChatParser(lorebook.prompt, {chara: currentChar})
+            content: risuChatParser(resolvePosition(lorebook.prompt), {chara: currentChar})
         }
         if(lorebook.pos === 'before_desc'){
             unformated.description.unshift(c)
@@ -516,7 +546,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     for(const lorebook of postEverythingLorebooks){
         unformated.postEverything.push({
             role: lorebook.role,
-            content: risuChatParser(lorebook.prompt, {chara: currentChar})
+            content: risuChatParser(resolvePosition(lorebook.prompt), {chara: currentChar})
         })
     }
 
@@ -537,7 +567,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     for(const lorebook of postEverythingAssistantLorebooks){
         unformated.postEverything.push({
             role: lorebook.role,
-            content: risuChatParser(lorebook.prompt, {chara: currentChar})
+            content: risuChatParser(resolvePosition(lorebook.prompt), {chara: currentChar})
         })
     }
 
@@ -548,7 +578,6 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     //for unexpected error
     currentTokens += 50
     
-    const positionRegex = /{{position::(.+?)}}/g
     const positionParser = (text:string, loc:string) => {
         console.log(injectionLorePosSet)
         if(injectionLorePosSet.has(loc)){
@@ -572,16 +601,8 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                 }
             }
         }
-        return text.replace(positionRegex, (match, p1) => {
-            const posMatch = 'pt_' + p1
-            const matchingPrompts: string[] = []
-            for (const v of lorepmt.actives) {
-                if (v.pos === posMatch) {
-                    matchingPrompts.push(v.prompt)
-                }
-            }
-            return matchingPrompts.join('\n')
-        })
+
+        return resolvePosition(text)
     }
 
     let hasCachePoint = false

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -997,7 +997,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     for(const depthPrompt of depthPrompts){
         const chat:OpenAIChat = {
             role: depthPrompt.role,
-            content: risuChatParser(depthPrompt.prompt, {chara: currentChar})
+            content: risuChatParser(resolvePosition(depthPrompt.prompt), {chara: currentChar})
         }
         currentTokens += await tokenizer.tokenizeChat(chat)
     }
@@ -1125,7 +1125,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     for(const depthPrompt of depthPrompts){
         const chat:OpenAIChat = {
             role: depthPrompt.role,
-            content: risuChatParser(depthPrompt.prompt, {chara: currentChar})
+            content: risuChatParser(resolvePosition(depthPrompt.prompt), {chara: currentChar})
         }
         const depth = depthPrompt.pos === 'depth' ? (depthPrompt.depth) : (unformated.chats.length - depthPrompt.depth)
         unformated.chats.splice(depth,0,chat)


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Extended the {{position::}} feature to work inside lorebook prompt content, not just prompt templates.

## Related Issues

"None".

## Changes

- Moved `positionRegex` and create `replaceposition` above the lorebook processing block so they are available when lorebook prompts are assembled
- Extracted the `{{position::xxx}}` resolution logic from `positionParser` into a standalone `resolvePosition(text, maxDepth)` function
- Added a `replaced` boolean return value to `replaceposition` to avoid redundant regex checks during repeated resolution passes
- Introduced `resolvePosition` with a configurable `maxDepth` parameter (currently defaulting to `5`) for easier future adjustments
- Applied `resolvePosition` to `lorebook.prompt` at all insertion sites so `{{position::}}` markers are resolved in lorebook content

### Impact

- `{{position::}}` now works inside lorebook entries in addition to prompt templates
- Nested and recursive usage is supported up to the configured depth
- Infinite recursion is prevented by the depth limit

Additional Notes
Exposing `maxDepth` as a user-configurable setting would be a worthwhile follow-up.