### PR TITLE
style: Improved button visibility in light themes

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -658,7 +658,7 @@
                 {#if $doingChat || doingChatInputTranslate}
                     <button
                             aria-labelledby="cancel"
-                            class="peer-focus:border-textcolor  flex justify-center border-y border-darkborderc items-center text-gray-100 p-3 hover:bg-blue-500 transition-colors" onclick={abortChat}
+                            class="peer-focus:border-textcolor  flex justify-center border-y border-darkborderc items-center text-textcolor p-3 hover:bg-blue-500 hover:text-white transition-colors" onclick={abortChat}
                             style:height={inputHeight}
                     >
                         <div class="loadmove chat-process-stage-{$chatProcessStage}" class:autoload={autoMode}></div>
@@ -666,7 +666,7 @@
                 {:else}
                     <button
                             onclick={send}
-                            class="flex justify-center border-y border-darkborderc items-center text-gray-100 p-3 peer-focus:border-textcolor hover:bg-blue-500 transition-colors button-icon-send"
+                            class="flex justify-center border-y border-darkborderc items-center text-textcolor p-3 peer-focus:border-textcolor hover:bg-blue-500 hover:text-white transition-colors button-icon-send"
                             style:height={inputHeight}
                     >
                         <Send />
@@ -678,7 +678,7 @@
                             openMenu = !openMenu
                             e.stopPropagation()
                         }}
-                            class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-gray-100 p-3 rounded-r-md hover:bg-blue-500 transition-colors"
+                            class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
                             style:height={inputHeight}
                     >
                         <MenuIcon />
@@ -691,7 +691,7 @@
                         })
                         DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage] = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage]
                     }}
-                         class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-gray-100 p-3 rounded-r-md hover:bg-blue-500 transition-colors"
+                         class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
                          style:height={inputHeight}
                     >
                         <Plus />

