### PR TITLE
fix: support relaxed JSON for additional parameters

### DIFF
--- a/src/ts/process/request/additionalParams.ts
+++ b/src/ts/process/request/additionalParams.ts
@@ -1,0 +1,78 @@
+const relaxedJsonKeywords = [
+    ['True', 'true'],
+    ['False', 'false'],
+    ['None', 'null']
+] as const
+
+function isRelaxedJsonBoundary(char: string | undefined) {
+    return !char || !/[A-Za-z0-9_$]/.test(char)
+}
+
+function normalizeRelaxedJsonKeywords(value: string) {
+    let normalized = ''
+    let quote: '"' | "'" | null = null
+
+    for (let i = 0; i < value.length; i++) {
+        const char = value[i]
+
+        if (quote) {
+            normalized += char
+
+            if (char === '\\' && i + 1 < value.length) {
+                normalized += value[++i]
+                continue
+            }
+
+            if (char === quote) {
+                quote = null
+            }
+
+            continue
+        }
+
+        if (char === '"' || char === "'") {
+            quote = char
+            normalized += char
+            continue
+        }
+
+        let replaced = false
+
+        for (const [keyword, replacement] of relaxedJsonKeywords) {
+            if (
+                value.startsWith(keyword, i) &&
+                isRelaxedJsonBoundary(value[i - 1]) &&
+                isRelaxedJsonBoundary(value[i + keyword.length])
+            ) {
+                normalized += replacement
+                i += keyword.length - 1
+                replaced = true
+                break
+            }
+        }
+
+        if (!replaced) {
+            normalized += char
+        }
+    }
+
+    return normalized
+}
+
+export function parseAdditionalParamJsonValue(value: string): unknown | undefined {
+    try {
+        return JSON.parse(value)
+    } catch {}
+
+    const normalized = normalizeRelaxedJsonKeywords(value)
+
+    if (normalized === value) {
+        return undefined
+    }
+
+    try {
+        return JSON.parse(normalized)
+    } catch {
+        return undefined
+    }
+}

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -1,4 +1,5 @@
 import { getDatabase } from 'src/ts/storage/database.svelte'
+import { parseAdditionalParamJsonValue } from './additionalParams'
 
 export type LLMParameter =
     | 'temperature'
@@ -91,10 +92,10 @@ export function applyAdditionalParameters<T extends Record<string, any>>(
         }
 
         if (value.startsWith('json::')) {
-            try {
-                body = setObjectValue(body, key, JSON.parse(value.replace('json::', '')))
+            const parsedValue = parseAdditionalParamJsonValue(value.replace('json::', ''))
+            if (parsedValue !== undefined) {
+                body = setObjectValue(body, key, parsedValue)
             }
-            catch (error) {}
             continue
         }
 

--- a/src/ts/process/request/tests/additionalParams.test.ts
+++ b/src/ts/process/request/tests/additionalParams.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAdditionalParamJsonValue } from "../additionalParams";
+
+describe("parseAdditionalParamJsonValue", () => {
+    it("parses standard JSON additional parameter values", () => {
+        expect(
+            parseAdditionalParamJsonValue('{"enable_thinking":true,"budget_tokens":0}')
+        ).toEqual({
+            enable_thinking: true,
+            budget_tokens: 0,
+        });
+    });
+
+    it("accepts Python-style booleans and null in json:: values", () => {
+        expect(
+            parseAdditionalParamJsonValue(
+                '{"enable_thinking": True, "nested": {"flag": False, "value": None}}'
+            )
+        ).toEqual({
+            enable_thinking: true,
+            nested: {
+                flag: false,
+                value: null,
+            },
+        });
+    });
+
+    it("does not rewrite quoted keyword strings", () => {
+        expect(
+            parseAdditionalParamJsonValue(
+                '{"string_true": "True", "string_false": "False", "string_none": "None"}'
+            )
+        ).toEqual({
+            string_true: "True",
+            string_false: "False",
+            string_none: "None",
+        });
+    });
+
+    it("returns undefined for invalid json:: payloads", () => {
+        expect(parseAdditionalParamJsonValue('{"enable_thinking": Truthy}')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models, check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary
This PR adds support for "relaxed" JSON keywords (Python-style `True`, `False`, `None`) in additional parameters for Google and OpenAI requests.

## Related Issues
None

## Changes
- Created `additionalParams.ts` utility to normalize and parse JSON values that might contain Python-style keywords.
- Updated `google.ts` and `openAI/requests.ts` to use the new parsing utility for additional parameters.
- Added comprehensive unit tests in `additionalParams.test.ts` to ensure keywords inside quotes are preserved while others are correctly transformed.

## Impact
Improves flexibility for users who copy-paste configurations or use Python-style boolean/null values in their additional parameter JSON settings, preventing parsing errors.

## Additional Notes
The parsing logic specifically targets `True`, `False`, and `None` when they are outside of quotes and at word boundaries.
