### PR TITLE
feat: add HypaV3 preset to Loadout system

### DIFF
--- a/src/lib/Others/LoadoutModal.svelte
+++ b/src/lib/Others/LoadoutModal.svelte
@@ -66,7 +66,7 @@
     }
 
     function onSelect(loadout: Loadout) {
-        const apply = (Object.keys(loadOptions) as LoadoutApplyOption[]).filter(k => loadOptions[k]);
+        const apply = (Object.keys(loadOptions) as LoadoutApplyOption[]).filter(k => loadOptions[k] && (k !== 'hypaV3Preset' || DBState.db.hypaV3));
         applyLoadout(loadout, apply);
         close();
     }
@@ -115,7 +115,7 @@
                         ></span
                     >
                 {/if}
-                {#if loadout.hypaV3PresetName}
+                {#if DBState.db.hypaV3 && loadout.hypaV3PresetName}
                     <span
                         >HypaV3: <span class="text-textcolor/60"
                             >{loadout.hypaV3PresetName}</span
@@ -180,14 +180,16 @@
             <span class="text-xs text-textcolor/40 uppercase tracking-wider font-medium mr-1">Load:</span>
             {#each Object.keys(loadOptions) as key}
                 {@const k = key as LoadoutApplyOption}
-                <button
-                    class="px-2.5 py-1 rounded text-xs font-medium transition-colors {loadOptions[k]
-                        ? 'bg-textcolor/15 text-textcolor/90'
-                        : 'bg-textcolor/5 text-textcolor/30 hover:bg-textcolor/10 hover:text-textcolor/50'}"
-                    onclick={() => loadOptions[k] = !loadOptions[k]}
-                >
-                    {loadOptionLabels[k]}
-                </button>
+                {#if k !== 'hypaV3Preset' || DBState.db.hypaV3}
+                    <button
+                        class="px-2.5 py-1 rounded text-xs font-medium transition-colors {loadOptions[k]
+                            ? 'bg-textcolor/15 text-textcolor/90'
+                            : 'bg-textcolor/5 text-textcolor/30 hover:bg-textcolor/10 hover:text-textcolor/50'}"
+                        onclick={() => loadOptions[k] = !loadOptions[k]}
+                    >
+                        {loadOptionLabels[k]}
+                    </button>
+                {/if}
             {/each}
         </div>
 

--- a/src/lib/Others/LoadoutModal.svelte
+++ b/src/lib/Others/LoadoutModal.svelte
@@ -13,13 +13,14 @@
     import { applyLoadout, saveCurrentLoadout, type Loadout } from "src/ts/loadout";
     import { getCurrentCharacter } from "src/ts/storage/database.svelte";
 
-    type LoadoutApplyOption = 'modules' | 'globalVariables' | 'preset' | 'persona';
+    type LoadoutApplyOption = 'modules' | 'globalVariables' | 'preset' | 'persona' | 'hypaV3Preset';
 
     let loadOptions: Record<LoadoutApplyOption, boolean> = $state({
         modules: true,
         globalVariables: true,
         preset: true,
         persona: true,
+        hypaV3Preset: true,
     });
 
     const loadOptionLabels: Record<LoadoutApplyOption, string> = {
@@ -27,6 +28,7 @@
         globalVariables: 'Global Variables',
         preset: 'Preset',
         persona: 'Persona',
+        hypaV3Preset: 'HypaV3 Preset',
     };
 
     let saveName = $state('');
@@ -109,7 +111,14 @@
                 {#if loadout.presetName}
                     <span
                         >Preset: <span class="text-textcolor/60"
-                            >{loadout.presetName}</span 
+                            >{loadout.presetName}</span
+                        ></span
+                    >
+                {/if}
+                {#if loadout.hypaV3PresetName}
+                    <span
+                        >HypaV3: <span class="text-textcolor/60"
+                            >{loadout.hypaV3PresetName}</span
                         ></span
                     >
                 {/if}

--- a/src/ts/loadout.test.ts
+++ b/src/ts/loadout.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./persona", () => ({
+    changeUserPersona: vi.fn(),
+}));
+
+vi.mock("./storage/database.svelte", () => ({
+    changeToPreset: vi.fn(),
+    getCurrentCharacter: vi.fn(() => ({
+        chaId: "character-1",
+        image: "character-image",
+    })),
+}));
+
+vi.mock("./stores.svelte", () => ({
+    DBState: {
+        db: {},
+    },
+}));
+
+import { applyLoadout, makeLoadout, type Loadout } from "./loadout";
+import { DBState } from "./stores.svelte";
+
+function resetDb(hypaV3: boolean) {
+    DBState.db = {
+        botPresets: [{ name: "Bot Preset" }],
+        botPresetsId: 0,
+        personas: [{ id: "persona-1" }],
+        selectedPersona: 0,
+        enabledModules: ["module-1"],
+        globalChatVariables: { key: "value" },
+        hypaV3,
+        hypaV3Presets: [
+            { name: "Default", settings: {} },
+            { name: "Detailed", settings: {} },
+        ],
+        hypaV3PresetId: 1,
+        loadouts: [],
+        lastLoadedLoadoutName: "",
+    } as any;
+}
+
+function makeTestLoadout(hypaV3PresetName: string): Loadout {
+    return {
+        name: "Loadout",
+        id: "loadout-1",
+        lastUsed: 0,
+        favorite: false,
+        characterIds: [],
+        modules: [],
+        globalVariables: {},
+        presetName: "",
+        personaId: "",
+        icons: [],
+        hypaV3PresetName,
+    };
+}
+
+describe("Loadout HypaV3 preset handling", () => {
+    beforeEach(() => {
+        (globalThis as any).safeStructuredClone = structuredClone;
+    });
+
+    it("does not store a HypaV3 preset name when HypaV3 memory is disabled", () => {
+        resetDb(false);
+
+        const loadout = makeLoadout({ name: "Loadout" });
+
+        expect(loadout.hypaV3PresetName).toBe("");
+    });
+
+    it("does not apply a HypaV3 preset when HypaV3 memory is disabled", () => {
+        resetDb(false);
+
+        applyLoadout(makeTestLoadout("Default"), ["hypaV3Preset"]);
+
+        expect(DBState.db.hypaV3PresetId).toBe(1);
+    });
+
+    it("stores and applies the selected HypaV3 preset when HypaV3 memory is enabled", () => {
+        resetDb(true);
+
+        const loadout = makeLoadout({ name: "Loadout" });
+        expect(loadout.hypaV3PresetName).toBe("Detailed");
+
+        DBState.db.hypaV3PresetId = 0;
+        applyLoadout(makeTestLoadout("Detailed"), ["hypaV3Preset"]);
+
+        expect(DBState.db.hypaV3PresetId).toBe(1);
+    });
+});

--- a/src/ts/loadout.ts
+++ b/src/ts/loadout.ts
@@ -74,7 +74,7 @@ export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     }
     if(apply.includes('hypaV3Preset')) {
         let presetIndex = DBState.db.hypaV3Presets?.findIndex(p => p.name === loadout.hypaV3PresetName)
-        if(presetIndex !== -1){
+        if(presetIndex >= 0){
             DBState.db.hypaV3PresetId = presetIndex
         }
     }

--- a/src/ts/loadout.ts
+++ b/src/ts/loadout.ts
@@ -39,7 +39,7 @@ export function makeLoadout(options:{
         presetName: preset.name ?? '',
         personaId: DBState.db.personas[DBState.db.selectedPersona]?.id,
         icons: icons,
-        hypaV3PresetName: DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.name ?? ''
+        hypaV3PresetName: DBState.db.hypaV3 ? DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.name ?? '' : ''
     });
 }
 
