### PR TITLE
feat(alert): include environment metadata in error details 

### DIFF
--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -26,41 +26,22 @@
     import { getChatBranches } from "src/ts/gui/branches";
     import { getCurrentCharacter } from "src/ts/storage/database.svelte";
     import { translateStackTrace } from "../../ts/sourcemap";
-    import { isIOS, isNodeServer, isTauri } from "src/ts/platform";
+    import { getDetailedOSLabel, getFallbackOSLabel, getRisuEnvironmentLabel } from "src/ts/platform";
     import versionData from "../../../version.json";
 
     let showDetails = $state(false);
     let translatedStackTrace = $state('');
     let stackTraceTranslationFailed = $state(false);
     let isTranslating = $state(false);
+    let osLabel = $state(getFallbackOSLabel());
     const displayedStackTrace = $derived(translatedStackTrace || $alertStore.stackTrace || '');
     const risuVersion = versionData.version;
-    const risuEnvironment = isTauri ? "local" : isNodeServer ? "node" : "web";
+    const risuEnvironment = getRisuEnvironmentLabel();
     const userAgent = typeof navigator === "undefined" ? "Unknown" : navigator.userAgent || "Unknown";
-
-    function getOSName() {
-        if (typeof navigator === "undefined") {
-            return "Unknown";
-        }
-
-        const ua = navigator.userAgent || "";
-        const platform = navigator.platform || "";
-
-        if (/Windows/i.test(ua)) return "Windows";
-        if (/Android/i.test(ua)) return "Android";
-        if (isIOS()) return "iOS";
-        if (/CrOS/i.test(ua)) return "ChromeOS";
-        if (/Mac/i.test(platform) || /Mac OS X/i.test(ua)) return "macOS";
-        if (/Linux/i.test(platform) || /Linux/i.test(ua)) return "Linux";
-
-        return platform || "Unknown";
-    }
-
-    const osName = getOSName();
     const stackTraceCodeBlock = $derived.by(() => {
         const lines = [
             `Risu version: ${risuVersion}`,
-            `OS: ${osName}`,
+            `OS: ${osLabel}`,
             `User-Agent: ${userAgent}`,
             `Risu environment: ${risuEnvironment}`
         ]
@@ -98,6 +79,10 @@
         hljs.registerLanguage('json', json)
     }
 
+    $effect(() => {
+        void loadDetailedOSLabel();
+    });
+
     function highlightJson(code: string): string {
         try {
             return hljs.highlight(code, { language: 'json' }).value
@@ -123,6 +108,15 @@
             if (copiedKey === key) copiedKey = null
         }, 1500)
     }
