### PR TITLE
chore: update GitHub Actions versions 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,10 +59,10 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,13 +21,13 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-     
+        uses: actions/checkout@v6
+      
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
     

--- a/.github/workflows/github-actions-builder.yml
+++ b/.github/workflows/github-actions-builder.yml
@@ -25,9 +25,9 @@ jobs:
           
     runs-on: ${{ matrix.settings.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - id: set_var_win
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "VERSION_JSON=$(jq -c . < version.json)" >> $GITHUB_ENV
       - name: install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: latest
       - name: install dependencies (ubuntu only)
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/mod.yml
+++ b/.github/workflows/mod.yml
@@ -16,7 +16,7 @@ jobs:
       models: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: github/ai-moderator@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Updated the repository's GitHub Actions workflow version.

## Related Issues

None.

## Changes

- Updated `actions/checkout` to `@v6` across repository workflows, aligning with the `v6.0.2` release line for Node 24 runtime and credential handling improvements.
- Updated `actions/setup-node` to `@v6` in CI workflows, matching the `v6.3.0` release line for Node 24 support and cache behavior improvements.
- Updated `pnpm/action-setup` to `@v6` in the desktop build workflow to align with the current Node 24-compatible bootstrap flow.
- Updated `actions/cache` to `@v5` in the pnpm cache step, aligning with the `v5.0.5` release line and the newer cache service API.
- Updated Docker-related actions to their current majors: `docker/setup-buildx-action@v4`, `docker/login-action@v4`, and `docker/metadata-action@v6`.

## Impact

These changes only affect CI and release automation. They should reduce the risk of runtime deprecation issues in GitHub-hosted runners while keeping existing workflow behavior and release outputs unchanged.

## Additional Notes

None.
