### PR TITLE
fix: release doingChat lock in sendChat plugin API

### DIFF
--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -1168,6 +1168,11 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                 throw new Error("A chat is already in progress");
             }
 
+            if(getModelInfo(DBState.db.aiModel).id.startsWith('pluginmodel:::')){
+                // Executing plugin provider is block because it can be used for loopholes for ipc right now.
+                throw new Error("Sending chat with plugin-based model is currently blocked");
+            }
+
             const charId = get(selectedCharID);
             const char = DBState.db.characters[charId];
             if(!char){
@@ -1187,12 +1192,13 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                 });
             }
 
-            if(getModelInfo(DBState.db.aiModel).id.startsWith('pluginmodel:::')){
-                // Executing plugin provider is block because it can be used for loopholes for ipc right now.
-                throw new Error("Sending chat with plugin-based model is currently blocked");    
+            try {
+                await processSendChat(-1, {});
+            } finally {
+                // Plugin API path does not pass through the UI unlock logic,
+                // so release doingChat here on both success and failure.
+                doingChat.set(false);
             }
-
-            await processSendChat(-1, {});
 
             return true;
         },


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.


## Summary
- Release `doingChat` lock after `processSendChat` completes in the plugin API path
- Reorder the `pluginmodel:::` check so a blocked model doesn't leave an orphan user message

## Problem

When a v3 plugin calls `risuai.sendChat(message)`, the `doingChat` lock is set to `true` (inside `processSendChat`) but never reset when generation finishes. The UI send path handles this in `DefaultChatScreen.svelte`, but the plugin API path does not go through that code.

As a result, subsequent `sendChat` calls throw `"A chat is already in progress"` even after the previous generation completed normally.

## Changes

1. Wrap `processSendChat` in `try/finally` so `doingChat` is released on both success and failure.
2. Move the `pluginmodel:::` check above the user message push so that a blocked model doesn't leave an orphan user message in the chat log.

`return true` still means "generation completed successfully" — same as before, just with the lock now properly released.

## Note

This started as an OOM investigation (original PR title), but on further testing the OOM could not be cleanly reproduced against `main`. The confirmed, reproducible issue is the `doingChat` lock, so the PR scope has been narrowed to that fix plus the small validation reordering.