### PR TITLE
fix: disable thinking/reasoning for submodel calls

### DIFF
--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -761,11 +761,22 @@ export async function requestHTTPOpenAI(
         // For deepseek Official Reasoning Model: https://api-docs.deepseek.com/guides/thinking_mode#api-example
         const reasoningContentField = dat?.choices[0]?.reasoning_content ?? dat?.choices[0]?.message?.reasoning_content
         if(reasoningContentField){
-            result = `<Thoughts>\n${reasoningContentField}\n</Thoughts>\n${result}`
+            if(arg.mode === 'submodel'){
+                // For submodel calls (SD prompt generation etc.), skip reasoning wrapper.
+                // If the model's text content is empty, fall back to reasoning content directly
+                // so downstream filtering can extract keywords from it.
+                if(!result.trim()) result = reasoningContentField
+            } else {
+                result = `<Thoughts>\n${reasoningContentField}\n</Thoughts>\n${result}`
+            }
         }
         // For openrouter, https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#response.body.choices.message.reasoning
         if(dat?.choices?.[0]?.message?.reasoning){
-            result = `<Thoughts>\n${dat.choices[0].message.reasoning}\n</Thoughts>\n${result}`
+            if(arg.mode === 'submodel'){
+                if(!result.trim()) result = dat.choices[0].message.reasoning
+            } else {
+                result = `<Thoughts>\n${dat.choices[0].message.reasoning}\n</Thoughts>\n${result}`
+            }
         }
 
         return result

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -760,23 +760,12 @@ export async function requestHTTPOpenAI(
         }
         // For deepseek Official Reasoning Model: https://api-docs.deepseek.com/guides/thinking_mode#api-example
         const reasoningContentField = dat?.choices[0]?.reasoning_content ?? dat?.choices[0]?.message?.reasoning_content
-        if(reasoningContentField){
-            if(arg.mode === 'submodel'){
-                // For submodel calls (SD prompt generation etc.), skip reasoning wrapper.
-                // If the model's text content is empty, fall back to reasoning content directly
-                // so downstream filtering can extract keywords from it.
-                if(!result.trim()) result = reasoningContentField
-            } else {
-                result = `<Thoughts>\n${reasoningContentField}\n</Thoughts>\n${result}`
-            }
+        if(reasoningContentField && arg.mode !== 'submodel'){
+            result = `<Thoughts>\n${reasoningContentField}\n</Thoughts>\n${result}`
         }
         // For openrouter, https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#response.body.choices.message.reasoning
-        if(dat?.choices?.[0]?.message?.reasoning){
-            if(arg.mode === 'submodel'){
-                if(!result.trim()) result = dat.choices[0].message.reasoning
-            } else {
-                result = `<Thoughts>\n${dat.choices[0].message.reasoning}\n</Thoughts>\n${result}`
-            }
+        if(dat?.choices?.[0]?.message?.reasoning && arg.mode !== 'submodel'){
+            result = `<Thoughts>\n${dat.choices[0].message.reasoning}\n</Thoughts>\n${result}`
         }
 
         return result

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -353,6 +353,13 @@ export async function requestChatDataMain(arg:requestDataArgument, model:ModelMo
     targ.abortSignal = abortSignal
     targ.mode = model
     targ.extractJson = arg.extractJson ?? db.extractJson
+
+    // Disable thinking/reasoning for submodel calls (SD tag generation, etc.)
+    // so the model returns only the requested content without reasoning wrappers.
+    if(model === 'submodel'){
+        const thinkingFlags = [LLMFlags.geminiThinking, LLMFlags.deepSeekThinkingOutput, LLMFlags.claudeThinking, LLMFlags.claudeAdaptiveThinking]
+        targ.modelInfo = {...targ.modelInfo, flags: targ.modelInfo.flags.filter(f => !thinkingFlags.includes(f))}
+    }
     if(targ.aiModel === 'reverse_proxy'){
         targ.modelInfo.internalID = db.customProxyRequestModel
         targ.modelInfo.format = db.customAPIFormat

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -52,8 +52,10 @@ export async function stableDiff(currentChar:character,prompt:string){
         return false
     }
 
-    const r = rq.result
-
+    // Strip thinking wrappers from the submodel result.
+    // Thinking is disabled for submodel calls at the request level, but local models
+    // may still emit <think> tags in their text output.
+    const r = rq.result.replace(/<Thoughts>[\s\S]*?<\/Thoughts>/g, '').replace(/<think>[\s\S]*?<\/think>/gi, '').trim()
 
     const genPrompt = currentChar.newGenData.prompt.replaceAll('{{slot}}', r)
     const neg = currentChar.newGenData.negative


### PR DESCRIPTION
## Problem

#1373 fixed the `<Thoughts>` block leaking into SD submodel output via post-processing strip.

However, with a local thinking model (gemma4:31b via OpenAI-compatible API), a deeper issue was found: the model's actual result (image tags for `{{slot}}`) is often empty or incomplete because the model spends its output budget on chain-of-thought reasoning that gets discarded anyway.

Disabling thinking at the request level — not just stripping it from the output — is needed so the model focuses entirely on producing useful tag content.

## Solution

Three layers of defense for `mode === 'submodel'` calls:

| File | Change |
|---|---|
| `request.ts` | Strip thinking-related `LLMFlags` (`geminiThinking`, `deepSeekThinkingOutput`, `claudeThinking`, `claudeAdaptiveThinking`) from model info before the request is sent |
| `openAI/requests.ts` | Skip wrapping `reasoning_content` / `reasoning` response fields in `<Thoughts>` tags |
| `stableDiff.ts` | Strip residual `<Thoughts>` and `<think>` blocks from output (safety net for local models that emit thinking in text) |

## Testing

Tested with **gemma4:31b** (local, OpenAI-compatible API):
- Tag generation works correctly in most cases — model produces clean keyword output without thinking wrappers
- In some cases, the thinking result is still not included in the prompt; the exact conditions for this are not yet identified

## Known Limitations

- Only verified with a single local model (gemma4:31b). Behavior with other thinking models (DeepSeek R1, Claude thinking, Gemini thinking) has not been tested.
- The intermittent failure condition (thinking result missing from prompt) needs further investigation.

Feedback, additional test results from other thinking models, or insights on the intermittent issue would be very welcome.

## Related

- Builds on #1373 (merged — output-level strip)
- Replaces #1377 (self-closed — reported as fixed prematurely before intermittent issue was identified)