### PR TITLE
fix: Asset loading fallback for SW cache failures

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -112,6 +112,34 @@ let checkedPaths: string[] = []
  * @returns {Promise<string>} - A promise that resolves to the source URL of the file.
  */
 export async function getFileSrc(loc: string) {
+    const getMimeTypeFromLoc = (path: string) => {
+        const ext = path.split('.').pop()?.toLocaleLowerCase() ?? ''
+        switch (ext) {
+            case 'png': return 'image/png'
+            case 'jpg':
+            case 'jpeg': return 'image/jpeg'
+            case 'webp': return 'image/webp'
+            case 'gif': return 'image/gif'
+            case 'svg': return 'image/svg+xml'
+            case 'avif': return 'image/avif'
+            case 'mp4': return 'video/mp4'
+            case 'webm': return 'video/webm'
+            case 'mp3': return 'audio/mpeg'
+            case 'wav': return 'audio/wav'
+            case 'ogg': return 'audio/ogg'
+            case 'ttf': return 'font/ttf'
+            case 'otf': return 'font/otf'
+            case 'woff': return 'font/woff'
+            case 'woff2': return 'font/woff2'
+            case 'css': return 'text/css'
+            default: return 'application/octet-stream'
+        }
+    }
+
+    const getDataUrl = (path: string, data: Uint8Array) => {
+        return `data:${getMimeTypeFromLoc(path)};base64,${Buffer.from(data).toString('base64')}`
+    }
+
     if (isTauri) {
         if (loc.startsWith('assets')) {
             if (appDataDirPath === '') {
@@ -148,6 +176,10 @@ export async function getFileSrc(loc: string) {
                     }
                     else {
                         const f: Uint8Array = await forageStorage.getItem(loc) as unknown as Uint8Array
+                        if (!f) {
+                            fileCache.res[ind] = 'done'
+                            return ''
+                        }
                         await fetch("/sw/register/" + encoded, {
                             method: "POST",
                             body: f as any
@@ -157,17 +189,47 @@ export async function getFileSrc(loc: string) {
                     }
                     return "/sw/img/" + encoded
                 } catch (error) {
-
+                    // Service worker registration can fail transiently on mobile/network hiccups.
+                    // Fall back to a direct data URL so this key doesn't remain stuck in "loading" forever.
+                    try {
+                        const f: Uint8Array = await forageStorage.getItem(loc) as unknown as Uint8Array
+                        if (f) {
+                            fileCache.res[ind] = f
+                            return getDataUrl(loc, f)
+                        }
+                    } catch (error2) { }
+                    fileCache.res[ind] = 'done'
+                    return ''
                 }
             }
             else {
                 const f = fileCache.res[ind]
                 if (f === 'loading') {
-                    while (fileCache.res[ind] === 'loading') {
+                    let timeoutCount = 0
+                    while (fileCache.res[ind] === 'loading' && timeoutCount < 500) {
                         await sleep(10)
+                        timeoutCount++
+                    }
+                    if (fileCache.res[ind] === 'loading') {
+                        try {
+                            const r: Uint8Array = await forageStorage.getItem(loc) as unknown as Uint8Array
+                            if (r) {
+                                fileCache.res[ind] = r
+                                return getDataUrl(loc, r)
+                            }
+                        } catch (error3) { }
+                        fileCache.res[ind] = 'done'
+                        return ''
                     }
                 }
-                return "/sw/img/" + encoded
+                const resolved = fileCache.res[ind]
+                if (resolved === 'done') {
+                    return "/sw/img/" + encoded
+                }
+                if (resolved === 'loading') {
+                    return ''
+                }
+                return getDataUrl(loc, resolved)
             }
         }
         else {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary
There were cases of errors in the storage where the image was stored, but it was not imported because there was no image.
These errors occur occasionally and cannot be specified yet, but I think the code in this part might be a problem, so I'm adding fallback.


## Changes

So I add the following modifications.
- If there is no image on the server, and there is no image on the client, it returns for sure.
- If a file does not exist on the server, or if an error occurs, But the file exists on the client, read it, and then return it in the base64 form of 'data:' instead of the server's path.

## Impact

All modifications apply only in getFileSrc, when usingSw.
Since I fixed one of the suspected causes without being able to reproduce the bug where the image breaks, I can’t guarantee that it will definitely be fixed, but there shouldn’t be any side effects.