--- a/src/lib/Others/PluginAlertModal.svelte
+++ b/src/lib/Others/PluginAlertModal.svelte
@@ -24,7 +24,7 @@
 {#if pluginAlertModalStore.open}
     <dialog open class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
         <div class="bg-orange-800 rounded-lg shadow-xl max-w-md w-full p-6">
-            <h2 class="text-xl font-bold mb-4 text-gray-100">
+            <h2 class="text-xl font-bold mb-4 text-textcolor">
                 {language.pluginRiskDetectedAlert}
             </h2>
             

--- a/src/lib/Others/WelcomeRisu.svelte
+++ b/src/lib/Others/WelcomeRisu.svelte
@@ -365,7 +365,7 @@
                         ></textarea>
                         <button
                             onclick={send}
-                            class="flex justify-center border-y border-r rounded-r-md border-darkborderc items-center text-gray-100 p-2 peer-focus:border-textcolor hover:bg-blue-500 transition-colors"
+                            class="flex justify-center border-y border-r rounded-r-md border-darkborderc items-center text-textcolor p-2 peer-focus:border-textcolor hover:bg-blue-500 hover:text-white transition-colors"
                         >
                             <Send />
                         </button>

--- a/src/lib/Setting/Pages/OpenrouterSettings.svelte
+++ b/src/lib/Setting/Pages/OpenrouterSettings.svelte
@@ -39,7 +39,7 @@
                 <OpenrouterProviderList bind:value={DBState.db.openrouterProvider.order[i]} options={openRouterProviders} />
             {/each}
             <div class="flex gap-2">
-                <button class="bg-selected text-white p-2 rounded-md" onclick={() => {
+                <button class="bg-selected text-textcolor p-2 rounded-md" onclick={() => {
                     let value = DBState.db.openrouterProvider.order ?? []
                     value.push('')
                     DBState.db.openrouterProvider.order = value
@@ -60,7 +60,7 @@
                 <OpenrouterProviderList bind:value={DBState.db.openrouterProvider.only[i]} options={openRouterProviders} />
             {/each}
             <div class="flex gap-2">
-                <button class="bg-selected text-white p-2 rounded-md" onclick={() => {
+                <button class="bg-selected text-textcolor p-2 rounded-md" onclick={() => {
                     let value = DBState.db.openrouterProvider.only ?? []
                     value.push('')
                     DBState.db.openrouterProvider.only = value
@@ -81,7 +81,7 @@
                 <OpenrouterProviderList bind:value={DBState.db.openrouterProvider.ignore[i]} options={openRouterProviders} />
             {/each}
             <div class="flex gap-2">
-                <button class="bg-selected text-white p-2 rounded-md" onclick={() => {
+                <button class="bg-selected text-textcolor p-2 rounded-md" onclick={() => {
                     let value = DBState.db.openrouterProvider.ignore ?? []
                     value.push('')
                     DBState.db.openrouterProvider.ignore = value

--- a/src/lib/Setting/Pages/PromptSettings.svelte
+++ b/src/lib/Setting/Pages/PromptSettings.svelte
@@ -308,6 +308,7 @@
     {#if !DBState.db.auxModelUnderModelSettings}
         <AuxModelSelectors />
     {/if}
+    
     {#snippet fallbackModelList(arg:'model'|'memory'|'translate'|'emotion'|'otherAx')}
         {#each DBState.db.fallbackModels[arg] as model, i}
             <span class="text-textcolor mt-4">

--- a/src/lib/Setting/Pages/PromptSettings.svelte
+++ b/src/lib/Setting/Pages/PromptSettings.svelte
@@ -308,7 +308,6 @@
     {#if !DBState.db.auxModelUnderModelSettings}
         <AuxModelSelectors />
     {/if}
-
     {#snippet fallbackModelList(arg:'model'|'memory'|'translate'|'emotion'|'otherAx')}
         {#each DBState.db.fallbackModels[arg] as model, i}
             <span class="text-textcolor mt-4">
@@ -317,7 +316,7 @@
             <ModelList bind:value={DBState.db.fallbackModels[arg][i]} blankable />
         {/each}
         <div class="flex gap-2">
-            <button class="bg-selected text-white p-2 rounded-md" onclick={() => {
+            <button class="bg-selected text-textcolor p-2 rounded-md" onclick={() => {
                 let value = DBState.db.fallbackModels[arg] ?? []
                 value.push('')
                 DBState.db.fallbackModels[arg] = value

--- a/src/lib/UI/ModelGrid.svelte
+++ b/src/lib/UI/ModelGrid.svelte
@@ -84,7 +84,7 @@
                 {#each sortFields as sf}
                     <button
                         onclick={() => { sortField = sf.key }}
-                        class="rounded px-3 py-1 text-sm transition-colors {sortField === sf.key ? 'bg-selected text-white font-bold ring-2 ring-white/50 ring-offset-1 ring-offset-bgcolor shadow-md' : 'bg-darkbutton text-textcolor2 font-medium hover:bg-darkbutton hover:text-textcolor'}"
+                        class="rounded px-3 py-1 text-sm transition-colors {sortField === sf.key ? 'bg-selected text-textcolor font-bold ring-2 ring-textcolor/30 ring-offset-1 ring-offset-bgcolor shadow-md' : 'bg-darkbutton text-textcolor2 font-medium hover:bg-darkbutton hover:text-textcolor'}"
                     >{sf.label}</button>
                 {/each}
             </div>
@@ -95,7 +95,7 @@
                 {#each sortDirs as sd}
                     <button
                         onclick={() => { sortDir = sd.key }}
-                        class="rounded px-3 py-1 text-sm transition-colors {sortDir === sd.key ? 'bg-selected text-white font-bold ring-2 ring-white/50 ring-offset-1 ring-offset-bgcolor shadow-md' : 'bg-darkbutton text-textcolor2 font-medium hover:bg-darkbutton hover:text-textcolor'}"
+                        class="rounded px-3 py-1 text-sm transition-colors {sortDir === sd.key ? 'bg-selected text-textcolor font-bold ring-2 ring-textcolor/30 ring-offset-1 ring-offset-bgcolor shadow-md' : 'bg-darkbutton text-textcolor2 font-medium hover:bg-darkbutton hover:text-textcolor'}"
                     >{sd.label}</button>
                 {/each}
             </div>
@@ -139,7 +139,7 @@
                             <div class="flex items-center gap-1">
                                 <span class="text-xs text-textcolor2">{item.providerName}</span>
                                 {#if showSubBadge}
-                                    <span class="rounded px-1 text-[0.6rem] font-bold leading-tight bg-selected text-white">SUB</span>
+                                    <span class="rounded px-1 text-[0.6rem] font-bold leading-tight bg-selected text-textcolor">SUB</span>
                                 {/if}
                             </div>
                             <span class="line-clamp-2 text-sm font-medium leading-snug text-textcolor">{item.displayName}</span>

--- a/src/lib/UI/Realm/RealmMain.svelte
+++ b/src/lib/UI/Realm/RealmMain.svelte
@@ -59,7 +59,7 @@
                 page = 0
                 getHub()
             }}
-            class="flex justify-center border-y border-darkborderc items-center text-gray-100 p-3 peer-focus:border-textcolor hover:bg-blue-500 transition-colors"
+                class="flex justify-center border-y border-darkborderc items-center text-textcolor p-3 peer-focus:border-textcolor hover:bg-blue-500 hover:text-white transition-colors"
         >
             <SearchIcon />
         </button>
@@ -67,7 +67,7 @@
             onclick={(e) => {
                 menuOpen = true
             }}
-            class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-gray-100 p-3 rounded-r-md hover:bg-blue-500 transition-colors"
+                class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
         >
             <MenuIcon />
         </button>


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

In the original risuai, there were many hardcoded colors that did not support the light theme.
In this PR, I've fixed the critical things I can find.

## Impact
It doesn't change anything except light theme.

## Before

<img width="157" height="88" alt="image" src="https://github.com/user-attachments/assets/4e5c341c-8489-4fbd-98e1-1223fd6be993" />
<img width="865" height="146" alt="image" src="https://github.com/user-attachments/assets/735ba642-7628-4231-8dba-5a2a74be299f" />
<img width="907" height="520" alt="image" src="https://github.com/user-attachments/assets/1f91286f-e37d-4689-830d-e5b34eeffc4c" />


## After

<img width="146" height="81" alt="image" src="https://github.com/user-attachments/assets/35abe070-6697-46a5-925d-9d50050d4383" />
<img width="893" height="153" alt="image" src="https://github.com/user-attachments/assets/b14873a5-1e49-45ac-b700-e8a09715c2a1" />
<img width="896" height="511" alt="image" src="https://github.com/user-attachments/assets/d55a04e1-3c07-47c0-8fc5-dd3dc49c3f1e" />


