### PR TITLE
feat: add embedding regex filter for HypaV3 summary chunks

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -318,6 +318,8 @@ export const languageEnglish = {
             "Higher values use more chat context to determine similarity.",
         hypaV3SummaryChunkSeparator:
             "Separator used to split summaries into chunks for similarity search.",
+        hypaV3EmbeddingRegex:
+            "Regex scripts applied to summary chunks before they are embedded for similarity search. The summary text finally injected into the prompt is not modified.",
         coldstorage: "Coldstorage is a feature that automatically moves old chats and character data to a seperate storage to reduce the size of the main storage and improve performance. This will reduce the transfer time, transfer traffic and improve the performance when loading chats."
     },
     setup: {
@@ -1383,6 +1385,7 @@ export const languageEnglish = {
         preserveOrphanedMemoryLabel: "Preserve Orphaned Memory",
         applyRegexScriptWhenRerollingLabel: "Apply Regex Script When Rerolling",
         doNotSummarizeUserMessageLabel: "Do Not Summarize User Message",
+        editEmbeddingRequestData: "Edit Embedding Request Data",
     },
     hypaV3Modal: {
         titleLabel: "HypaV3",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -301,6 +301,8 @@ export const languageEnglish = {
         hypaV3QueryChatCount:
             "The number of recent chat messages used as the query for similarity search. " +
             "Higher values use more chat context to determine similarity.",
+        hypaV3EmbeddingRegex:
+            "Regex scripts applied to summary chunks before they are embedded for similarity search. The summary text finally injected into the prompt is not modified.",
     },
     setup: {
         chooseProvider: "Choose AI Provider",
@@ -1358,6 +1360,7 @@ export const languageEnglish = {
         preserveOrphanedMemoryLabel: "Preserve Orphaned Memory",
         applyRegexScriptWhenRerollingLabel: "Apply Regex Script When Rerolling",
         doNotSummarizeUserMessageLabel: "Do Not Summarize User Message",
+        editEmbeddingRequestData: "Edit Embedding Request Data",
     },
     hypaV3Modal: {
         titleLabel: "HypaV3",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -307,6 +307,8 @@ export const languageEnglish = {
             "Higher values use more chat context to determine similarity.",
         hypaV3SummaryChunkSeparator:
             "Separator used to split summaries into chunks for similarity search.",
+        hypaV3EmbeddingRegex:
+            "Regex scripts applied to summary chunks before they are embedded for similarity search. The summary text finally injected into the prompt is not modified.",
         coldstorage: "Coldstorage is a feature that automatically moves old chats and character data to a seperate storage to reduce the size of the main storage and improve performance. This will reduce the transfer time, transfer traffic and improve the performance when loading chats."
     },
     setup: {
@@ -1368,6 +1370,7 @@ export const languageEnglish = {
         preserveOrphanedMemoryLabel: "Preserve Orphaned Memory",
         applyRegexScriptWhenRerollingLabel: "Apply Regex Script When Rerolling",
         doNotSummarizeUserMessageLabel: "Do Not Summarize User Message",
+        editEmbeddingRequestData: "Edit Embedding Request Data",
     },
     hypaV3Modal: {
         titleLabel: "HypaV3",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -172,6 +172,7 @@ export const languageKorean = {
         "hypaV3MaxChatsPerSummary": "하나의 요약본을 만들 때 포함할 최대 채팅 메시지 수입니다.",
         "hypaV3QueryChatCount": "유사도 검색의 쿼리로 사용되는 최근 채팅 메시지 수입니다. 값이 높을수록 더 많은 분량의 채팅으로 유사도를 판별합니다.",
         "hypaV3SummaryChunkSeparator": "요약본을 청크 단위로 분리할 때 사용되는 구분자입니다.",
+        "hypaV3EmbeddingRegex": "임베딩되기 전 요약본 청크에 적용되는 정규식 스크립트입니다. 최종적으로 삽입되는 요약본에는 적용되지 않습니다.",
         "hypaV3RecentMemoryRatio": "메모리 토큰 중 최근 메모리에 할당할 비율입니다. 가장 최근에 만들어진 요약본부터 할당된 토큰이 다 찰 때까지 자동으로 채워집니다.",
         "hypaV3SimilarMemoryRatio": "메모리 토큰 중 유사 메모리에 할당할 비율입니다. 최근 채팅과의 유사도 점수가 높은 요약본부터 할당된 토큰이 다 찰 때까지 자동으로 채워집니다.",
         "hypaV3RandomMemoryRatio": "이미 선택된 요약본을 제외한 나머지 중에서 무작위로 채워집니다.",
@@ -1242,7 +1243,8 @@ export const languageKorean = {
         "enableSimilarityCorrectionLabel": "유사도 보정 활성화",
         "preserveOrphanedMemoryLabel": "고아 메모리 보존",
         "applyRegexScriptWhenRerollingLabel": "재생성 시 정규식 스크립트 적용",
-        "doNotSummarizeUserMessageLabel": "유저 메시지 요약하지 않기"
+        "doNotSummarizeUserMessageLabel": "유저 메시지 요약하지 않기",
+        "editEmbeddingRequestData": "임베딩 리퀘스트 데이터 수정"
     },
     "hypaV3Modal": {
         "titleLabel": "HypaV3",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -162,6 +162,7 @@ export const languageKorean = {
         "hypaV3ExtraSummarizationRatio": "요약이 멈추는 기준을 낮추는 비율입니다. 0이면 최대 컨텍스트 이하가 되었을 때 요약을 멈추고, 높을수록 더 많이 요약을 진행한 뒤 멈춥니다.",
         "hypaV3MaxChatsPerSummary": "하나의 요약본을 만들 때 포함할 최대 채팅 메시지 수입니다.",
         "hypaV3QueryChatCount": "유사도 검색의 쿼리로 사용되는 최근 채팅 메시지 수입니다. 값이 높을수록 더 많은 분량의 채팅으로 유사도를 판별합니다.",
+        "hypaV3EmbeddingRegex": "임베딩되기 전 요약본 청크에 적용되는 정규식 스크립트입니다. 최종적으로 삽입되는 요약본에는 적용되지 않습니다.",
         "hypaV3RecentMemoryRatio": "메모리 토큰 중 최근 메모리에 할당할 비율입니다. 가장 최근에 만들어진 요약본부터 할당된 토큰이 다 찰 때까지 자동으로 채워집니다.",
         "hypaV3SimilarMemoryRatio": "메모리 토큰 중 유사 메모리에 할당할 비율입니다. 최근 채팅과의 유사도 점수가 높은 요약본부터 할당된 토큰이 다 찰 때까지 자동으로 채워집니다.",
         "hypaV3RandomMemoryRatio": "이미 선택된 요약본을 제외한 나머지 중에서 무작위로 채워집니다.",
@@ -1225,7 +1226,8 @@ export const languageKorean = {
         "enableSimilarityCorrectionLabel": "유사도 보정 활성화",
         "preserveOrphanedMemoryLabel": "고아 메모리 보존",
         "applyRegexScriptWhenRerollingLabel": "재생성 시 정규식 스크립트 적용",
-        "doNotSummarizeUserMessageLabel": "유저 메시지 요약하지 않기"
+        "doNotSummarizeUserMessageLabel": "유저 메시지 요약하지 않기",
+        "editEmbeddingRequestData": "임베딩 리퀘스트 데이터 수정"
     },
     "hypaV3Modal": {
         "titleLabel": "HypaV3",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -166,6 +166,7 @@ export const languageKorean = {
         "hypaV3MaxChatsPerSummary": "하나의 요약본을 만들 때 포함할 최대 채팅 메시지 수입니다.",
         "hypaV3QueryChatCount": "유사도 검색의 쿼리로 사용되는 최근 채팅 메시지 수입니다. 값이 높을수록 더 많은 분량의 채팅으로 유사도를 판별합니다.",
         "hypaV3SummaryChunkSeparator": "요약본을 청크 단위로 분리할 때 사용되는 구분자입니다.",
+        "hypaV3EmbeddingRegex": "임베딩되기 전 요약본 청크에 적용되는 정규식 스크립트입니다. 최종적으로 삽입되는 요약본에는 적용되지 않습니다.",
         "hypaV3RecentMemoryRatio": "메모리 토큰 중 최근 메모리에 할당할 비율입니다. 가장 최근에 만들어진 요약본부터 할당된 토큰이 다 찰 때까지 자동으로 채워집니다.",
         "hypaV3SimilarMemoryRatio": "메모리 토큰 중 유사 메모리에 할당할 비율입니다. 최근 채팅과의 유사도 점수가 높은 요약본부터 할당된 토큰이 다 찰 때까지 자동으로 채워집니다.",
         "hypaV3RandomMemoryRatio": "이미 선택된 요약본을 제외한 나머지 중에서 무작위로 채워집니다.",
@@ -1232,7 +1233,8 @@ export const languageKorean = {
         "enableSimilarityCorrectionLabel": "유사도 보정 활성화",
         "preserveOrphanedMemoryLabel": "고아 메모리 보존",
         "applyRegexScriptWhenRerollingLabel": "재생성 시 정규식 스크립트 적용",
-        "doNotSummarizeUserMessageLabel": "유저 메시지 요약하지 않기"
+        "doNotSummarizeUserMessageLabel": "유저 메시지 요약하지 않기",
+        "editEmbeddingRequestData": "임베딩 리퀘스트 데이터 수정"
     },
     "hypaV3Modal": {
         "titleLabel": "HypaV3",

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -21,6 +21,7 @@
     import { PlusIcon, PencilIcon, TrashIcon, DownloadIcon, HardDriveUploadIcon } from "@lucide/svelte";
     import { alertError, alertInput, alertConfirm, alertNormal } from "src/ts/alert";
     import { createHypaV3Preset } from "src/ts/process/memory/hypav3";
+    import HypaV3EmbeddingRegexList from "src/lib/SideBars/Scripts/HypaV3EmbeddingRegexList.svelte";
 
     let submenu = $state(DBState.db.useLegacyGUI ? -1 : 0);
 
@@ -1193,6 +1194,11 @@
                 <span class="text-textcolor">{language.reSummarizationPrompt} <Help key="reSummarizationPrompt"/></span>
                 <div class="mb-4">
                     <TextAreaInput size="sm" placeholder={language.hypaV3Settings.supaMemoryPromptPlaceHolder} bind:value={settings.reSummarizationPrompt} />
+                </div>
+                <div class="mb-4">
+                    <Accordion styled name={language.regexScript} help="hypaV3EmbeddingRegex">
+                        <HypaV3EmbeddingRegexList bind:value={settings.embeddingRegex} />
+                    </Accordion>
                 </div>
                 {#await getMaxMemoryRatio() then maxMemoryRatio}
                 <span class="text-textcolor">{language.hypaV3Settings.maxMemoryTokensRatioLabel}</span>

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -21,6 +21,7 @@
     import { PlusIcon, PencilIcon, TrashIcon, DownloadIcon, HardDriveUploadIcon } from "@lucide/svelte";
     import { alertError, alertInput, alertConfirm, alertNormal } from "src/ts/alert";
     import { createHypaV3Preset } from "src/ts/process/memory/hypav3";
+    import HypaV3EmbeddingRegexList from "src/lib/SideBars/Scripts/HypaV3EmbeddingRegexList.svelte";
 
     let submenu = $state(DBState.db.useLegacyGUI ? -1 : 0);
 
@@ -1192,6 +1193,11 @@
                 <span class="text-textcolor">{language.reSummarizationPrompt} <Help key="reSummarizationPrompt"/></span>
                 <div class="mb-4">
                     <TextAreaInput size="sm" placeholder={language.hypaV3Settings.supaMemoryPromptPlaceHolder} bind:value={settings.reSummarizationPrompt} />
+                </div>
+                <div class="mb-4">
+                    <Accordion styled name={language.regexScript} help="hypaV3EmbeddingRegex">
+                        <HypaV3EmbeddingRegexList bind:value={settings.embeddingRegex} />
+                    </Accordion>
                 </div>
                 {#await getMaxMemoryRatio() then maxMemoryRatio}
                 <span class="text-textcolor">{language.hypaV3Settings.maxMemoryTokensRatioLabel}</span>

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -21,6 +21,7 @@
     import { PlusIcon, PencilIcon, TrashIcon, DownloadIcon, HardDriveUploadIcon } from "@lucide/svelte";
     import { alertError, alertInput, alertConfirm, alertNormal } from "src/ts/alert";
     import { createHypaV3Preset } from "src/ts/process/memory/hypav3";
+    import HypaV3EmbeddingRegexList from "src/lib/SideBars/Scripts/HypaV3EmbeddingRegexList.svelte";
 
     let submenu = $state(DBState.db.useLegacyGUI ? -1 : 0);
 
@@ -1191,6 +1192,11 @@
                 <span class="text-textcolor">{language.reSummarizationPrompt} <Help key="reSummarizationPrompt"/></span>
                 <div class="mb-4">
                     <TextAreaInput size="sm" placeholder={language.hypaV3Settings.supaMemoryPromptPlaceHolder} bind:value={settings.reSummarizationPrompt} />
+                </div>
+                <div class="mb-4">
+                    <Accordion styled name={language.regexScript} help="hypaV3EmbeddingRegex">
+                        <HypaV3EmbeddingRegexList bind:value={settings.embeddingRegex} />
+                    </Accordion>
                 </div>
                 {#await getMaxMemoryRatio() then maxMemoryRatio}
                 <span class="text-textcolor">{language.hypaV3Settings.maxMemoryTokensRatioLabel}</span>

--- a/src/lib/SideBars/Scripts/HypaV3EmbeddingRegexData.svelte
+++ b/src/lib/SideBars/Scripts/HypaV3EmbeddingRegexData.svelte
@@ -69,7 +69,7 @@
         <button class="valuer" onclick={async () => {
             const d = await alertConfirm(language.removeConfirm + value.comment)
             if(d){
-                if(!open){
+                if(open){
                     onClose()
                 }
                 onRemove()

--- a/src/lib/SideBars/Scripts/HypaV3EmbeddingRegexData.svelte
+++ b/src/lib/SideBars/Scripts/HypaV3EmbeddingRegexData.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+    import { XIcon } from "@lucide/svelte";
+    import { language } from "src/lang";
+    import { alertConfirm } from "src/ts/alert";
+    import type { EmbeddingRegex } from "src/ts/process/memory/embeddingRegex";
+    import Check from "../../UI/GUI/CheckInput.svelte";
+    import TextInput from "../../UI/GUI/TextInput.svelte";
+    import TextAreaInput from "../../UI/GUI/TextAreaInput.svelte";
+    import SelectInput from "../../UI/GUI/SelectInput.svelte";
+    import OptionInput from "../../UI/GUI/OptionInput.svelte";
+    import Accordion from "src/lib/UI/Accordion.svelte";
+
+    interface Props {
+        value: EmbeddingRegex;
+        onRemove?: () => void;
+        onClose?: () => void;
+        onOpen?: () => void;
+        idx: number;
+    }
+
+    let {
+        value = $bindable(),
+        onRemove = () => {},
+        onClose = () => {},
+        onOpen = () => {},
+        idx
+    }: Props = $props();
+
+    const checkFlagContain = (flag: string, matchFlag: string) => {
+        if (flag.length === 1) {
+            matchFlag = (value.flag ?? '')
+        }
+        return matchFlag.includes(flag)
+    }
+
+    const toggleFlag = (flag: string) => {
+        const current = value.flag ?? ''
+        if (checkFlagContain(flag, current)) {
+            value.flag = current.replace(flag, '')
+        } else {
+            value.flag = current + flag
+        }
+    }
+
+    const flags = [
+        ['Global (g)', 'g'],
+        ['Case Insensitive (i)', 'i'],
+        ['Multi Line (m)', 'm'],
+        ['Unicode (u)', 'u'],
+        ['Dot All (s)', 's'],
+    ]
+
+    let open = $state(false)
+</script>
+
+<div class="w-full flex flex-col pt-2 mt-2 border-t border-t-selected first:pt-0 first:mt-0 first:border-0" data-risu-idx={idx}>
+    <div class="flex items-center transition-colors w-full ">
+        <button class="endflex valuer border-borderc" onclick={() => {
+            open = !open
+            if(open){
+                onOpen()
+            }
+            else{
+                onClose()
+            }
+        }}>
+            <span>{value.comment.length === 0 ? 'Unnamed Script' : value.comment}</span>
+        </button>
+        <button class="valuer" onclick={async () => {
+            const d = await alertConfirm(language.removeConfirm + value.comment)
+            if(d){
+                if(!open){
+                    onClose()
+                }
+                onRemove()
+            }
+        }}>
+            <XIcon />
+        </button>
+    </div>
+    {#if open}
+        <div class="seperator p-2">
+            <span class="text-textcolor mt-6">{language.name}</span>
+            <TextInput size="sm" bind:value={value.comment} />
+            <span class="text-textcolor mt-4">Modification Type</span>
+            <SelectInput bind:value={value.type}>
+                <OptionInput value="disabled">{language.disabled}</OptionInput>
+                <OptionInput value="editembedding">{language.hypaV3Settings.editEmbeddingRequestData}</OptionInput>
+            </SelectInput>
+            <span class="text-textcolor mt-6">IN:</span>
+            <TextInput size="sm" bind:value={value.in} />
+            <span class="text-textcolor mt-6">OUT:</span>
+            <TextAreaInput highlight autocomplete="off" size="sm" bind:value={value.out} />
+            {#if value.ableFlag}
+                <Accordion styled name="FLAGS">
+                    <span class="text-textcolor mt-3">Normal Flag</span>
+                    <div class="grid w-full grid-cols-2 rounded-md border border-darkborderc">
+                        {#each flags as flag, i}
+                            <button class="w-full bg-darkbg border-darkborderc text-sm py-1"
+                                class:border-r-1={i % 2 === 0}
+                                class:border-b-1={i < flags.length - 1}
+                                class:text-textcolor2={!checkFlagContain(flag[1], value.flag ?? '')}
+                                class:text-textcolor={checkFlagContain(flag[1], value.flag ?? '')}
+                                onclick={() => {
+                                    toggleFlag(flag[1])
+                                }}
+                            >
+                                <span>{flag[0]}</span>
+                                </button>
+                        {/each}
+                        <div class="w-full bg-darkbg text-sm py-1"></div>
+                    </div>
+                </Accordion>
+            {/if}
+            <div class="flex items-center mt-4">
+                <Check bind:check={value.ableFlag} onChange={() => {
+                    if(!value.flag){
+                        value.flag = 'g'
+                    }
+                }}/>
+                <span>Custom Flag</span>
+            </div>
+       </div>
+    {/if}
+</div>
+
+<style>
+    .valuer:hover{
+        color: rgba(16, 185, 129, 1);
+        cursor: pointer;
+    }
+
+    .endflex{
+        display: flex;
+        flex-grow: 1;
+        cursor: pointer;
+    }
+
+    .seperator{
+        border: none;
+        outline: 0;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 0.5rem;
+    }
+</style>

--- a/src/lib/SideBars/Scripts/HypaV3EmbeddingRegexList.svelte
+++ b/src/lib/SideBars/Scripts/HypaV3EmbeddingRegexList.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+    import type { EmbeddingRegex } from "src/ts/process/memory/embeddingRegex";
+    import HypaV3EmbeddingRegexData from "./HypaV3EmbeddingRegexData.svelte";
+    import Sortable from "sortablejs";
+    import { sleep, sortableOptions } from "src/ts/util";
+    import { onDestroy, onMount } from "svelte";
+    import { PlusIcon } from "@lucide/svelte";
+
+    interface Props {
+        value?: EmbeddingRegex[];
+    }
+
+    let { value = $bindable([]) }: Props = $props();
+    let stb: Sortable = null
+    let ele: HTMLDivElement = $state()
+    let sorted = $state(0)
+    let opened = 0
+    const createStb = () => {
+        stb = Sortable.create(ele, {
+            onEnd: async () => {
+                let idx:number[] = []
+                ele.querySelectorAll('[data-risu-idx]').forEach((e, i) => {
+                    idx.push(parseInt(e.getAttribute('data-risu-idx')))
+                })
+                let newValue:EmbeddingRegex[] = []
+                idx.forEach((i) => {
+                    newValue.push(value[i])
+                })
+                value = newValue
+                try {
+                    stb.destroy()
+                } catch (error) {}
+                sorted += 1
+                await sleep(1)
+                createStb()
+            },
+            ...sortableOptions
+        })
+    }
+
+    const onOpen = () => {
+        opened += 1
+        if(stb){
+            try {
+                stb.destroy()
+            } catch (error) {}
+        }
+    }
+    const onClose = () => {
+        opened -= 1
+        if(opened === 0){
+            createStb()
+        }
+    }
+
+    onMount(createStb)
+
+    onDestroy(() => {
+        if(stb){
+            try {
+                stb.destroy()
+            } catch (error) {}
+        }
+    })
+</script>
+{#key sorted}
+    <div class="contain w-full max-w-full mt-2 flex flex-col p-3 border-selected border-1 bg-darkbg rounded-md" bind:this={ele}>
+        {#if value.length === 0}
+                <div class="text-textcolor2">No Scripts</div>
+        {/if}
+        {#each value as entry, i}
+            <HypaV3EmbeddingRegexData idx={i} bind:value={value[i]} onOpen={onOpen} onClose={onClose} onRemove={() => {
+                let list = value
+                list.splice(i, 1)
+                value = list
+            }}/>
+        {/each}
+    </div>
+{/key}
+<div class="flex gap-2 mt-2">
+    <button class="rounded-md text-textcolor2 hover:text-textcolor focus-within:text-textcolor" onclick={() => {
+        value.push({
+            comment: "",
+            in: "",
+            out: "",
+            type: "disabled",
+            flag: "g",
+            ableFlag: false,
+        })
+    }}>
+        <PlusIcon />
+    </button>
+</div>

--- a/src/ts/process/memory/embeddingRegex.test.ts
+++ b/src/ts/process/memory/embeddingRegex.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { applyEmbeddingRegex, type EmbeddingRegex } from "./embeddingRegex";
+
+describe("applyEmbeddingRegex", () => {
+    it("applies enabled embedding regex scripts in order", () => {
+        const scripts: EmbeddingRegex[] = [
+            {
+                comment: "",
+                in: "secret",
+                out: "public",
+                type: "editembedding",
+                flag: "g",
+                ableFlag: true,
+            },
+            {
+                comment: "",
+                in: "public",
+                out: "visible",
+                type: "editembedding",
+                flag: "g",
+                ableFlag: true,
+            },
+        ];
+
+        expect(applyEmbeddingRegex("secret note", scripts)).toBe("visible note");
+    });
+
+    it("ignores disabled scripts and invalid patterns", () => {
+        const scripts: EmbeddingRegex[] = [
+            {
+                comment: "",
+                in: "secret",
+                out: "public",
+                type: "disabled",
+            },
+            {
+                comment: "",
+                in: "[",
+                out: "",
+                type: "editembedding",
+                flag: "g",
+                ableFlag: true,
+            },
+        ];
+
+        expect(applyEmbeddingRegex("secret note", scripts)).toBe("secret note");
+    });
+
+    it("defaults to global replacement when custom flags are disabled", () => {
+        const scripts: EmbeddingRegex[] = [
+            {
+                comment: "",
+                in: "secret",
+                out: "public",
+                type: "editembedding",
+                flag: "i",
+                ableFlag: false,
+            },
+        ];
+
+        expect(applyEmbeddingRegex("secret secret SECRET", scripts)).toBe(
+            "public public SECRET"
+        );
+    });
+});

--- a/src/ts/process/memory/embeddingRegex.ts
+++ b/src/ts/process/memory/embeddingRegex.ts
@@ -1,0 +1,33 @@
+export type EmbeddingRegexType = 'disabled' | 'editembedding'
+
+export interface EmbeddingRegex {
+    comment: string
+    in: string
+    out: string
+    type: EmbeddingRegexType
+    flag?: string
+    ableFlag?: boolean
+}
+
+const ALLOWED_FLAGS = /[^gimus]/g
+
+function normalizeFlag(raw: string | undefined, ableFlag: boolean | undefined): string {
+    if (!ableFlag) return 'g'
+    const cleaned = (raw ?? '').replace(ALLOWED_FLAGS, '')
+    const deduped = Array.from(new Set(cleaned)).join('')
+    return deduped.length > 0 ? deduped : 'g'
+}
+
+export function applyEmbeddingRegex(text: string, scripts: EmbeddingRegex[]): string {
+    let result = text
+    for (const script of scripts) {
+        if (script.type !== 'editembedding') continue
+        if (!script.in) continue
+        try {
+            const reg = new RegExp(script.in, normalizeFlag(script.flag, script.ableFlag))
+            result = result.replace(reg, script.out ?? '')
+        } catch {
+        }
+    }
+    return result
+}

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -20,6 +20,7 @@ import { chatCompletion, unloadEngine } from "../webllm";
 import { hypaV3ProgressStore } from "src/ts/stores.svelte";
 import { type ChatTokenizer } from "src/ts/tokenizer";
 import { inlayTokenRegex } from "src/ts/util/inlayTokens";
+import { applyEmbeddingRegex, type EmbeddingRegex } from "./embeddingRegex";
 
 export interface HypaV3Preset {
     name: string;
@@ -48,6 +49,7 @@ export interface HypaV3Settings {
     embeddingMaxConcurrent: number;
     alwaysToggleOn: boolean;
     queryChatCount: number;
+    embeddingRegex: EmbeddingRegex[];
 }
 
 interface HypaV3Data {
@@ -617,11 +619,14 @@ async function hypaMemoryV3MainExp(
                 const splitted = splitBySeparator(summary.text, settings.summaryChunkSeparator)
                     .filter((e) => e.trim().length > 0);
 
-                return splitted.map((chunk, chunkIndex) => ({
-                    id: `${summaryIndex}-${chunkIndex}`,
-                    content: chunk.trim(),
-                    metadata: summary,
-                }));
+                return splitted
+                    .map((chunk) => applyEmbeddingRegex(chunk.trim(), settings.embeddingRegex))
+                    .filter((filtered) => filtered.trim().length > 0)
+                    .map((filtered, chunkIndex) => ({
+                        id: `${summaryIndex}-${chunkIndex}`,
+                        content: filtered,
+                        metadata: summary,
+                    }));
             }
         );
 
@@ -1336,12 +1341,14 @@ async function hypaMemoryV3Main(
             const splitted = splitBySeparator(summary.text, settings.summaryChunkSeparator)
                 .filter((e) => e.trim().length > 0);
 
-            summaryChunks.push(
-                ...splitted.map((e) => ({
-                    text: e.trim(),
+            for (const raw of splitted) {
+                const filtered = applyEmbeddingRegex(raw.trim(), settings.embeddingRegex);
+                if (filtered.trim().length === 0) continue;
+                summaryChunks.push({
+                    text: filtered,
                     summary,
-                }))
-            );
+                });
+            }
         });
 
         // Initialize embedding processor
@@ -1809,6 +1816,7 @@ export function createHypaV3Preset(
         embeddingMaxConcurrent: 1,
         alwaysToggleOn: false,
         queryChatCount: 3,
+        embeddingRegex: [],
     };
 
     if (

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -20,6 +20,7 @@ import { chatCompletion, unloadEngine } from "../webllm";
 import { hypaV3ProgressStore } from "src/ts/stores.svelte";
 import { type ChatTokenizer } from "src/ts/tokenizer";
 import { inlayTokenRegex } from "src/ts/util/inlayTokens";
+import { applyEmbeddingRegex, type EmbeddingRegex } from "./embeddingRegex";
 
 export interface HypaV3Preset {
     name: string;
@@ -47,6 +48,7 @@ export interface HypaV3Settings {
     embeddingMaxConcurrent: number;
     alwaysToggleOn: boolean;
     queryChatCount: number;
+    embeddingRegex: EmbeddingRegex[];
 }
 
 interface HypaV3Data {
@@ -604,11 +606,14 @@ async function hypaMemoryV3MainExp(
                     .split("\n\n")
                     .filter((e) => e.trim().length > 0);
 
-                return splitted.map((chunk, chunkIndex) => ({
-                    id: `${summaryIndex}-${chunkIndex}`,
-                    content: chunk.trim(),
-                    metadata: summary,
-                }));
+                return splitted
+                    .map((chunk) => applyEmbeddingRegex(chunk.trim(), settings.embeddingRegex))
+                    .filter((filtered) => filtered.trim().length > 0)
+                    .map((filtered, chunkIndex) => ({
+                        id: `${summaryIndex}-${chunkIndex}`,
+                        content: filtered,
+                        metadata: summary,
+                    }));
             }
         );
 
@@ -1324,12 +1329,14 @@ async function hypaMemoryV3Main(
                 .split("\n\n")
                 .filter((e) => e.trim().length > 0);
 
-            summaryChunks.push(
-                ...splitted.map((e) => ({
-                    text: e.trim(),
+            for (const raw of splitted) {
+                const filtered = applyEmbeddingRegex(raw.trim(), settings.embeddingRegex);
+                if (filtered.trim().length === 0) continue;
+                summaryChunks.push({
+                    text: filtered,
                     summary,
-                }))
-            );
+                });
+            }
         });
 
         // Initialize embedding processor
@@ -1796,6 +1803,7 @@ export function createHypaV3Preset(
         embeddingMaxConcurrent: 1,
         alwaysToggleOn: false,
         queryChatCount: 3,
+        embeddingRegex: [],
     };
 
     if (


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Adds a preset-level list of regex scripts that transform HypaV3 summary chunks **before** they are embedded for similarity search. The summary text finally injected into the `<Past Events Summary>` block is not modified — only the embedding representation is.

Motivation: summarization prompts often produce repeated section prefixes like `Time and Place:` that appear in every chunk of every summary, dragging embedding vectors toward a shared noise direction and diluting similarity search signal. Removing them for embedding improves retrieval precision; keeping them for injection preserves the generation model's structural comprehension of the summary format.

Default value is `[]`, preserving existing behavior exactly.

## Related Issues

None.

## Changes

### New: `src/ts/process/memory/embeddingRegex.ts`
- `EmbeddingRegex` type and `EmbeddingRegexType` union (`'disabled' | 'editembedding'`)
- `applyEmbeddingRegex(text, scripts)` pure function — iterates the chain, skipping disabled/empty/malformed entries, and returns the filtered text
- `normalizeFlag` helper matching the existing `scripts.ts` engine: `ableFlag` off forces `'g'`; on runs through a `gimus` whitelist with dedup and `'g'` fallback

### Modified: `src/ts/process/memory/hypav3.ts`
- Added `embeddingRegex: EmbeddingRegex[]` field to `HypaV3Settings` interface
- Default `[]` in `createHypaV3Preset`; legacy presets pick up the default automatically via the existing DB migration loop
- Replaced the chunk-building logic at the two document-side embedding sites:
  - Standard path (`HypaProcesserEx`, `hypaMemoryV3Main`) — `forEach` + `for...of` + `continue` to skip empty-after-filter chunks
  - Experimental path (`HypaProcessorV2`, `hypaMemoryV3MainExp`) — `flatMap` with a filter stage for empty-after-filter chunks
- Query-side (`recentChats` sub-query split) intentionally left untouched — chat content is user input, not prompt-author-controlled, so the filter doesn't apply there

### New: `src/lib/SideBars/Scripts/HypaV3EmbeddingRegexData.svelte`, `HypaV3EmbeddingRegexList.svelte`
- Visual-parity fork of the existing `RegexData.svelte` / `RegexList.svelte` preset regex script editor
- Scope-narrowed: Modification Type dropdown has 2 options (`Disabled`, `Edit Embedding Request Data`), flag grid exposes the 5 JS flags (`g/i/m/u/s`), Order Flag and import/export buttons removed
- New entries default to `type: 'disabled'` so an accidentally-added empty entry is fail-safe

### Modified: `src/lib/Setting/Pages/OtherBotSettings.svelte`
- Added collapsible Accordion directly below the Re-summarization Prompt, embedding the new list component
- Uses the existing `language.regexScript` label with a new `hypaV3EmbeddingRegex` help tooltip

### `src/lang/en.ts`, `src/lang/ko.ts`
- Added `hypaV3EmbeddingRegex` help tooltip and `editEmbeddingRequestData` dropdown option label in both languages

## Impact

- **Existing users:** No change. Default `embeddingRegex: []` means the filter loop is a no-op and the chunk-building logic is byte-identical to prior behavior.
- **Prompt authors:** Can now strip noise prefixes (or any other pattern) from the embedding representation without affecting the injected summary text.
- **Both HypaV3 implementations:** Standard and experimental paths use the same `applyEmbeddingRegex` helper — identical filter behavior across modes.
- **Cache correctness:** Both embedding processors key on the actual text content, so changing a filter entry automatically invalidates affected cache entries on the next retrieval.

## Additional Notes

- The filter system is deliberately isolated from the global `customscript` / `ScriptMode` / `processScriptFull` pipeline. A dedicated `EmbeddingRegex` type, a pure-function evaluator, and forked UI components keep the new domain self-contained — it does not interact with preset regex scripts or character regex scripts, and changes to the global script engine won't affect it.
- Query-side splitting was deliberately not filtered. The filter is a tool for prompt authors to align embedding representation with their summary output format; user chat turns are outside the prompt author's control.
- Empty-after-filter chunks are dropped rather than falling back to the unfiltered text. If a user configures an aggressive filter that erases whole chunks, that's considered user responsibility — other memory tiers (Recent/Random/Important) still populate the memory block.