### PR TITLE
fix: reset accumulated streaming reasoning

### DIFF
--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -1221,6 +1221,7 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
             combined.set(chunk, dataUint.length);
             dataUint = Buffer.from(combined);
             let JSONreaded:{[key:string]:string} = {}
+            reasoningContent = ""
                         try {
                 const datas = dataUint.toString().split('\n')
                 let readed:{[key:string]:string} = {}

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -1214,6 +1214,16 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
     let reasoningContent = ""
     const db = getDatabase()
 
+    const appendStreamingFragment = (current:string, incoming?:string) => {
+        if(!incoming){
+            return current
+        }
+        if(incoming.length > current.length && incoming.startsWith(current)){
+            return incoming
+        }
+        return current + incoming
+    }
+
     return new TransformStream<Uint8Array, StreamResponseChunk>({
         transform(chunk, control) {
             const combined = new Uint8Array(dataUint.length + chunk.length);
@@ -1260,20 +1270,20 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
                             }
                             const choices = JSON.parse(rawChunk).choices
                             for(const choice of choices){
-                                const chunk = choice.delta.content ?? choices.text
+                                const chunk = choice.delta.content ?? choice.text
                                 if(chunk){
                                     if(arg.multiGen){
                                         const ind = choice.index.toString()
                                         if(!readed[ind]){
                                             readed[ind] = ""
                                         }
-                                        readed[ind] += chunk
+                                        readed[ind] = appendStreamingFragment(readed[ind], chunk)
                                     }
                                     else{
                                         if(!readed["0"]){
                                             readed["0"] = ""
                                         }
-                                        readed["0"] += chunk
+                                        readed["0"] = appendStreamingFragment(readed["0"], chunk)
                                     }
                                 }
                                 // Check for tool calls in the delta
@@ -1307,14 +1317,14 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
                                             toolCallsData[index].function.name = toolCall.function.name
                                         }
                                         if(toolCall.function?.arguments) {
-                                            toolCallsData[index].function.arguments += toolCall.function.arguments
+                                            toolCallsData[index].function.arguments = appendStreamingFragment(toolCallsData[index].function.arguments, toolCall.function.arguments)
                                         }
                                     }
                                     
                                     readed["__tool_calls"] = JSON.stringify(toolCallsData)
                                 }
                                 if(choice?.delta?.reasoning_content){
-                                    reasoningContent += choice.delta.reasoning_content
+                                    reasoningContent = appendStreamingFragment(reasoningContent, choice.delta.reasoning_content)
                                 }
                             }
                         } catch (error) {}

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -1323,8 +1323,9 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
                                     
                                     readed["__tool_calls"] = JSON.stringify(toolCallsData)
                                 }
-                                if(choice?.delta?.reasoning_content){
-                                    reasoningContent = appendStreamingFragment(reasoningContent, choice.delta.reasoning_content)
+                                const reasoningChunk = choice?.delta?.reasoning_content ?? choice?.delta?.reasoning
+                                if(reasoningChunk){
+                                    reasoningContent = appendStreamingFragment(reasoningContent, reasoningChunk)
                                 }
                             }
                         } catch (error) {}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

<img width="1034" height="339" alt="image" src="https://github.com/user-attachments/assets/0fa9ed12-4119-4b95-b490-18cf98170627" />
<img width="1034" height="484" alt="image" src="https://github.com/user-attachments/assets/ab2bd3c6-ea08-485d-84dc-4849d3b891c6" />

Fixed the issue with OpenAI compatible API's Chat-Completion API has accumulating reasoning texts like:

A
A B
A B C
A B C D
....

Format.



## Related Issues

None

## Changes

In `getTranStream()`, the `transform()` callback re-parses the entire accumulated SSE byte buffer (`dataUint`) from scratch on every call -- `dataUint` grows but is never cleared. Local variables like `readed` are fine because they're re-declared each call. But `reasoningContent` was a **closure variable** that persisted across calls and was only ever appended to. (refer to [line 1317](https://github.com/tasoo-oos/Risuai/blob/fix-chat-completion-streaming/src/ts/process/request/openAI/requests.ts#L1317))

It is resolved by resetting `reasoningContent` for every transform hook start.

## Impact

<img width="1032" height="383" alt="image" src="https://github.com/user-attachments/assets/8f4cdbbf-dd59-4de2-9143-ed700ed3be9a" />
<img width="1032" height="414" alt="image" src="https://github.com/user-attachments/assets/23edc003-c9c2-411f-bc50-599c8c87eaff" />

Bug gets resolved.
Tested on llama.cpp and Openrouter API.

## Additional Notes

The request on the footage was taken with RisuAI's "Custom API" feature since Openrouter model client embedded in RisuAI does not handle reasoning properly.

<img width="1198" height="281" alt="image" src="https://github.com/user-attachments/assets/63592427-afe7-4533-b8c0-43e6532cb5ef" />