### PR TITLE
fix: drag-and-drop reordering rework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ See `plugins.md` for comprehensive plugin development guide.
 - Multiple UI modes: Classic, WaifuLike, WaifuCut
 - Dynamic GUI switching based on viewport
 - No traditional router; uses conditional rendering in App.svelte
+- In-app drag-and-drop uses custom MIME types to avoid conflicting with file imports; see `src/ts/dragTypes.ts`
 
 ## Supported AI Providers
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -44,13 +44,18 @@
     let aprilFools = $state(new Date().getMonth() === 3 && new Date().getDate() === 1)
     let aprilFoolsPage = $state(0)
     let keepingSessionAlive = $state(false)
+
+    const getMainDropEffect = (e:DragEvent): DataTransfer['dropEffect'] => {
+        const types = Array.from(e.dataTransfer?.types ?? [])
+        return types.includes('Files') ? 'copy' : 'link'
+    }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <main class="flex bg-bg w-full h-full max-w-100vw text-textcolor" ondragover={(e) => {
     e.preventDefault()
-    e.dataTransfer.dropEffect = 'link'
+    e.dataTransfer.dropEffect = getMainDropEffect(e)
 }} ondrop={async (e) => {
     e.preventDefault()
     if (e.dataTransfer.types.includes('application/x-risu-internal')) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -36,7 +36,7 @@
     import IrisModal from './lib/Others/IrisModal.svelte';
     import Legal from './lib/Others/Legal.svelte';
     import CustomSidebarConfig from './lib/Others/CustomSidebarConfig.svelte';
-    import { RISU_SIDEBAR_DRAG_TYPE } from './ts/dragTypes';
+    import { RISU_APP_INTERNAL_DRAG_TYPE, RISU_SIDEBAR_DRAG_TYPE } from './ts/dragTypes';
 
 
   
@@ -46,12 +46,19 @@
     let aprilFoolsPage = $state(0)
     let keepingSessionAlive = $state(false)
 
-    const getMainDropEffect = (e:DragEvent): DataTransfer['dropEffect'] => {
+    const getMainDropEffect = (e:DragEvent): DataTransfer['dropEffect'] | null => {
         const types = Array.from(e.dataTransfer?.types ?? [])
         if(types.includes(RISU_SIDEBAR_DRAG_TYPE)){
             return 'none'
         }
-        return types.includes('Files') ? 'copy' : 'link'
+        if(types.includes(RISU_APP_INTERNAL_DRAG_TYPE)){
+            return null
+        }
+        return types.includes('Files') ? 'copy' : null
+    }
+
+    const markAppInternalDrag = (e:DragEvent) => {
+        e.dataTransfer?.setData(RISU_APP_INTERNAL_DRAG_TYPE, 'true')
     }
 
 </script>
@@ -59,33 +66,40 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <main class="flex bg-bg w-full h-full max-w-100vw text-textcolor" ondragover={(e) => {
+    const dropEffect = getMainDropEffect(e)
+    if(!dropEffect){
+        return
+    }
     e.preventDefault()
-    e.dataTransfer.dropEffect = getMainDropEffect(e)
-}} ondrop={async (e) => {
-    e.preventDefault()
-    if (e.dataTransfer.types.includes(RISU_SIDEBAR_DRAG_TYPE)) {
+    e.dataTransfer.dropEffect = dropEffect
+}} ondragstart={markAppInternalDrag} ondrop={async (e) => {
+    const types = Array.from(e.dataTransfer.types ?? [])
+    if (types.includes(RISU_APP_INTERNAL_DRAG_TYPE) || types.includes(RISU_SIDEBAR_DRAG_TYPE)) {
+        e.preventDefault()
         return
     }
     const file = e.dataTransfer.files[0]
-    if (file) {
-        const name = file.name.toLowerCase()
+    if (!file) {
+        return
+    }
+    e.preventDefault()
+    const name = file.name.toLowerCase()
 
-        if (name.endsWith('.risup')) {
-            const data = new Uint8Array(await file.arrayBuffer())
-            await importPreset({ name: file.name, data })
-            alertNormal(language.successImport)
-        } else if (name.endsWith('.risum')) {
-            const data = new Uint8Array(await file.arrayBuffer())
-            const module = await readModule(Buffer.from(data))
-            DBState.db.modules.push(module)
-            alertNormal(language.successImport)
-        } else {
-            await importCharacterProcess({
-                name: file.name,
-                data: file
-            })
-            checkCharOrder()
-        }
+    if (name.endsWith('.risup')) {
+        const data = new Uint8Array(await file.arrayBuffer())
+        await importPreset({ name: file.name, data })
+        alertNormal(language.successImport)
+    } else if (name.endsWith('.risum')) {
+        const data = new Uint8Array(await file.arrayBuffer())
+        const module = await readModule(Buffer.from(data))
+        DBState.db.modules.push(module)
+        alertNormal(language.successImport)
+    } else {
+        await importCharacterProcess({
+            name: file.name,
+            data: file
+        })
+        checkCharOrder()
     }
 }} onclick={() => {
     if(keepingSessionAlive){

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -54,9 +54,6 @@
         return types.includes('Files') ? 'copy' : 'link'
     }
 
-    const markInternalDrag = (e:DragEvent) => {
-        e.dataTransfer?.setData(internalDragType, 'true')
-    }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -64,7 +61,7 @@
 <main class="flex bg-bg w-full h-full max-w-100vw text-textcolor" ondragover={(e) => {
     e.preventDefault()
     e.dataTransfer.dropEffect = getMainDropEffect(e)
-}} ondragstart={markInternalDrag} ondrop={async (e) => {
+}} ondrop={async (e) => {
     e.preventDefault()
     if (e.dataTransfer.types.includes(internalDragType)) {
         return

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -36,6 +36,7 @@
     import IrisModal from './lib/Others/IrisModal.svelte';
     import Legal from './lib/Others/Legal.svelte';
     import CustomSidebarConfig from './lib/Others/CustomSidebarConfig.svelte';
+    import { RISU_SIDEBAR_DRAG_TYPE } from './ts/dragTypes';
 
 
   
@@ -44,11 +45,10 @@
     let aprilFools = $state(new Date().getMonth() === 3 && new Date().getDate() === 1)
     let aprilFoolsPage = $state(0)
     let keepingSessionAlive = $state(false)
-    const internalDragType = 'application/x-risu-internal'
 
     const getMainDropEffect = (e:DragEvent): DataTransfer['dropEffect'] => {
         const types = Array.from(e.dataTransfer?.types ?? [])
-        if(types.includes(internalDragType)){
+        if(types.includes(RISU_SIDEBAR_DRAG_TYPE)){
             return 'none'
         }
         return types.includes('Files') ? 'copy' : 'link'
@@ -63,7 +63,7 @@
     e.dataTransfer.dropEffect = getMainDropEffect(e)
 }} ondrop={async (e) => {
     e.preventDefault()
-    if (e.dataTransfer.types.includes(internalDragType)) {
+    if (e.dataTransfer.types.includes(RISU_SIDEBAR_DRAG_TYPE)) {
         return
     }
     const file = e.dataTransfer.files[0]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -44,10 +44,18 @@
     let aprilFools = $state(new Date().getMonth() === 3 && new Date().getDate() === 1)
     let aprilFoolsPage = $state(0)
     let keepingSessionAlive = $state(false)
+    const internalDragType = 'application/x-risu-internal'
 
     const getMainDropEffect = (e:DragEvent): DataTransfer['dropEffect'] => {
         const types = Array.from(e.dataTransfer?.types ?? [])
+        if(types.includes(internalDragType)){
+            return 'none'
+        }
         return types.includes('Files') ? 'copy' : 'link'
+    }
+
+    const markInternalDrag = (e:DragEvent) => {
+        e.dataTransfer?.setData(internalDragType, 'true')
     }
 </script>
 
@@ -56,9 +64,9 @@
 <main class="flex bg-bg w-full h-full max-w-100vw text-textcolor" ondragover={(e) => {
     e.preventDefault()
     e.dataTransfer.dropEffect = getMainDropEffect(e)
-}} ondrop={async (e) => {
+}} ondragstart={markInternalDrag} ondrop={async (e) => {
     e.preventDefault()
-    if (e.dataTransfer.types.includes('application/x-risu-internal')) {
+    if (e.dataTransfer.types.includes(internalDragType)) {
         return
     }
     const file = e.dataTransfer.files[0]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -46,15 +46,15 @@
     let aprilFoolsPage = $state(0)
     let keepingSessionAlive = $state(false)
 
-    const getMainDropEffect = (e:DragEvent): DataTransfer['dropEffect'] | null => {
+    const getMainDropEffect = (e:DragEvent): DataTransfer['dropEffect'] => {
         const types = Array.from(e.dataTransfer?.types ?? [])
         if(types.includes(RISU_SIDEBAR_DRAG_TYPE)){
             return 'none'
         }
         if(types.includes(RISU_APP_INTERNAL_DRAG_TYPE)){
-            return null
+            return 'none'
         }
-        return types.includes('Files') ? 'copy' : null
+        return types.includes('Files') ? 'copy' : 'none'
     }
 
     const markAppInternalDrag = (e:DragEvent) => {
@@ -67,9 +67,6 @@
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <main class="flex bg-bg w-full h-full max-w-100vw text-textcolor" ondragover={(e) => {
     const dropEffect = getMainDropEffect(e)
-    if(!dropEffect){
-        return
-    }
     e.preventDefault()
     e.dataTransfer.dropEffect = dropEffect
 }} ondragstart={markAppInternalDrag} ondrop={async (e) => {
@@ -80,6 +77,7 @@
     }
     const file = e.dataTransfer.files[0]
     if (!file) {
+        e.preventDefault()
         return
     }
     e.preventDefault()

--- a/src/lib/Setting/botpreset.svelte
+++ b/src/lib/Setting/botpreset.svelte
@@ -8,6 +8,7 @@
     import { prebuiltPresets } from "src/ts/process/templates/templates";
     import { ShowRealmFrameStore } from "src/ts/stores.svelte";
     import PromptDiffModal from "../Others/PromptDiffModal.svelte";
+    import { RISU_PRESET_DRAG_TYPE } from "src/ts/dragTypes";
 
     let editMode = $state(false)
     let isDragging = $state(false)
@@ -47,14 +48,24 @@
         DBState.db.botPresets = botPresets;
     }
 
-    function handlePresetDrop(targetIndex: number, e) {
+    function isPresetDrag(e: DragEvent) {
+        return e.dataTransfer?.types.includes(RISU_PRESET_DRAG_TYPE) ?? false;
+    }
+
+    function markPresetDrag(e: DragEvent, index: number) {
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', 'preset');
+        e.dataTransfer.setData(RISU_PRESET_DRAG_TYPE, index.toString());
+    }
+
+    function handlePresetDrop(targetIndex: number, e: DragEvent) {
+        if (!isPresetDrag(e)) {
+            return;
+        }
         e.preventDefault();
         e.stopPropagation();
-        const data = e.dataTransfer?.getData('text');
-        if (data === 'preset') {
-            const sourceIndex = parseInt(e.dataTransfer?.getData('presetIndex') || '0');
-            movePreset(sourceIndex, targetIndex);
-        }
+        const sourceIndex = parseInt(e.dataTransfer?.getData(RISU_PRESET_DRAG_TYPE) || '0');
+        movePreset(sourceIndex, targetIndex);
     }
 
 
@@ -107,7 +118,12 @@
                 class:hover:bg-gray-600={!isDragging}
                 role="listitem"
                 ondragover={(e) => {
+                    if (!isPresetDrag(e)) {
+                        return
+                    }
                     e.preventDefault()
+                    e.stopPropagation()
+                    e.dataTransfer.dropEffect = 'move'
                     dragOverIndex = i
                 }}
                 ondragleave={(e) => {
@@ -135,8 +151,7 @@
                     return
                 }
                 isDragging = true
-                e.dataTransfer?.setData('text', 'preset')
-                e.dataTransfer?.setData('presetIndex', i.toString())
+                markPresetDrag(e, i)
 
                 const dragElement = document.createElement('div')
                 dragElement.textContent = preset?.name || 'Unnamed Preset'
@@ -153,7 +168,12 @@
                 dragOverIndex = -1
             }}
             ondragover={(e) => {
+                if (!isPresetDrag(e)) {
+                    return
+                }
                 e.preventDefault()
+                e.stopPropagation()
+                e.dataTransfer.dropEffect = 'move'
                 const rect = e.currentTarget.getBoundingClientRect()
                 const mouseY = e.clientY
                 const elementCenter = rect.top + rect.height / 2
@@ -254,7 +274,12 @@
             class:hover:bg-gray-600={!isDragging}
             role="listitem"
             ondragover={(e) => {
+                if (!isPresetDrag(e)) {
+                    return
+                }
                 e.preventDefault()
+                e.stopPropagation()
+                e.dataTransfer.dropEffect = 'move'
                 dragOverIndex = DBState.db.botPresets.length
             }}
             ondragleave={(e) => {

--- a/src/lib/SideBars/Scripts/TriggerV2List.svelte
+++ b/src/lib/SideBars/Scripts/TriggerV2List.svelte
@@ -12,6 +12,7 @@
     import { type triggerEffectV2, type triggerEffect, type triggerscript, displayAllowList, requestAllowList, type triggerV2IfAdvanced } from "src/ts/process/triggers";
     import { onDestroy, onMount } from "svelte";
     import { DBState } from "src/ts/stores.svelte";
+    import { RISU_EFFECT_DRAG_TYPE, RISU_TRIGGER_DRAG_TYPE } from "src/ts/dragTypes";
 
     interface Props {
         value?: triggerscript[];
@@ -1784,14 +1785,25 @@
         value = triggers;
     }
 
-    const handleTriggerDrop = (targetIndex: number, e) => {
+    const isTriggerDrag = (e: DragEvent) => {
+        return e.dataTransfer?.types.includes(RISU_TRIGGER_DRAG_TYPE) ?? false;
+    }
+
+    const markTriggerDrag = (e: DragEvent, index: number) => {
+        if (!e.dataTransfer) return;
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', 'trigger');
+        e.dataTransfer.setData(RISU_TRIGGER_DRAG_TYPE, index.toString());
+    }
+
+    const handleTriggerDrop = (targetIndex: number, e: DragEvent) => {
+        if (!isTriggerDrag(e)) {
+            return;
+        }
         e.preventDefault();
         e.stopPropagation();
-        const data = e.dataTransfer?.getData('text');
-        if (data === 'trigger') {
-            const sourceIndex = parseInt(e.dataTransfer?.getData('triggerIndex') || '0');
-            moveTrigger(sourceIndex, targetIndex);
-        }
+        const sourceIndex = parseInt(e.dataTransfer?.getData(RISU_TRIGGER_DRAG_TYPE) || '0');
+        moveTrigger(sourceIndex, targetIndex);
     }
 
     const getBlockRange = (startIndex: number): { start: number, end: number } => {
@@ -1965,14 +1977,25 @@
         updateGuideLines();
     }
 
-    const handleEffectDrop = (targetIndex: number, e) => {
+    const isEffectDrag = (e: DragEvent) => {
+        return e.dataTransfer?.types.includes(RISU_EFFECT_DRAG_TYPE) ?? false;
+    }
+
+    const markEffectDrag = (e: DragEvent, index: number) => {
+        if (!e.dataTransfer) return;
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', 'effect');
+        e.dataTransfer.setData(RISU_EFFECT_DRAG_TYPE, index.toString());
+    }
+
+    const handleEffectDrop = (targetIndex: number, e: DragEvent) => {
+        if (!isEffectDrag(e)) {
+            return;
+        }
         e.preventDefault();
         e.stopPropagation();
-        const data = e.dataTransfer?.getData('text');
-        if (data === 'effect') {
-            const sourceIndex = parseInt(e.dataTransfer?.getData('effectIndex') || '0');
-            moveEffect(sourceIndex, targetIndex);
-        }
+        const sourceIndex = parseInt(e.dataTransfer?.getData(RISU_EFFECT_DRAG_TYPE) || '0');
+        moveEffect(sourceIndex, targetIndex);
     }
 
     const handleKeydown = (e:KeyboardEvent) => {
@@ -2422,8 +2445,10 @@
                             class:shadow-lg={isDragging && dragOverIndex === i}
                             role="listitem"
                             ondragover={(e) => {
-                                if (!isMobileScreen) {
+                                if (!isMobileScreen && isTriggerDrag(e)) {
                                     e.preventDefault()
+                                    e.stopPropagation()
+                                    e.dataTransfer.dropEffect = 'move'
                                 }
                             }} 
                             ondrop={(e) => {
@@ -2451,8 +2476,7 @@
                                             return
                                         }
                                         isDragging = true
-                                        e.dataTransfer?.setData('text', 'trigger')
-                                        e.dataTransfer?.setData('triggerIndex', i.toString())
+                                        markTriggerDrag(e, i)
                                         
                                         const dragElement = document.createElement('div')
                                         if (isMultipleSelected() && isTriggerSelected(i)) {
@@ -2474,8 +2498,10 @@
                                         scrollManager.stopAutoScroll()
                                     }}
                                     ondragover={(e) => {
-                                        if (!isMobileScreen) {
+                                        if (!isMobileScreen && isTriggerDrag(e)) {
                                             e.preventDefault()
+                                            e.stopPropagation()
+                                            e.dataTransfer.dropEffect = 'move'
                                             const rect = e.currentTarget.getBoundingClientRect()
                                             const mouseY = e.clientY
                                             const elementCenter = rect.top + rect.height / 2
@@ -2526,8 +2552,10 @@
                             class:shadow-lg={isDragging && dragOverIndex === value.length}
                             role="listitem"
                             ondragover={(e) => {
-                                if (!isMobileScreen) {
+                                if (!isMobileScreen && isTriggerDrag(e)) {
                                     e.preventDefault()
+                                    e.stopPropagation()
+                                    e.dataTransfer.dropEffect = 'move'
                                     dragOverIndex = value.length
                                 }
                             }} 
@@ -2699,8 +2727,10 @@
                                 class:shadow-lg={isEffectDragging && effectDragOverIndex === i}
                                 role="listitem"
                                 ondragover={(e) => {
-                                    if (!isMobileScreen && isEffectDragging) {
+                                    if (!isMobileScreen && isEffectDragging && isEffectDrag(e)) {
                                         e.preventDefault()
+                                        e.stopPropagation()
+                                        e.dataTransfer.dropEffect = 'move'
                                     }
                                 }} 
                                 ondrop={(e) => {
@@ -2715,8 +2745,10 @@
                                 class:hover:bg-selected={selectedEffectIndex !== i}
                                 class:bg-selected={selectedEffectIndex === i}
                                 ondragover={(e) => {
-                                    if (!isMobileScreen && isEffectDragging) {
+                                    if (!isMobileScreen && isEffectDragging && isEffectDrag(e)) {
                                         e.preventDefault()
+                                        e.stopPropagation()
+                                        e.dataTransfer.dropEffect = 'move'
                                         const rect = e.currentTarget.getBoundingClientRect()
                                         const mouseY = e.clientY
                                         const elementCenter = rect.top + rect.height / 2
@@ -2786,8 +2818,7 @@
                                                  return
                                              }
                                              isEffectDragging = true
-                                             e.dataTransfer?.setData('text', 'effect')
-                                             e.dataTransfer?.setData('effectIndex', i.toString())
+                                             markEffectDrag(e, i)
                                              
                                              const dragElement = document.createElement('div')
                                              dragElement.textContent = formatEffectDisplay(effect).replace(/<[^>]*>/g, '') || 'Effect'
@@ -2822,8 +2853,10 @@
                             class:shadow-lg={isEffectDragging && effectDragOverIndex === (value && value[selectedIndex] && value[selectedIndex].effect ? value[selectedIndex].effect.length : 0)}
                             role="listitem"
                             ondragover={(e) => {
-                                if (!isMobileScreen && isEffectDragging) {
+                                if (!isMobileScreen && isEffectDragging && isEffectDrag(e)) {
                                     e.preventDefault()
+                                    e.stopPropagation()
+                                    e.dataTransfer.dropEffect = 'move'
                                 }
                             }} 
                             ondrop={(e) => {

--- a/src/lib/SideBars/Scripts/TriggerV2List.svelte
+++ b/src/lib/SideBars/Scripts/TriggerV2List.svelte
@@ -300,7 +300,7 @@
         startAutoScroll(container: HTMLElement, direction: 'up' | 'down', speed?: number) {
             this.stopAutoScroll()
             const scrollSpeed = speed || this.scrollSpeed
-            
+
             this.autoScrollInterval = window.setInterval(() => {
                 if (!container) return
                 
@@ -317,7 +317,7 @@
         checkAutoScrollZone(mouseY: number, containerRect: DOMRect): 'up' | 'down' | null {
             const topZone = containerRect.top + this.scrollThreshold
             const bottomZone = containerRect.bottom - this.scrollThreshold
-            
+
             if (mouseY < topZone) {
                 return 'up'
             } else if (mouseY > bottomZone) {
@@ -1789,6 +1789,28 @@
         return e.dataTransfer?.types.includes(RISU_TRIGGER_DRAG_TYPE) ?? false;
     }
 
+    const handleTriggerAutoScroll = (e: DragEvent) => {
+        if (!isMobileScreen && isDragging && triggerScrollRef && isTriggerDrag(e)) {
+            const rect = triggerScrollRef.getBoundingClientRect()
+            const autoScrollDirection = scrollManager.checkAutoScrollZone(e.clientY, rect)
+
+            if (autoScrollDirection) {
+                scrollManager.startAutoScroll(triggerScrollRef, autoScrollDirection)
+            } else {
+                scrollManager.stopAutoScroll()
+            }
+        }
+    }
+
+    const handleTriggerDragOver = (e: DragEvent) => {
+        if (!isMobileScreen && isTriggerDrag(e)) {
+            handleTriggerAutoScroll(e)
+            e.preventDefault()
+            e.stopPropagation()
+            e.dataTransfer.dropEffect = 'move'
+        }
+    }
+
     const markTriggerDrag = (e: DragEvent, index: number) => {
         if (!e.dataTransfer) return;
         e.dataTransfer.effectAllowed = 'move';
@@ -1979,6 +2001,28 @@
 
     const isEffectDrag = (e: DragEvent) => {
         return e.dataTransfer?.types.includes(RISU_EFFECT_DRAG_TYPE) ?? false;
+    }
+
+    const handleEffectAutoScroll = (e: DragEvent) => {
+        if (!isMobileScreen && isEffectDragging && menu0Container && isEffectDrag(e)) {
+            const rect = menu0Container.getBoundingClientRect()
+            const autoScrollDirection = scrollManager.checkAutoScrollZone(e.clientY, rect)
+
+            if (autoScrollDirection) {
+                scrollManager.startAutoScroll(menu0Container, autoScrollDirection)
+            } else {
+                scrollManager.stopAutoScroll()
+            }
+        }
+    }
+
+    const handleEffectDragOver = (e: DragEvent) => {
+        if (!isMobileScreen && isEffectDragging && isEffectDrag(e)) {
+            handleEffectAutoScroll(e)
+            e.preventDefault()
+            e.stopPropagation()
+            e.dataTransfer.dropEffect = 'move'
+        }
     }
 
     const markEffectDrag = (e: DragEvent, index: number) => {
@@ -2408,18 +2452,7 @@
             {#if menuMode === 0}
                 <div class="pr-2 md:w-96 flex flex-col md:h-full mt-2 md:mt-0">
                     <div class="flex-1 flex flex-col overflow-y-auto" bind:this={triggerScrollRef} onscroll={scrollManager.handleTriggerScroll} 
-                         ondragover={(e) => {
-                             if (!isMobileScreen && isDragging && triggerScrollRef) {
-                                 const rect = e.currentTarget.getBoundingClientRect()
-                                 const autoScrollDirection = scrollManager.checkAutoScrollZone(e.clientY, rect)
-                                 
-                                 if (autoScrollDirection) {
-                                     scrollManager.startAutoScroll(triggerScrollRef, autoScrollDirection)
-                                 } else {
-                                     scrollManager.stopAutoScroll()
-                                 }
-                             }
-                         }}
+                         ondragover={handleTriggerDragOver}
                          ondragleave={(e) => {
                              if (!isMobileScreen) {
                                  const rect = e.currentTarget.getBoundingClientRect()
@@ -2444,13 +2477,7 @@
                             class:bg-blue-500={isDragging && dragOverIndex === i}
                             class:shadow-lg={isDragging && dragOverIndex === i}
                             role="listitem"
-                            ondragover={(e) => {
-                                if (!isMobileScreen && isTriggerDrag(e)) {
-                                    e.preventDefault()
-                                    e.stopPropagation()
-                                    e.dataTransfer.dropEffect = 'move'
-                                }
-                            }} 
+                            ondragover={handleTriggerDragOver}
                             ondrop={(e) => {
                                 if (!isMobileScreen) {
                                     handleTriggerDrop(i, e)
@@ -2499,9 +2526,7 @@
                                     }}
                                     ondragover={(e) => {
                                         if (!isMobileScreen && isTriggerDrag(e)) {
-                                            e.preventDefault()
-                                            e.stopPropagation()
-                                            e.dataTransfer.dropEffect = 'move'
+                                            handleTriggerDragOver(e)
                                             const rect = e.currentTarget.getBoundingClientRect()
                                             const mouseY = e.clientY
                                             const elementCenter = rect.top + rect.height / 2
@@ -2553,9 +2578,7 @@
                             role="listitem"
                             ondragover={(e) => {
                                 if (!isMobileScreen && isTriggerDrag(e)) {
-                                    e.preventDefault()
-                                    e.stopPropagation()
-                                    e.dataTransfer.dropEffect = 'move'
+                                    handleTriggerDragOver(e)
                                     dragOverIndex = value.length
                                 }
                             }} 
@@ -2661,18 +2684,7 @@
                     
                     <div class="border border-darkborderc mx-2 mb-2 rounded-md flex-1 overflow-x-hidden overflow-y-auto relative" bind:this={menu0Container}
                          onscroll={scrollManager.handleMenu0Scroll}
-                         ondragover={(e) => {
-                             if (!isMobileScreen && isEffectDragging && menu0Container) {
-                                 const rect = e.currentTarget.getBoundingClientRect()
-                                 const autoScrollDirection = scrollManager.checkAutoScrollZone(e.clientY, rect)
-                                 
-                                 if (autoScrollDirection) {
-                                     scrollManager.startAutoScroll(menu0Container, autoScrollDirection)
-                                 } else {
-                                     scrollManager.stopAutoScroll()
-                                 }
-                             }
-                         }}
+                         ondragover={handleEffectDragOver}
                          ondragleave={(e) => {
                              if (!isMobileScreen && isEffectDragging) {
                                  const rect = e.currentTarget.getBoundingClientRect()
@@ -2726,13 +2738,7 @@
                                 class:bg-blue-500={isEffectDragging && effectDragOverIndex === i}
                                 class:shadow-lg={isEffectDragging && effectDragOverIndex === i}
                                 role="listitem"
-                                ondragover={(e) => {
-                                    if (!isMobileScreen && isEffectDragging && isEffectDrag(e)) {
-                                        e.preventDefault()
-                                        e.stopPropagation()
-                                        e.dataTransfer.dropEffect = 'move'
-                                    }
-                                }} 
+                                ondragover={handleEffectDragOver}
                                 ondrop={(e) => {
                                     if (!isMobileScreen && isEffectDragging) {
                                         handleEffectDrop(i, e)
@@ -2746,9 +2752,7 @@
                                 class:bg-selected={selectedEffectIndex === i}
                                 ondragover={(e) => {
                                     if (!isMobileScreen && isEffectDragging && isEffectDrag(e)) {
-                                        e.preventDefault()
-                                        e.stopPropagation()
-                                        e.dataTransfer.dropEffect = 'move'
+                                        handleEffectDragOver(e)
                                         const rect = e.currentTarget.getBoundingClientRect()
                                         const mouseY = e.clientY
                                         const elementCenter = rect.top + rect.height / 2
@@ -2852,13 +2856,7 @@
                             class:bg-blue-500={isEffectDragging && effectDragOverIndex === (value && value[selectedIndex] && value[selectedIndex].effect ? value[selectedIndex].effect.length : 0)}
                             class:shadow-lg={isEffectDragging && effectDragOverIndex === (value && value[selectedIndex] && value[selectedIndex].effect ? value[selectedIndex].effect.length : 0)}
                             role="listitem"
-                            ondragover={(e) => {
-                                if (!isMobileScreen && isEffectDragging && isEffectDrag(e)) {
-                                    e.preventDefault()
-                                    e.stopPropagation()
-                                    e.dataTransfer.dropEffect = 'move'
-                                }
-                            }} 
+                            ondragover={handleEffectDragOver}
                             ondrop={(e) => {
                                 if (!isMobileScreen && isEffectDragging) {
                                     handleEffectDrop(value && value[selectedIndex] && value[selectedIndex].effect ? value[selectedIndex].effect.length : 0, e)

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -335,29 +335,44 @@
     }
   }
 
-  const avatarDragOver = (e:DragEv) => {
-    e.preventDefault()
-    if(currentDrag){
-      e.stopPropagation()
-      e.dataTransfer.dropEffect = 'move'
+  const clearCurrentDrag = () => {
+    currentDrag = null
+  }
+
+  const getCurrentSidebarDrag = (e:DragEvent) => {
+    if(!currentDrag || !e.dataTransfer?.types.includes('application/x-risu-internal')){
+      return null
     }
+    return currentDrag
+  }
+
+  const avatarDragOver = (e:DragEv) => {
+    if(!getCurrentSidebarDrag(e)){
+      return
+    }
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'move'
   }
 
   const avatarDrop = (ind:DragData, e:DragEv) => {
-    e.preventDefault()
-    if(!currentDrag){
+    const drag = getCurrentSidebarDrag(e)
+    if(!drag){
       return
     }
+    e.preventDefault()
     e.stopPropagation()
     try {
-      createFolder(currentDrag,ind)
+      createFolder(drag,ind)
     } catch (error) {
       console.error('avatarDrop error:', error)
+    } finally {
+      clearCurrentDrag()
     }
   }
 
-  const preventAll = (e:Event) => {
-    if(!currentDrag){
+  const preventAll = (e:DragEvent) => {
+    if(!getCurrentSidebarDrag(e)){
       return
     }
     e.preventDefault()
@@ -511,25 +526,31 @@
   {/if}
   <div class="flex grow w-full flex-col items-center overflow-x-hidden overflow-y-auto pr-0">
     <div class="h-4 min-h-4 w-14" role="listitem" ondragover={(e) => {
+      if(!getCurrentSidebarDrag(e)){ return }
       e.preventDefault()
-      if(!currentDrag){ return }
       e.stopPropagation()
       e.dataTransfer.dropEffect = 'move'
       e.currentTarget.classList.add('bg-green-500')
     }} ondragleave={(e) => {
       e.currentTarget.classList.remove('bg-green-500')
     }} ondrop={(e) => {
+      const drag = getCurrentSidebarDrag(e)
+      if(!drag){ return }
       e.preventDefault()
-      if(!currentDrag){ return }
       e.stopPropagation()
       e.currentTarget.classList.remove('bg-green-500')
-      inserter(currentDrag,{index:0})
+      try {
+        inserter(drag,{index:0})
+      } finally {
+        clearCurrentDrag()
+      }
     }} ondragenter={preventAll}></div>
     {#each charImages as char, ind}
       <div class="group relative flex items-center px-2"
         role="listitem"
         draggable="true"
         ondragstart={(e) => {avatarDragStart({index:ind}, e)}}
+        ondragend={clearCurrentDrag}
         ondragover={avatarDragOver}
         ondrop={(e) => {avatarDrop({index:ind}, e)}}
         ondragenter={preventAll}
@@ -666,20 +687,25 @@
             'bg-darkbg/20'
           }"></div>
           <div class="h-4 min-h-4 w-14 relative z-10" role="listitem" ondragover={(e) => {
+            if(!getCurrentSidebarDrag(e)){ return }
             e.preventDefault()
-            if(!currentDrag){ return }
             e.stopPropagation()
             e.dataTransfer.dropEffect = 'move'
             e.currentTarget.classList.add('bg-green-500')
           }} ondragleave={(e) => {
             e.currentTarget.classList.remove('bg-green-500')
           }} ondrop={(e) => {
+            const drag = getCurrentSidebarDrag(e)
+            if(!drag){ return }
             e.preventDefault()
-            if(!currentDrag){ return }
             e.stopPropagation()
             e.currentTarget.classList.remove('bg-green-500')
-            if(char.type === 'folder'){
-              inserter(currentDrag,{index:0,folder:char.id})
+            try {
+              if(char.type === 'folder'){
+                inserter(drag,{index:0,folder:char.id})
+              }
+            } finally {
+              clearCurrentDrag()
             }
           }} ondragenter={preventAll}></div>
           {#each char.folder as char2, ind}
@@ -687,6 +713,7 @@
               role="listitem"
               draggable="true"
               ondragstart={(e) => {if(char.type === 'folder'){avatarDragStart({index: ind, folder:char.id}, e)}}}
+              ondragend={clearCurrentDrag}
               ondragover={avatarDragOver}
               ondrop={(e) => {if(char.type === 'folder'){avatarDrop({index: ind, folder:char.id}, e)}}}
               ondragenter={preventAll}
@@ -720,20 +747,25 @@
               </div>
             </div>
             <div class="h-4 min-h-4 w-14 relative z-20" role="listitem" ondragover={(e) => {
+              if(!getCurrentSidebarDrag(e)){ return }
               e.preventDefault()
-              if(!currentDrag){ return }
               e.stopPropagation()
               e.dataTransfer.dropEffect = 'move'
               e.currentTarget.classList.add('bg-green-500')
             }} ondragleave={(e) => {
               e.currentTarget.classList.remove('bg-green-500')
             }} ondrop={(e) => {
+              const drag = getCurrentSidebarDrag(e)
+              if(!drag){ return }
               e.preventDefault()
-              if(!currentDrag){ return }
               e.stopPropagation()
               e.currentTarget.classList.remove('bg-green-500')
-              if(char.type === 'folder'){
-                inserter(currentDrag,{index:ind+1,folder:char.id})
+              try {
+                if(char.type === 'folder'){
+                  inserter(drag,{index:ind+1,folder:char.id})
+                }
+              } finally {
+                clearCurrentDrag()
               }
             }} ondragenter={preventAll}></div>
           {/each}
@@ -741,19 +773,24 @@
         {/key}
       {/if}
       <div class="h-4 min-h-4 w-14" role="listitem" ondragover={((e) => {
+        if(!getCurrentSidebarDrag(e)){ return }
         e.preventDefault()
-        if(!currentDrag){ return }
         e.stopPropagation()
         e.dataTransfer.dropEffect = 'move'
         e.currentTarget.classList.add('bg-green-500')
       })} ondragleave={(e) => {
         e.currentTarget.classList.remove('bg-green-500')
       }} ondrop={(e) => {
+        const drag = getCurrentSidebarDrag(e)
+        if(!drag){ return }
         e.preventDefault()
-        if(!currentDrag){ return }
         e.stopPropagation()
         e.currentTarget.classList.remove('bg-green-500')
-        inserter(currentDrag,{index:ind+1})
+        try {
+          inserter(drag,{index:ind+1})
+        } finally {
+          clearCurrentDrag()
+        }
       }} ondragenter={preventAll}></div>
     {/each}
     <div class="flex flex-col items-center gap-2 px-2">

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -337,23 +337,29 @@
 
   const avatarDragOver = (e:DragEv) => {
     e.preventDefault()
-    e.stopPropagation()
-    e.dataTransfer.dropEffect = 'move'
+    if(currentDrag){
+      e.stopPropagation()
+      e.dataTransfer.dropEffect = 'move'
+    }
   }
 
   const avatarDrop = (ind:DragData, e:DragEv) => {
     e.preventDefault()
+    if(!currentDrag){
+      return
+    }
     e.stopPropagation()
     try {
-      if(currentDrag){
-        createFolder(currentDrag,ind)
-      }
+      createFolder(currentDrag,ind)
     } catch (error) {
       console.error('avatarDrop error:', error)
     }
   }
 
   const preventAll = (e:Event) => {
+    if(!currentDrag){
+      return
+    }
     e.preventDefault()
     e.stopPropagation()
     return false
@@ -506,6 +512,7 @@
   <div class="flex grow w-full flex-col items-center overflow-x-hidden overflow-y-auto pr-0">
     <div class="h-4 min-h-4 w-14" role="listitem" ondragover={(e) => {
       e.preventDefault()
+      if(!currentDrag){ return }
       e.stopPropagation()
       e.dataTransfer.dropEffect = 'move'
       e.currentTarget.classList.add('bg-green-500')
@@ -513,12 +520,10 @@
       e.currentTarget.classList.remove('bg-green-500')
     }} ondrop={(e) => {
       e.preventDefault()
+      if(!currentDrag){ return }
       e.stopPropagation()
       e.currentTarget.classList.remove('bg-green-500')
-      const da = currentDrag
-      if(da){
-        inserter(da,{index:0})
-      }
+      inserter(currentDrag,{index:0})
     }} ondragenter={preventAll}></div>
     {#each charImages as char, ind}
       <div class="group relative flex items-center px-2"
@@ -662,6 +667,7 @@
           }"></div>
           <div class="h-4 min-h-4 w-14 relative z-10" role="listitem" ondragover={(e) => {
             e.preventDefault()
+            if(!currentDrag){ return }
             e.stopPropagation()
             e.dataTransfer.dropEffect = 'move'
             e.currentTarget.classList.add('bg-green-500')
@@ -669,11 +675,11 @@
             e.currentTarget.classList.remove('bg-green-500')
           }} ondrop={(e) => {
             e.preventDefault()
+            if(!currentDrag){ return }
             e.stopPropagation()
             e.currentTarget.classList.remove('bg-green-500')
-            const da = currentDrag
-            if(da && char.type === 'folder'){
-              inserter(da,{index:0,folder:char.id})
+            if(char.type === 'folder'){
+              inserter(currentDrag,{index:0,folder:char.id})
             }
           }} ondragenter={preventAll}></div>
           {#each char.folder as char2, ind}
@@ -715,6 +721,7 @@
             </div>
             <div class="h-4 min-h-4 w-14 relative z-20" role="listitem" ondragover={(e) => {
               e.preventDefault()
+              if(!currentDrag){ return }
               e.stopPropagation()
               e.dataTransfer.dropEffect = 'move'
               e.currentTarget.classList.add('bg-green-500')
@@ -722,11 +729,11 @@
               e.currentTarget.classList.remove('bg-green-500')
             }} ondrop={(e) => {
               e.preventDefault()
+              if(!currentDrag){ return }
               e.stopPropagation()
               e.currentTarget.classList.remove('bg-green-500')
-              const da = currentDrag
-              if(da && char.type === 'folder'){
-                inserter(da,{index:ind+1,folder:char.id})
+              if(char.type === 'folder'){
+                inserter(currentDrag,{index:ind+1,folder:char.id})
               }
             }} ondragenter={preventAll}></div>
           {/each}
@@ -735,6 +742,7 @@
       {/if}
       <div class="h-4 min-h-4 w-14" role="listitem" ondragover={((e) => {
         e.preventDefault()
+        if(!currentDrag){ return }
         e.stopPropagation()
         e.dataTransfer.dropEffect = 'move'
         e.currentTarget.classList.add('bg-green-500')
@@ -742,12 +750,10 @@
         e.currentTarget.classList.remove('bg-green-500')
       }} ondrop={(e) => {
         e.preventDefault()
+        if(!currentDrag){ return }
         e.stopPropagation()
         e.currentTarget.classList.remove('bg-green-500')
-        const da = currentDrag
-        if(da){
-          inserter(da,{index:ind+1})
-        }
+        inserter(currentDrag,{index:ind+1})
       }} ondragenter={preventAll}></div>
     {/each}
     <div class="flex flex-col items-center gap-2 px-2">

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -313,6 +313,9 @@
         db.characterOrder.splice(mainIndex.index, 1)
       }
     }
+
+    DBState.db.characterOrder = db.characterOrder
+    checkCharOrder()
   }
 
   type DragEv = DragEvent & {
@@ -334,16 +337,20 @@
 
   const avatarDragOver = (e:DragEv) => {
     e.preventDefault()
+    e.stopPropagation()
     e.dataTransfer.dropEffect = 'move'
   }
 
   const avatarDrop = (ind:DragData, e:DragEv) => {
     e.preventDefault()
+    e.stopPropagation()
     try {
       if(currentDrag){
         createFolder(currentDrag,ind)
       }
-    } catch (error) {}
+    } catch (error) {
+      console.error('avatarDrop error:', error)
+    }
   }
 
   const preventAll = (e:Event) => {
@@ -499,12 +506,14 @@
   <div class="flex grow w-full flex-col items-center overflow-x-hidden overflow-y-auto pr-0">
     <div class="h-4 min-h-4 w-14" role="listitem" ondragover={(e) => {
       e.preventDefault()
+      e.stopPropagation()
       e.dataTransfer.dropEffect = 'move'
       e.currentTarget.classList.add('bg-green-500')
     }} ondragleave={(e) => {
       e.currentTarget.classList.remove('bg-green-500')
     }} ondrop={(e) => {
       e.preventDefault()
+      e.stopPropagation()
       e.currentTarget.classList.remove('bg-green-500')
       const da = currentDrag
       if(da){
@@ -653,12 +662,14 @@
           }"></div>
           <div class="h-4 min-h-4 w-14 relative z-10" role="listitem" ondragover={(e) => {
             e.preventDefault()
+            e.stopPropagation()
             e.dataTransfer.dropEffect = 'move'
             e.currentTarget.classList.add('bg-green-500')
           }} ondragleave={(e) => {
             e.currentTarget.classList.remove('bg-green-500')
           }} ondrop={(e) => {
             e.preventDefault()
+            e.stopPropagation()
             e.currentTarget.classList.remove('bg-green-500')
             const da = currentDrag
             if(da && char.type === 'folder'){
@@ -704,12 +715,14 @@
             </div>
             <div class="h-4 min-h-4 w-14 relative z-20" role="listitem" ondragover={(e) => {
               e.preventDefault()
+              e.stopPropagation()
               e.dataTransfer.dropEffect = 'move'
               e.currentTarget.classList.add('bg-green-500')
             }} ondragleave={(e) => {
               e.currentTarget.classList.remove('bg-green-500')
             }} ondrop={(e) => {
               e.preventDefault()
+              e.stopPropagation()
               e.currentTarget.classList.remove('bg-green-500')
               const da = currentDrag
               if(da && char.type === 'folder'){
@@ -722,12 +735,14 @@
       {/if}
       <div class="h-4 min-h-4 w-14" role="listitem" ondragover={((e) => {
         e.preventDefault()
+        e.stopPropagation()
         e.dataTransfer.dropEffect = 'move'
         e.currentTarget.classList.add('bg-green-500')
       })} ondragleave={(e) => {
         e.currentTarget.classList.remove('bg-green-500')
       }} ondrop={(e) => {
         e.preventDefault()
+        e.stopPropagation()
         e.currentTarget.classList.remove('bg-green-500')
         const da = currentDrag
         if(da){

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -69,7 +69,7 @@
   let charImages: sortType[] = $state([]);
   let IconRounded = $state(false)
   let openFolders:string[] = $state([])
-  let currentDrag: DragData = $state(null)
+  let currentDrag: DragData | null = $state(null)
   interface Props {
     openGrid?: any;
     hidden?: boolean;

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -51,6 +51,7 @@
   import DevTool from "./DevTool.svelte";
     import QuickSettingsGui from "../Others/QuickSettingsGUI.svelte";
     import PluginDefinedIcon from "../Others/PluginDefinedIcon.svelte";
+    import { RISU_SIDEBAR_DRAG_TYPE } from "src/ts/dragTypes";
   let sideBarMode = $state(0);
   let editMode = $state(false);
   let menuMode = $state(0);
@@ -327,7 +328,7 @@
   }
   const avatarDragStart = (ind:DragData, e:DragEv) => {
     e.dataTransfer.setData('text/plain', '');
-    e.dataTransfer.setData('application/x-risu-internal', 'true');
+    e.dataTransfer.setData(RISU_SIDEBAR_DRAG_TYPE, 'true');
     currentDrag = ind
     const avatar = e.currentTarget.querySelector('.avatar')
     if(avatar){
@@ -339,8 +340,22 @@
     currentDrag = null
   }
 
+  $effect(() => {
+    if (typeof window === 'undefined') return
+
+    window.addEventListener('dragend', clearCurrentDrag)
+    window.addEventListener('drop', clearCurrentDrag)
+    window.addEventListener('blur', clearCurrentDrag)
+
+    return () => {
+      window.removeEventListener('dragend', clearCurrentDrag)
+      window.removeEventListener('drop', clearCurrentDrag)
+      window.removeEventListener('blur', clearCurrentDrag)
+    }
+  })
+
   const getCurrentSidebarDrag = (e:DragEvent) => {
-    if(!currentDrag || !e.dataTransfer?.types.includes('application/x-risu-internal')){
+    if(!currentDrag || !e.dataTransfer?.types.includes(RISU_SIDEBAR_DRAG_TYPE)){
       return null
     }
     return currentDrag

--- a/src/lib/UI/PromptDataItem.svelte
+++ b/src/lib/UI/PromptDataItem.svelte
@@ -9,6 +9,7 @@
     import { ArrowDown, ArrowUp, XIcon } from "@lucide/svelte";
     import TextInput from "./GUI/TextInput.svelte";
     import { DBState } from 'src/ts/stores.svelte';
+    import { RISU_PROMPT_DRAG_TYPE } from "src/ts/dragTypes";
     
     interface Props {
         promptItem: PromptItem;
@@ -113,24 +114,39 @@
 
     }
 
+    const isPromptDrag = (e:DragEvent) => {
+        return e.dataTransfer?.types.includes(RISU_PROMPT_DRAG_TYPE) ?? false
+    }
+
+    const markPromptDrag = (e:DragEvent) => {
+        e.dataTransfer.effectAllowed = 'move'
+        e.dataTransfer.setData('text/plain', 'prompt')
+        e.dataTransfer.setData(RISU_PROMPT_DRAG_TYPE, 'true')
+        e.dataTransfer.setData('prompt', JSON.stringify(promptItem))
+    }
+
 </script>
 
 <div class="first:mt-0 w-full h-2" role="doc-pagebreak"
     ondrop={(e) => {
+        if(!isPromptDrag(e)){
+            return
+        }
         e.preventDefault()
         e.stopPropagation()
-        const data = e.dataTransfer.getData('text')
-        if(data === 'prompt'){
-            onDrop()
-        }
+        onDrop()
     }}
     ondragover={(e) => {
+        if(!isPromptDrag(e)){
+            return
+        }
         e.preventDefault()
+        e.stopPropagation()
+        e.dataTransfer.dropEffect = 'move'
     }}
     draggable="true"
     ondragstart={(e) => {
-        e.dataTransfer.setData('text', 'prompt')
-        e.dataTransfer.setData('prompt', JSON.stringify(promptItem))
+        markPromptDrag(e)
     }}>
 
 </div>
@@ -141,7 +157,12 @@
     class:scale-95={isDragging}
 
     ondragover={(e) => {
+        if(!isPromptDrag(e)){
+            return
+        }
         e.preventDefault()
+        e.stopPropagation()
+        e.dataTransfer.dropEffect = 'move'
         if(draggedIndex === -1 || draggedIndex === currentIndex) {
             return
         }
@@ -157,11 +178,12 @@
         }
     }}
     ondrop={(e) => {
-        e.preventDefault()
-        const data = e.dataTransfer.getData('text')
-        if(data === 'prompt'){
-            onDrop()
+        if(!isPromptDrag(e)){
+            return
         }
+        e.preventDefault()
+        e.stopPropagation()
+        onDrop()
     }}
 >
     <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -171,8 +193,7 @@
         style:cursor="grab"
         ondragstart={(e) => {
             draggedIndex = currentIndex
-            e.dataTransfer.setData('text', 'prompt')
-            e.dataTransfer.setData('prompt', JSON.stringify(promptItem))
+            markPromptDrag(e)
 
             const dragElement = document.createElement('div')
             dragElement.textContent = getName(promptItem)

--- a/src/ts/dragTypes.ts
+++ b/src/ts/dragTypes.ts
@@ -1,1 +1,4 @@
+export const RISU_APP_INTERNAL_DRAG_TYPE = 'application/x-risu-app-internal-drag'
+export const RISU_PRESET_DRAG_TYPE = 'application/x-risu-preset-drag'
+export const RISU_PROMPT_DRAG_TYPE = 'application/x-risu-prompt-drag'
 export const RISU_SIDEBAR_DRAG_TYPE = 'application/x-risu-sidebar-drag'

--- a/src/ts/dragTypes.ts
+++ b/src/ts/dragTypes.ts
@@ -1,0 +1,1 @@
+export const RISU_SIDEBAR_DRAG_TYPE = 'application/x-risu-sidebar-drag'

--- a/src/ts/dragTypes.ts
+++ b/src/ts/dragTypes.ts
@@ -1,4 +1,6 @@
 export const RISU_APP_INTERNAL_DRAG_TYPE = 'application/x-risu-app-internal-drag'
+export const RISU_EFFECT_DRAG_TYPE = 'application/x-risu-effect-drag'
 export const RISU_PRESET_DRAG_TYPE = 'application/x-risu-preset-drag'
 export const RISU_PROMPT_DRAG_TYPE = 'application/x-risu-prompt-drag'
 export const RISU_SIDEBAR_DRAG_TYPE = 'application/x-risu-sidebar-drag'
+export const RISU_TRIGGER_DRAG_TYPE = 'application/x-risu-trigger-drag'

--- a/src/ts/dragTypes.ts
+++ b/src/ts/dragTypes.ts
@@ -1,6 +1,38 @@
+/**
+ * Drag-and-drop type constants.
+ *
+ * Each type is a custom MIME set via setData() on dragstart and validated
+ * by drop targets before reacting. Pattern per type:
+ *   dragstart: setData(type, payload)
+ *   dragover:  if (!types.includes(type)) return (no preventDefault)
+ *              preventDefault() + stopPropagation() + dropEffect = 'move'
+ *   drop:      if (!types.includes(type)) return
+ *              preventDefault() + stopPropagation() + handle payload
+ *
+ * Safety rule: if your drag handler calls stopPropagation(), the event
+ * never reaches App.svelte's <main> file-import handler — no changes to
+ * App.svelte needed. If the drag CAN reach <main> visually (sidebar drags
+ * crossing the main area, or in-app element drags that browsers report
+ * as Files), add the type to getMainDropEffect() in App.svelte too.
+ *
+ * When implementing a new drag feature, search existing drag types in
+ * this file first and follow the same pattern for consistency.
+ */
+
+/** Blocks in-app element drags from file-import path */
 export const RISU_APP_INTERNAL_DRAG_TYPE = 'application/x-risu-app-internal-drag'
+
+/** TriggerV2 effect reorder */
 export const RISU_EFFECT_DRAG_TYPE = 'application/x-risu-effect-drag'
+
+/** Bot preset reorder */
 export const RISU_PRESET_DRAG_TYPE = 'application/x-risu-preset-drag'
+
+/** Prompt template reorder */
 export const RISU_PROMPT_DRAG_TYPE = 'application/x-risu-prompt-drag'
+
+/** Sidebar character/folder reorder — also checked in App.svelte, hotkey.ts */
 export const RISU_SIDEBAR_DRAG_TYPE = 'application/x-risu-sidebar-drag'
+
+/** TriggerV2 trigger reorder */
 export const RISU_TRIGGER_DRAG_TYPE = 'application/x-risu-trigger-drag'

--- a/src/ts/hotkey.ts
+++ b/src/ts/hotkey.ts
@@ -6,6 +6,7 @@ import { language } from "src/lang"
 import { updateTextThemeAndCSS } from "./gui/colorscheme"
 import { defaultHotkeys } from "./defaulthotkeys"
 import { doingChat, previewBody, sendChat } from "./process/index.svelte"
+import { RISU_SIDEBAR_DRAG_TYPE } from "./dragTypes"
 
 export function initHotkey(){
     document.addEventListener('keydown', async (ev) => {
@@ -287,7 +288,7 @@ export function initHotkey(){
     document.addEventListener('dragover', (ev) => {
         if (ev.ctrlKey && !ev.shiftKey && !ev.altKey) {
             const types = ev.dataTransfer?.types || []
-            const isCharacterDrag = types.includes('application/x-risu-internal')
+            const isCharacterDrag = types.includes(RISU_SIDEBAR_DRAG_TYPE)
             
             if (isCharacterDrag) {
                 const db = getDatabase()


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes sidebar character drag-and-drop reordering/folder creation and Linux/Chromium external file drops.

## Changes

- Adds scoped drag types for app, sidebar, preset, and prompt drag operations.
- Prevents internal app/sidebar drags from reaching the file-import path.
- Lets external file drops over sidebar elements bubble to `<main>` for import.
- Uses `dropEffect = "copy"` for file drops and `move` for internal reordering.
- Clears sidebar drag state after drag end, drop, or window blur.
- Persists folder creation by updating `characterOrder` and running `checkCharOrder()`.

## Impact

Improves drag-and-drop reliability by scoping internal drag types and separating them from external file drops. This should fix sidebar character/folder reordering and Linux/Chromium file-drop behavior without breaking prompt, preset, TriggerV2, lorebook, persona, or chat reordering.

The main risk is browser/OS-specific drag-and-drop behavior, since this PR changes shared app-level drop handling in `App.svelte`.


## Additional notes

### Currently tested with:

- Both with Linux/Wayland and Windows:
  - sidebar character reorder
  - sidebar folder creation
  - move character into/out of folder
  - external .risu/image/card drop over main area
  - external file drop over sidebar
  - drag existing in-app <img>/asset
  - prompt template reorder
  - bot preset reorder
  - TriggerV2 trigger reorder
  - TriggerV2 effect reorder
  - lorebook reorder
  - persona reorder
  - chat reorder and chat-folder reorder