### PR TITLE
fix: prevent Loadout crash when referenced preset or persona is missing

### DIFF
--- a/src/ts/loadout.ts
+++ b/src/ts/loadout.ts
@@ -19,7 +19,7 @@ export function makeLoadout(options:{
 }): Loadout {
     const character = getCurrentCharacter()
     const id = crypto.randomUUID()
-    const preset = DBState.db.botPresets[DBState.db.botPresetsId]
+    const preset = DBState.db.botPresets?.[DBState.db.botPresetsId]
     return safeStructuredClone({
         name: options.name,
         id: id,
@@ -28,7 +28,7 @@ export function makeLoadout(options:{
         characterIds: character ? [character.chaId] : [],
         modules: DBState.db.enabledModules,
         globalVariables: DBState.db.globalChatVariables,
-        presetName: preset.name ?? '',
+        presetName: preset?.name ?? '',
         personaId: DBState.db.personas[DBState.db.selectedPersona]?.id
     });
 }
@@ -42,16 +42,19 @@ export function applyLoadout(loadout: Loadout, apply:LoadoutApplyOption[] = [
     'persona'
 ]) {
     loadout.lastUsed = Date.now()
-    loadout.characterIds.push(getCurrentCharacter()?.chaId)
+    const chaId = getCurrentCharacter()?.chaId
+    if(chaId){
+        loadout.characterIds.push(chaId)
+    }
     if(apply.includes('persona')) {
         let personaIndex = DBState.db.personas?.findIndex(p => p.id === loadout.personaId)
-        if(personaIndex !== -1){
+        if(personaIndex >= 0){
             changeUserPersona(personaIndex)
         }
     }
     if(apply.includes('preset')) {
         let presetIndex = DBState.db.botPresets?.findIndex(p => p.name === loadout.presetName)
-        if(presetIndex !== -1){
+        if(presetIndex >= 0){
             changeToPreset(presetIndex)
         }
     }

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1941,7 +1941,7 @@ export function saveCurrentPreset(){
     let db = DBState.db
     let pres = db.botPresets
 
-    if(db.botPresetsId === -1){
+    if(db.botPresetsId < 0 || !pres?.[db.botPresetsId]){
         return
     }
     const savedPreset:botPreset =  {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Fixes multiple crash paths in the Loadout system when a saved Loadout references a preset or persona that has since been deleted. The existing `!== -1` guards did not account for `undefined` returned by optional chaining on `findIndex`, allowing downstream functions (`changeToPreset`, `changeUserPersona`, `saveCurrentPreset`) to receive invalid indices and crash on property access.

## Related Issues

None (reported via user feedback).

## Changes

**`src/ts/loadout.ts`**
- Guard `botPresets` access in `makeLoadout` with optional chaining to prevent crash when `botPresetsId` is out of bounds
- Prevent `undefined` from being pushed into `characterIds` when no character is active
- Replace `!== -1` with `>= 0` for both persona and preset `findIndex` results, blocking `undefined` from passing the guard

**`src/ts/storage/database.svelte.ts`**
- Strengthen `saveCurrentPreset` early return: `=== -1` → `< 0 || !pres?.[db.botPresetsId]`, covering both negative indices and out-of-bounds access after preset deletion

## Impact

- All changes only affect error paths (missing/deleted presets or personas). Normal operation where presets and personas exist is byte-identical to prior behavior.
- `saveCurrentPreset` early return skips saving a nonexistent preset but does not block the subsequent preset switch or download.
- Existing Loadouts with `undefined` entries in `characterIds` are unaffected — the fix only prevents future pollution.