+
+    async function loadDetailedOSLabel() {
+        try {
+            osLabel = await getDetailedOSLabel();
+        } catch (error) {
+            console.warn("Failed to load detailed OS information:", error);
+        }
+    }
+
     $effect.pre(() => {
         showDetails = false;
         translatedStackTrace = '';

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -26,6 +26,7 @@
     import { getChatBranches } from "src/ts/gui/branches";
     import { getCurrentCharacter } from "src/ts/storage/database.svelte";
     import { translateStackTrace } from "../../ts/sourcemap";
+    import { isIOS, isNodeServer, isTauri } from "src/ts/platform";
     import versionData from "../../../version.json";
 
     let showDetails = $state(false);
@@ -34,8 +35,35 @@
     let isTranslating = $state(false);
     const displayedStackTrace = $derived(translatedStackTrace || $alertStore.stackTrace || '');
     const risuVersion = versionData.version;
+    const risuEnvironment = isTauri ? "local" : isNodeServer ? "node" : "web";
+    const userAgent = typeof navigator === "undefined" ? "Unknown" : navigator.userAgent || "Unknown";
+
+    function getOSName() {
+        if (typeof navigator === "undefined") {
+            return "Unknown";
+        }
+
+        const ua = navigator.userAgent || "";
+        const platform = navigator.platform || "";
+
+        if (/Windows/i.test(ua)) return "Windows";
+        if (/Android/i.test(ua)) return "Android";
+        if (isIOS()) return "iOS";
+        if (/CrOS/i.test(ua)) return "ChromeOS";
+        if (/Mac/i.test(platform) || /Mac OS X/i.test(ua)) return "macOS";
+        if (/Linux/i.test(platform) || /Linux/i.test(ua)) return "Linux";
+
+        return platform || "Unknown";
+    }
+
+    const osName = getOSName();
     const stackTraceCodeBlock = $derived.by(() => {
-        const lines = [`Risu version: ${risuVersion}`]
+        const lines = [
+            `Risu version: ${risuVersion}`,
+            `OS: ${osName}`,
+            `User-Agent: ${userAgent}`,
+            `Risu environment: ${risuEnvironment}`
+        ]
 
         if (stackTraceTranslationFailed) {
             lines.push(language.stackTraceTranslationFailed)

--- a/src/ts/platform.ts
+++ b/src/ts/platform.ts
@@ -1,23 +1,155 @@
+import * as tauriOs from "@tauri-apps/plugin-os";
+
+type UserAgentDataLike = {
+    platform?: string
+    getHighEntropyValues?: (hints: string[]) => Promise<{
+        platformVersion?: string
+    }>
+}
+
+type BrowserNavigator = Navigator & {
+    userAgentData?: UserAgentDataLike
+    standalone?: boolean
+}
+
+export type RisuEnvironmentLabel = "local" | "node" | "web" | "web(dev)"
+
+const browserNavigator = navigator as BrowserNavigator
+
 export const isTauri: boolean = !!(window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
 export const isNodeServer: boolean = !!(globalThis as typeof globalThis & { __NODE__?: boolean }).__NODE__
 export const isWeb: boolean = !isTauri && !isNodeServer && location.hostname === 'risuai.xyz'
-export const isMobile: boolean = /Android|iPhone|iPad|iPod|webOS/i.test(navigator.userAgent);
+export const isMobile: boolean = /Android|iPhone|iPad|iPod|webOS/i.test(browserNavigator.userAgent);
 
-export const isFirefox: boolean = navigator.userAgent.includes("Firefox")
+export const isFirefox: boolean = browserNavigator.userAgent.includes("Firefox")
+
+function normalizeOSVersion(version?: string | null): string | null {
+    if (!version) {
+        return null
+    }
+
+    const normalized = version.trim().replace(/_/g, ".")
+    return normalized && normalized !== "0.0.0" ? normalized : null
+}
+
+function formatOSName(osName: string): string {
+    switch (osName.toLowerCase()) {
+        case "macos":
+            return "macOS"
+        case "ios":
+            return "iOS"
+        case "windows":
+            return "Windows"
+        case "android":
+            return "Android"
+        case "linux":
+            return "Linux"
+        case "chromeos":
+            return "ChromeOS"
+        default:
+            return osName
+    }
+}
+
+function joinOSLabel(osName: string, version: string | null): string {
+    return version ? `${osName} ${version}` : osName
+}
 
 export function isIOS(): boolean {
-  if (typeof navigator === 'undefined') return false;
+    const ua = browserNavigator.userAgent || ''
+    const isAppleMobile = /iPad|iPhone|iPod/.test(ua)
 
-  const ua = navigator.userAgent || '';
-  const isAppleMobile = /iPad|iPhone|iPod/.test(ua);
+    // iPadOS 13+
+    const isIpadOS = browserNavigator.platform === 'MacIntel' && browserNavigator.maxTouchPoints > 1
 
-  // iPadOS 13+
-  const isIpadOS = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+    return isAppleMobile || isIpadOS
+}
 
-  return isAppleMobile || isIpadOS;
+function getBrowserOSName(): string {
+    const uaPlatform = browserNavigator.userAgentData?.platform
+    if (uaPlatform) {
+        return formatOSName(uaPlatform)
+    }
+
+    const ua = browserNavigator.userAgent || ""
+    const platform = browserNavigator.platform || ""
+
+    if (/Windows/i.test(ua)) return "Windows"
+    if (/Android/i.test(ua)) return "Android"
+    if (isIOS()) return "iOS"
+    if (/CrOS/i.test(ua)) return "ChromeOS"
+    if (/Mac/i.test(platform) || /Mac OS X/i.test(ua)) return "macOS"
+    if (/Linux/i.test(platform) || /Linux/i.test(ua)) return "Linux"
+
+    return platform || "Unknown"
+}
+
+function getUserAgentOSVersion(osName: string): string | null {
+    const ua = browserNavigator.userAgent || ""
+
+    switch (osName) {
+        case "Android":
+            return normalizeOSVersion(ua.match(/Android ([\d.]+)/i)?.[1])
+        case "iOS":
+            return normalizeOSVersion(ua.match(/(?:CPU (?:iPhone )?OS|iPhone OS|CPU OS) ([\d_]+)/i)?.[1])
+        case "ChromeOS":
+            return normalizeOSVersion(ua.match(/CrOS [^ ]+ ([\d.]+)/i)?.[1])
+        case "Windows": {
+            const windowsVersion = normalizeOSVersion(ua.match(/Windows NT ([\d.]+)/i)?.[1])
+            return windowsVersion ? `NT ${windowsVersion}` : null
+        }
+        default:
+            return null
+    }
+}
+
+async function getBrowserHighEntropyOSVersion(): Promise<string | null> {
+    try {
+        const values = await browserNavigator.userAgentData?.getHighEntropyValues?.(["platformVersion"])
+        return normalizeOSVersion(values?.platformVersion)
+    } catch (error) {
+        console.warn("Failed to read browser platformVersion:", error)
+        return null
+    }
+}
+
+export function getRisuEnvironmentLabel(): RisuEnvironmentLabel {
+    if (isTauri) {
+        return "local"
+    }
+
+    if (import.meta.env.DEV) {
+        return "web(dev)"
+    }
+
+    if (isNodeServer) {
+        return "node"
+    }
+
+    return "web"
+}
+
+export function getFallbackOSLabel(): string {
+    const osName = getBrowserOSName()
+    return joinOSLabel(osName, getUserAgentOSVersion(osName))
+}
+
+export async function getDetailedOSLabel(): Promise<string> {
+    if (isTauri) {
+        try {
+            return joinOSLabel(formatOSName(tauriOs.type()), normalizeOSVersion(tauriOs.version()))
+        } catch (error) {
+            console.warn("Failed to read native OS details:", error)
+        }
+    }
+
+    const osName = getBrowserOSName()
+    const browserVersion = await getBrowserHighEntropyOSVersion()
+
+    return joinOSLabel(osName, browserVersion ?? getUserAgentOSVersion(osName))
 }
 
 export const isInStandaloneMode =
     window.matchMedia("(display-mode: standalone)").matches ||
-    !!(navigator as any).standalone ||
+    !!browserNavigator.standalone ||
     document.referrer.includes("android-app://");


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This PR makes the error details alert more useful when someone reports a crash or shares a stack trace. The code block now includes the user's OS, user agent, and the Risu runtime environment right below the Risu version line. When the runtime can provide it, the OS line also includes a more specific version instead of just the OS name.

## Related Issues

None

## Changes

- Added `OS`, `User-Agent`, and `Risu environment` to the existing error details block in `AlertComp.svelte`, directly under the Risu version line.
- Moved the environment detection logic into shared helpers in `src/ts/platform.ts` so the alert component can use one consistent source of truth.
- Added a browser-side fallback for OS detection, with richer version info from `navigator.userAgentData` when the browser exposes it.
- Added native OS version support for the Tauri build through `@tauri-apps/plugin-os`.
- Updated the runtime label so Vite dev sessions show up as `web(dev)` instead of being confused with node-hosted environments.

## Impact

This should be low risk because it only changes the metadata shown in error alerts. Normal chat and settings flows should not be affected. The main limitation is that browser-hosted sessions may still expose only partial OS version information, depending on the browser's privacy restrictions.

## Additional Notes

- Checked with `pnpm test`, `pnpm build`, and `pnpm check`.

| Preview |
|---------|
| <img width="1237" height="589" alt="more-metadata-error" src="https://github.com/user-attachments/assets/7d066da9-fd78-4cc9-93a6-72e9c1d11dee" /> |