### PR TITLE
feat: enhance popup editor with dynamic language support and update T…

### DIFF
--- a/src/lib/Others/PopupEditor.svelte
+++ b/src/lib/Others/PopupEditor.svelte
@@ -8,7 +8,7 @@
     import Toggles from '../SideBars/Toggles.svelte';
     import { getCurrentCharacter } from 'src/ts/storage/database.svelte';
 
-    let languageMode = $state(popUpEditorStore.language !== 'risulanguage' ? popUpEditorStore.language : 'markdown');
+    let languageMode = $state(popUpEditorStore.language || 'markdown');
     let previewing = $state(false);
     let tokens = $state(0);
     let MonacoComponent: (typeof MonacoEditorType)|null = $state(null)
@@ -60,7 +60,7 @@
          <div class="flex items-center justify-between">
             <h2 class="text-xl font-bold">Popup Editor</h2>
             <div class="flex items-center gap-2">
-                {#if popUpEditorStore.language === 'risulanguage'}
+                {#if ['markdown', 'cbs'].includes(languageMode)}
                     {#if !previewing}
                         <select
                             bind:value={languageMode}

--- a/src/lib/Others/PopupEditor.svelte
+++ b/src/lib/Others/PopupEditor.svelte
@@ -8,7 +8,7 @@
     import Toggles from '../SideBars/Toggles.svelte';
     import { getCurrentCharacter } from 'src/ts/storage/database.svelte';
 
-    let languageMode = $state('markdown');
+    let languageMode = $state(popUpEditorStore.language || 'markdown');
     let previewing = $state(false);
     let tokens = $state(0);
     let MonacoComponent: (typeof MonacoEditorType)|null = $state(null)
@@ -60,21 +60,25 @@
          <div class="flex items-center justify-between">
             <h2 class="text-xl font-bold">Popup Editor</h2>
             <div class="flex items-center gap-2">
-                {#if !previewing}
-                    <select
-                        bind:value={languageMode}
-                        class="bg-bgcolor border-none rounded px-2 py-1 text-sm"
+                {#if languageMode !== 'lua'}
+                    {#if !previewing}
+                        <select
+                            bind:value={languageMode}
+                            class="bg-bgcolor border-none rounded px-2 py-1 text-sm"
+                        >
+                            <option value="markdown">Markdown</option>
+                            <option value="cbs" disabled>CBS</option>
+                        </select>
+                    {/if}
+                    <button
+                        class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 transition"
+                        onclick={() => (previewing = !previewing)}
                     >
-                        <option value="markdown">Markdown</option>
-                        <option value="cbs" disabled>CBS</option>
-                    </select>
+                        {previewing ? language.edit : language.preview}
+                    </button>
+                {:else}
+                    <span class="bg-bgcolor border-none rounded px-2 py-1 text-sm">Lua</span>
                 {/if}
-                <button
-                    class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 transition"
-                    onclick={() => (previewing = !previewing)}
-                >
-                    {previewing ? language.edit : language.preview}
-                </button>
                 <button
                     class="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 transition"
                     onclick={() => (popUpEditorStore.open = false)}

--- a/src/lib/Others/PopupEditor.svelte
+++ b/src/lib/Others/PopupEditor.svelte
@@ -8,7 +8,7 @@
     import Toggles from '../SideBars/Toggles.svelte';
     import { getCurrentCharacter } from 'src/ts/storage/database.svelte';
 
-    let languageMode = $state(popUpEditorStore.language || 'markdown');
+    let languageMode = $state(popUpEditorStore.language !== 'risulanguage' ? popUpEditorStore.language : 'markdown');
     let previewing = $state(false);
     let tokens = $state(0);
     let MonacoComponent: (typeof MonacoEditorType)|null = $state(null)
@@ -60,7 +60,7 @@
          <div class="flex items-center justify-between">
             <h2 class="text-xl font-bold">Popup Editor</h2>
             <div class="flex items-center gap-2">
-                {#if languageMode !== 'lua'}
+                {#if popUpEditorStore.language === 'risulanguage'}
                     {#if !previewing}
                         <select
                             bind:value={languageMode}
@@ -77,7 +77,7 @@
                         {previewing ? language.edit : language.preview}
                     </button>
                 {:else}
-                    <span class="bg-bgcolor border-none rounded px-2 py-1 text-sm">Lua</span>
+                    <span class="bg-bgcolor border-none rounded px-2 py-1 text-sm">{languageMode}</span>
                 {/if}
                 <button
                     class="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 transition"

--- a/src/lib/SideBars/Scripts/TriggerList.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList.svelte
@@ -86,7 +86,7 @@
     <span class="text-draculared">{language.triggerV1Warning}</span>
 {/if}
 {#if value?.[0]?.effect?.[0]?.type === 'triggerlua'}
-    <TextAreaInput margin="both" autocomplete="off" bind:value={value[0].effect[0].code}></TextAreaInput>
+    <TextAreaInput margin="both" autocomplete="off" bind:value={value[0].effect[0].code} popupLanguage="lua"></TextAreaInput>
     <Button onclick={() => {
         openURL(hubURL + '/redirect/docs/lua')
     }}>{language.helpBlock}</Button>

--- a/src/lib/UI/GUI/TextAreaInput.svelte
+++ b/src/lib/UI/GUI/TextAreaInput.svelte
@@ -177,7 +177,7 @@
         optimaizedInput = true,
         highlight = false,
         onchange = () => {},
-        popupLanguage = 'risulanguage'
+        popupLanguage = 'markdown'
     }: Props = $props();
     let selectingAutoComplete = $state(0)
     // TODO: Review if highlight prop can change dynamically - if so, this needs to be reactive

--- a/src/lib/UI/GUI/TextAreaInput.svelte
+++ b/src/lib/UI/GUI/TextAreaInput.svelte
@@ -177,7 +177,7 @@
         optimaizedInput = true,
         highlight = false,
         onchange = () => {},
-        popupLanguage = 'markdown'
+        popupLanguage = 'risulanguage'
     }: Props = $props();
     let selectingAutoComplete = $state(0)
     // TODO: Review if highlight prop can change dynamically - if so, this needs to be reactive

--- a/src/lib/UI/GUI/TextAreaInput.svelte
+++ b/src/lib/UI/GUI/TextAreaInput.svelte
@@ -75,6 +75,7 @@
                     e.preventDefault()
                     popUpEditorStore.value = value
                     popUpEditorStore.mode = 'default'
+                    popUpEditorStore.language = popupLanguage
                     popUpEditorStore.open = true
 
                     //lazy wait
@@ -92,6 +93,7 @@
                     e.preventDefault()
                     popUpEditorStore.value = value
                     popUpEditorStore.mode = 'default'
+                    popUpEditorStore.language = popupLanguage
                     popUpEditorStore.open = true
 
                     //lazy wait
@@ -157,6 +159,7 @@
         optimaizedInput?: boolean;
         highlight?: boolean;
         onchange?: () => void;
+        popupLanguage?: string;
     }
 
     let {
@@ -173,7 +176,8 @@
         className = '',
         optimaizedInput = true,
         highlight = false,
-        onchange = () => {}
+        onchange = () => {},
+        popupLanguage = 'markdown'
     }: Props = $props();
     let selectingAutoComplete = $state(0)
     // TODO: Review if highlight prop can change dynamically - if so, this needs to be reactive

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -151,7 +151,7 @@ export const popUpEditorStore = $state({
     open: false,
     value: '',
     mode: 'default' as 'default',
-    language: 'markdown' as string
+    language: 'risulanguage' as string
 })
 
 export const loadoutModalStore = $state({

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -151,7 +151,7 @@ export const popUpEditorStore = $state({
     open: false,
     value: '',
     mode: 'default' as 'default',
-    language: 'risulanguage' as string
+    language: 'markdown' as string
 })
 
 export const loadoutModalStore = $state({

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -150,7 +150,8 @@ export const popupStore = $state({
 export const popUpEditorStore = $state({
     open: false,
     value: '',
-    mode: 'default' as 'default'
+    mode: 'default' as 'default',
+    language: 'markdown' as string
 })
 
 export const loadoutModalStore = $state({


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add `popupLanguage` prop to `TextAreaInput` to allow the Popup Editor to open with the correct Monaco language mode depending on context.

## Related Issues

None

## Changes

- Added `language` field to `popUpEditorStore` in `stores.svelte.ts` (default: `'markdown'`)
- Added `popupLanguage` prop to `TextAreaInput.svelte` (default: `'markdown'`); the prop value is written to `popUpEditorStore.language` whenever the Popup Editor is opened via hotkey or context menu
- Updated `PopupEditor.svelte` to initialize `languageMode` from `popUpEditorStore.language` instead of always defaulting to `'markdown'`
- Applied `popupLanguage="lua"` to the `TextAreaInput` used in `TriggerList.svelte` for Lua trigger scripts

## Impact

- No breaking changes to existing behavior — the default value is `'markdown'`, so all other `TextAreaInput` usages are unaffected
- Lua trigger script fields now open in the Popup Editor with Lua syntax highlighting and Monaco's built-in Lua language support
<img width="403" height="198" alt="image" src="https://github.com/user-attachments/assets/10fae939-b795-4559-94e6-35a728b475d4" />