@@ -72,7 +72,7 @@ export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     if(apply.includes('globalVariables')) {
         DBState.db.globalChatVariables = loadout.globalVariables
     }
-    if(apply.includes('hypaV3Preset')) {
+    if(DBState.db.hypaV3 && apply.includes('hypaV3Preset')) {
         let presetIndex = DBState.db.hypaV3Presets?.findIndex(p => p.name === loadout.hypaV3PresetName)
         if(presetIndex >= 0){
             DBState.db.hypaV3PresetId = presetIndex

--- a/src/ts/loadout.ts
+++ b/src/ts/loadout.ts
@@ -13,6 +13,7 @@ export type Loadout = {
     presetName: string
     personaId: string
     icons?:string[]
+    hypaV3PresetName: string
 }
 
 export function makeLoadout(options:{
@@ -37,17 +38,19 @@ export function makeLoadout(options:{
         globalVariables: DBState.db.globalChatVariables,
         presetName: preset.name ?? '',
         personaId: DBState.db.personas[DBState.db.selectedPersona]?.id,
-        icons: icons
+        icons: icons,
+        hypaV3PresetName: DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.name ?? ''
     });
 }
 
-type LoadoutApplyOption = 'modules' | 'globalVariables' | 'preset' | 'persona'
+type LoadoutApplyOption = 'modules' | 'globalVariables' | 'preset' | 'persona' | 'hypaV3Preset'
 
 export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     'modules',
     'globalVariables',
     'preset',
-    'persona'
+    'persona',
+    'hypaV3Preset'
 ]) {
     loadout.lastUsed = Date.now()
     loadout.characterIds.push(getCurrentCharacter()?.chaId)
@@ -68,6 +71,12 @@ export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     }
     if(apply.includes('globalVariables')) {
         DBState.db.globalChatVariables = loadout.globalVariables
+    }
+    if(apply.includes('hypaV3Preset')) {
+        let presetIndex = DBState.db.hypaV3Presets?.findIndex(p => p.name === loadout.hypaV3PresetName)
+        if(presetIndex !== -1){
+            DBState.db.hypaV3PresetId = presetIndex
+        }
     }
     DBState.db.lastLoadedLoadoutName = loadout.name
 }

--- a/src/ts/loadout.ts
+++ b/src/ts/loadout.ts
@@ -66,7 +66,7 @@ export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     }
     if(apply.includes('hypaV3Preset')) {
         let presetIndex = DBState.db.hypaV3Presets?.findIndex(p => p.name === loadout.hypaV3PresetName)
-        if(presetIndex !== -1){
+        if(presetIndex >= 0){
             DBState.db.hypaV3PresetId = presetIndex
         }
     }

--- a/src/ts/loadout.ts
+++ b/src/ts/loadout.ts
@@ -12,6 +12,7 @@ export type Loadout = {
     globalVariables: {[key:string]:string}
     presetName: string
     personaId: string
+    hypaV3PresetName: string
 }
 
 export function makeLoadout(options:{
@@ -29,17 +30,19 @@ export function makeLoadout(options:{
         modules: DBState.db.enabledModules,
         globalVariables: DBState.db.globalChatVariables,
         presetName: preset.name ?? '',
-        personaId: DBState.db.personas[DBState.db.selectedPersona]?.id
+        personaId: DBState.db.personas[DBState.db.selectedPersona]?.id,
+        hypaV3PresetName: DBState.db.hypaV3Presets?.[DBState.db.hypaV3PresetId]?.name ?? ''
     });
 }
 
-type LoadoutApplyOption = 'modules' | 'globalVariables' | 'preset' | 'persona'
+type LoadoutApplyOption = 'modules' | 'globalVariables' | 'preset' | 'persona' | 'hypaV3Preset'
 
 export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     'modules',
     'globalVariables',
     'preset',
-    'persona'
+    'persona',
+    'hypaV3Preset'
 ]) {
     loadout.lastUsed = Date.now()
     loadout.characterIds.push(getCurrentCharacter()?.chaId)
@@ -60,6 +63,12 @@ export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     }
     if(apply.includes('globalVariables')) {
         DBState.db.globalChatVariables = loadout.globalVariables
+    }
+    if(apply.includes('hypaV3Preset')) {
+        let presetIndex = DBState.db.hypaV3Presets?.findIndex(p => p.name === loadout.hypaV3PresetName)
+        if(presetIndex !== -1){
+            DBState.db.hypaV3PresetId = presetIndex
+        }
     }
 }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Adds HypaV3 preset support to the Loadout system. Previously, saving/loading a Loadout only captured Bot Preset, Persona, Modules, and Global Variables, so users who switch between different HypaV3 configurations had to manually re-select the active HypaV3 preset.

The HypaV3 preset is now captured and restored only when the current long-term memory mode is HypaMemory V3. This avoids storing or showing a misleading default HypaV3 preset on Loadouts created while another memory mode is selected.

## Related Issues

None.

## Changes

**src/ts/loadout.ts**
- Added hypaV3PresetName field to Loadout
- Capture the selected HypaV3 preset name only when HypaMemory V3 is enabled
- Added hypaV3Preset to LoadoutApplyOption
- Restore the HypaV3 preset by name only when HypaMemory V3 is enabled
- Kept the preset lookup guarded so missing or deleted presets no-op safely

**src/lib/Others/LoadoutModal.svelte**
- Added a HypaV3 Preset load toggle only when HypaMemory V3 is enabled
- Display the saved HypaV3 preset name only when HypaMemory V3 is enabled
- Exclude HypaV3 preset restoration from the apply list when HypaMemory V3 is disabled

**src/ts/loadout.test.ts**
- Covers that HypaV3 preset names are not stored or applied when HypaMemory V3 is disabled
- Covers that the selected HypaV3 preset is stored and restored when HypaMemory V3 is enabled

## Validation

- pnpm vitest run src/ts/loadout.test.ts
- pnpm check
- pnpm test
- pnpm build