### PR TITLE
feat(tts): plugin hooks for preprocessing and postprocessing

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -951,6 +951,56 @@ await Risuai.setCustomTextTheme({
 });
 ```
 
+### TTS Hooks
+
+Risuai's plugin API lets you intercept Text-to-Speech just before synthesis and just before playback.
+
+#### `Risuai.addTTSPreprocessor(func)`
+
+Runs before TTS synthesis for every message, across every provider (including `webspeech`). The hook receives the text that is about to be spoken along with the active provider's name and the character id, and may return a replacement text or abort playback.
+
+```javascript
+//@name simple-tts-prefix
+//@api 3.0
+
+(async () => {
+  await Risuai.addTTSPreprocessor(async (ctx) => {
+    return { text: '[narrator] ' + ctx.text };
+  });
+})();
+```
+
+#### `Risuai.addTTSPostprocessor(func)`
+
+Runs after the provider returns its audio, just before it is decoded and played. The hook receives the raw encoded bytes (mp3, wav, etc.) plus the MIME type. Return a replacement `{ audio, mimeType }` to swap the audio, `{ skip: true }` to suppress playback, or `undefined` / `void` to pass through unchanged.
+
+Does **not** run for the `webspeech` provider (the browser synthesizes and plays internally, so there is no audio buffer to intercept) or the `vits` provider (uses its own playback path).
+
+```javascript
+//@name volume-normalize-tts
+//@api 3.0
+
+(async () => {
+  await Risuai.addTTSPostprocessor(async (ctx) => {
+    // Decode to PCM inside the plugin iframe.
+    const audioCtx = new AudioContext();
+    const decoded = await audioCtx.decodeAudioData(ctx.audio);
+    // ... analyse peak amplitude, produce a normalised Float32Array,
+    //     re-encode to wav bytes as `newBytes` ...
+    return { audio: newBytes, mimeType: 'audio/wav' };
+  });
+})();
+```
+
+#### Pipeline semantics
+
+- **Sequential.** Hooks run in registration order; each receives the previous hook's output.
+- **Error isolation.** If a hook throws, its result is discarded and the next hook runs. TTS playback itself is not interrupted.
+- **No enforced timeout.** Matches the trust model of `addRisuScriptHandler` and `addRisuReplacer`. A hook that hangs will stall TTS playback for that message. Plugins that call slow services (auxiliary LLMs, remote audio processors) should implement their own `AbortController` + timer for cancellation.
+- **Short-circuit.** A hook that returns `{ skip: true }` stops the pipeline and aborts the TTS for that message. Later hooks are not called.
+- **No permission prompt.** These hooks are in the same trust category as `addRisuScriptHandler`. They transform text or audio that the plugin could already transmit via `nativeFetch`.
+- **Auto-cleanup.** Hooks registered by a plugin are removed automatically when the plugin unloads.
+
 ### Custom AI Provider
 
 Register a plugin as a custom AI provider that Risuai can use for generation:

--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -1932,12 +1932,20 @@ interface RisuaiPluginAPI {
      * @param options.messages - Array of chat messages to send to the model
      * @param options.staticModel - Optional static model name to use (e.g., 'gpt-4')
      * @param options.mode - Request mode
+     * @param options.allowPlugins - If true, allow the call to resolve to a
+     *   plugin-provided model (`pluginmodel:::*`). Default is false: plugin
+     *   models are blocked to guard against accidental IPC loops between
+     *   provider plugins. Opt in when the plugin legitimately needs to use
+     *   the user's plugin-supplied main or auxiliary model (e.g. a TTS
+     *   preprocessor rewriting text with the configured otherAx model).
+     *   Loop avoidance becomes the opting-in plugin's responsibility.
      * @returns The model's response, which may be a string or a stream depending on the mode
      */
     runLLMModel(options: {
         messages: any[];
         staticModel?: string;
         mode: string;
+        allowPlugins?: boolean;
     }): Promise<any>;
 
     /**

--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -150,6 +150,61 @@ interface MCPToolCallResourceContent {
 type MCPToolCallContent = MCPToolCallTextContent | MCPToolCallImageAudioContent | MCPToolCallResourceContent;
 
 // ============================================================================
+// TTS Hook Types
+// ============================================================================
+
+/**
+ * Context passed to a TTS preprocessor hook. Preprocessors receive the text
+ * that is about to be spoken and may transform it before synthesis.
+ */
+interface BeforeTTSContext {
+    /** The text that will be sent to the TTS provider. */
+    text: string;
+    /** The provider the current character is configured to use (e.g. 'openai', 'gptsovits'). */
+    ttsMode: string;
+    /** The stable character id (character.chaId). Use risuai.getCharacter() if you need the full object. */
+    characterId: string;
+}
+
+/**
+ * Return value of a TTS preprocessor hook. Omit fields to leave them unchanged.
+ */
+interface BeforeTTSResult {
+    /** Replace the text that will be synthesized. */
+    text?: string;
+    /** If true, abort the entire TTS playback for this message (no subsequent hooks run, no audio is played). */
+    skip?: boolean;
+}
+
+/**
+ * Context passed to a TTS postprocessor hook. Postprocessors receive the raw
+ * encoded audio bytes returned by the provider, before they are decoded for
+ * playback. To access PCM, call `await new AudioContext().decodeAudioData(ctx.audio)`.
+ */
+interface AfterTTSContext {
+    /** Raw encoded audio as returned by the provider (mp3, wav, etc.). */
+    audio: ArrayBuffer;
+    /** MIME type of the audio (e.g. 'audio/mpeg', 'audio/wav'). Best-effort. */
+    mimeType: string;
+    /** The provider that produced this audio. */
+    ttsMode: string;
+    /** Stable character id. */
+    characterId: string;
+}
+
+/**
+ * Return value of a TTS postprocessor hook. Omit fields to leave them unchanged.
+ */
+interface AfterTTSResult {
+    /** Replace the audio bytes that will be played. If you change the codec, set mimeType too. */
+    audio?: ArrayBuffer;
+    /** Updated MIME type (if you changed the codec). */
+    mimeType?: string;
+    /** If true, skip playback entirely (hooks after this one are not called). */
+    skip?: boolean;
+}
+
+// ============================================================================
 // Core Types
 // ============================================================================
 
@@ -1590,6 +1645,63 @@ interface RisuaiPluginAPI {
         name: string,
         func: ProviderFunction,
         options?: ProviderOptions
+    ): Promise<void>;
+
+    // ========== TTS Hooks ==========
+
+    /**
+     * Registers a preprocessor that runs before every TTS synthesis.
+     * The hook may transform the text or abort playback by returning `{ skip: true }`.
+     *
+     * Multiple preprocessors run sequentially in registration order — each hook
+     * receives the previous hook's output. If a hook throws, its result is
+     * discarded and the next hook runs.
+     *
+     * No timeout is enforced on hook execution (consistent with
+     * `addRisuScriptHandler` and `addRisuReplacer`), so a hook that hangs will
+     * stall TTS playback for that message. Plugins that call slow services
+     * (auxiliary LLMs, remote analysis) should implement their own
+     * `AbortController` + timer if cancellation is needed.
+     *
+     * Applies to all providers (including 'webspeech'). No permission prompt.
+     * Auto-unregistered when the plugin unloads.
+     *
+     * @example
+     * ```typescript
+     * await risuai.addTTSPreprocessor(async (ctx) => {
+     *   if (ctx.ttsMode !== 'openai') return;
+     *   return { text: ctx.text.replace(/\*(.*?)\*/g, '') };
+     * });
+     * ```
+     */
+    addTTSPreprocessor(
+        func: (ctx: BeforeTTSContext) => Promise<BeforeTTSResult | void> | BeforeTTSResult | void,
+    ): Promise<void>;
+
+    /**
+     * Registers a postprocessor that runs after synthesis, just before playback.
+     * The hook receives the raw encoded audio bytes and may return replacement
+     * audio (with optional new mimeType) or `{ skip: true }` to suppress playback.
+     *
+     * Sequential pipeline semantics identical to `addTTSPreprocessor`. No
+     * timeout is enforced on hook execution; plugins that perform long-running
+     * audio transforms should self-manage cancellation.
+     *
+     * Skipped for the 'webspeech' provider (browser-native synthesis does not
+     * produce an audio buffer) and the 'vits' provider (uses a separate playback
+     * path that does not flow through the shared helper).
+     *
+     * @example
+     * ```typescript
+     * await risuai.addTTSPostprocessor(async (ctx) => {
+     *   const audioBuffer = await new AudioContext().decodeAudioData(ctx.audio);
+     *   // ... analyse / normalize / re-encode ...
+     *   return { audio: normalizedBytes, mimeType: 'audio/wav' };
+     * });
+     * ```
+     */
+    addTTSPostprocessor(
+        func: (ctx: AfterTTSContext) => Promise<AfterTTSResult | void> | AfterTTSResult | void,
     ): Promise<void>;
 
     // ========== Script Handlers ==========

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -21,6 +21,17 @@ import { sendChat as processSendChat, doingChat } from "src/ts/process/index.sve
 import { getModelInfo } from "src/ts/model/modellist";
 import type { ModelModeExtended } from "src/ts/process/request/shared";
 import { requestChatDataMain } from "src/ts/process/request/request";
+import {
+    registerTTSPreprocessor,
+    unregisterTTSPreprocessor,
+    registerTTSPostprocessor,
+    unregisterTTSPostprocessor,
+    type BeforeTTSContext,
+    type BeforeTTSResult,
+    type AfterTTSContext,
+    type AfterTTSResult,
+    type TTSHookFn,
+} from "src/ts/process/ttsHooks";
 
 /*
     V3 API for RisuAI Plugins
@@ -666,6 +677,18 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                 tokenizer:options?.model?.tokenizer ??  LLMTokenizer.Unknown
             }
             customV3ProviderMetaStore.push(modelData);
+        },
+        addTTSPreprocessor: async (
+            func: TTSHookFn<BeforeTTSContext, BeforeTTSResult>,
+        ) => {
+            registerTTSPreprocessor(func);
+            addPluginUnloadCallback(plugin.name, () => unregisterTTSPreprocessor(func));
+        },
+        addTTSPostprocessor: async (
+            func: TTSHookFn<AfterTTSContext, AfterTTSResult>,
+        ) => {
+            registerTTSPostprocessor(func);
+            addPluginUnloadCallback(plugin.name, () => unregisterTTSPostprocessor(func));
         },
         addRisuScriptHandler: oldApis.addRisuScriptHandler,
         removeRisuScriptHandler: oldApis.removeRisuScriptHandler,

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -1167,14 +1167,21 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             mode: ModelModeExtended
             messages: OpenAIChat[]
             staticModel?: string
+            allowPlugins?: boolean
         }) => {
             return requestChatDataMain({
                 formated: options.messages,
                 bias: {},
                 staticModel: options.staticModel,
 
-                //Executing plugin provider is block because it can be used for loopholes for ipc right now.
-                blockPlugins: true
+                // Calls into plugin-provided models are blocked by default to
+                // guard against accidental IPC loops between provider plugins.
+                // Plugin authors who need to reach the user's plugin-supplied
+                // main or auxiliary model (e.g. a TTS preprocessor that
+                // rewrites text with the configured otherAx model) can opt in
+                // explicitly with `allowPlugins: true`, accepting responsibility
+                // for avoiding provider-to-provider call loops.
+                blockPlugins: !options.allowPlugins,
             }, options.mode)
         },
         sendChat: async (message: string) => {

--- a/src/ts/plugins/migrationGuide.md
+++ b/src/ts/plugins/migrationGuide.md
@@ -473,6 +473,23 @@ const oldKeys = risuai._getOldKeys()
 
 **Note:** Methods prefixed with `_` are internal and subject to change without notice.
 
+#### TTS Hooks (v3.0)
+
+Plugins can intercept Text-to-Speech both before synthesis (transform the text) and before playback (transform or swap the audio):
+
+```javascript
+await risuai.addTTSPreprocessor(async (ctx) => {
+  return { text: ctx.text + ' (via plugin)' }
+})
+
+await risuai.addTTSPostprocessor(async (ctx) => {
+  // ctx.audio is the raw encoded bytes; decode to PCM if needed.
+  // Return { audio, mimeType } to swap, { skip: true } to suppress playback.
+})
+```
+
+Sequential pipeline with error isolation, no enforced timeout (same trust model as `addRisuScriptHandler`), no permission prompt, auto-unregister on plugin unload. See `plugins.md` (Advanced Features → TTS Hooks) for the full reference.
+
 ### Security Model
 
 API v3.0 implements multiple security layers:

--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -17,28 +17,60 @@ import {
 
 let sourceNode:AudioBufferSourceNode = null
 
-async function playAudio(audio: ArrayBuffer, mimeType: string, ctx: { ttsMode: string; characterId: string }): Promise<void> {
+/**
+ * Run every registered TTS postprocessor hook against the audio bytes, honoring
+ * replacement audio / mimeType / skip semantics. Before each hook invocation a
+ * fresh slice of the current base audio is handed to the hook as its disposable
+ * copy — the plugin sandbox postMessage layer transfers that buffer into the
+ * iframe and neuters it on the host side, so reusing a single slice across
+ * multiple hooks would leave all hooks after the first with a detached buffer.
+ *
+ * Returns the final audio bytes (possibly replaced by a hook), the final
+ * mimeType, and whether a hook requested a skip.
+ */
+async function runPostprocessorPipeline(
+    audio: ArrayBuffer,
+    mimeType: string,
+    ctx: { ttsMode: string; characterId: string },
+): Promise<{ audio: ArrayBuffer; mimeType: string; skip: boolean }> {
     const hooks = getTTSPostprocessors();
-    // The plugin sandbox transfers ArrayBuffer ownership across postMessage,
-    // which neuters the original on this side. Hand the hooks a disposable
-    // copy so the main thread always retains a usable buffer to play.
-    const audioForHook = hooks.length > 0 ? audio.slice(0) : audio;
+    if (hooks.length === 0) return { audio, mimeType, skip: false };
 
-    const afterResult = await runHookPipeline<AfterTTSContext, AfterTTSResult>(
-        hooks,
-        { audio: audioForHook, mimeType, ttsMode: ctx.ttsMode, characterId: ctx.characterId },
-    );
-    if (afterResult.skip) return;
+    let currentAudio = audio;
+    let currentMime = mimeType;
 
-    // If a hook returned replacement audio, use it. Otherwise the ctx still
-    // points at audioForHook, which is detached after being transferred —
-    // detect via byteLength === 0 and fall back to the untouched original.
-    const finalAudio = afterResult.ctx.audio.byteLength > 0
-        ? afterResult.ctx.audio
-        : audio;
+    for (const hook of hooks) {
+        const disposable = currentAudio.slice(0); // fresh clone per hook
+        let result: AfterTTSResult | void;
+        try {
+            result = await Promise.resolve().then(() =>
+                hook({
+                    audio: disposable,
+                    mimeType: currentMime,
+                    ttsMode: ctx.ttsMode,
+                    characterId: ctx.characterId,
+                })
+            );
+        } catch (err) {
+            console.error('[TTS postprocessor] threw, continuing with next hook:', err);
+            continue;
+        }
+
+        if (!result) continue;
+        if (result.skip) return { audio: currentAudio, mimeType: currentMime, skip: true };
+        if (result.audio && result.audio.byteLength > 0) currentAudio = result.audio;
+        if (typeof result.mimeType === 'string' && result.mimeType) currentMime = result.mimeType;
+    }
+
+    return { audio: currentAudio, mimeType: currentMime, skip: false };
+}
+
+async function playAudio(audio: ArrayBuffer, mimeType: string, ctx: { ttsMode: string; characterId: string }): Promise<void> {
+    const processed = await runPostprocessorPipeline(audio, mimeType, ctx);
+    if (processed.skip) return;
 
     const audioContext = new AudioContext();
-    const decoded = await audioContext.decodeAudioData(finalAudio);
+    const decoded = await audioContext.decodeAudioData(processed.audio);
     sourceNode = audioContext.createBufferSource();
     sourceNode.buffer = decoded;
     sourceNode.connect(audioContext.destination);
@@ -312,21 +344,27 @@ export async function sayTTS(character:character,text:string) {
 
                 if (response.ok) {
                     const mimeType = 'audio/wav'
+                    const hookCtx = { ttsMode: character.ttsMode ?? '', characterId: character.chaId }
                     const volume = character.gptSoVitsConfig.volume
                     if (volume !== undefined && volume !== 1.0) {
-                        // Volume != 1.0 requires a GainNode in the graph, so route here
-                        // instead of playAudio to preserve existing per-character volume control.
-                        const audioContext = new AudioContext();
-                        const decoded = await audioContext.decodeAudioData(response.data.buffer);
-                        sourceNode = audioContext.createBufferSource();
-                        sourceNode.buffer = decoded;
-                        const gainNode = audioContext.createGain();
-                        gainNode.gain.value = volume;
-                        sourceNode.connect(gainNode);
-                        gainNode.connect(audioContext.destination);
-                        sourceNode.start();
+                        // Volume != 1.0 requires a GainNode in the graph, so we can't
+                        // route through playAudio directly. Run the postprocessor
+                        // pipeline first to honor plugin hooks consistently, then
+                        // build the gain-enabled graph with the final bytes.
+                        const processed = await runPostprocessorPipeline(response.data.buffer, mimeType, hookCtx)
+                        if (!processed.skip) {
+                            const audioContext = new AudioContext();
+                            const decoded = await audioContext.decodeAudioData(processed.audio);
+                            sourceNode = audioContext.createBufferSource();
+                            sourceNode.buffer = decoded;
+                            const gainNode = audioContext.createGain();
+                            gainNode.gain.value = volume;
+                            sourceNode.connect(gainNode);
+                            gainNode.connect(audioContext.destination);
+                            sourceNode.start();
+                        }
                     } else {
-                        await playAudio(response.data.buffer, mimeType, { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
+                        await playAudio(response.data.buffer, mimeType, hookCtx)
                     }
                 } else {
                     const textBuffer: Uint8Array = response.data.buffer

--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -485,7 +485,15 @@ export function getNovelAIVoices(){
 
 export function FixNAITTS(data:character){
     if (data.naittsConfig === undefined){
-        data.naittsConfig = { voice: 'Anananan' }
+        // Mirror the defaults used by CharConfig.svelte's $effect.pre
+        // initializer so that the NovelAI request URL — which templates
+        // in `version` and branches on `customvoice` — gets valid values
+        // instead of the literal string "undefined".
+        data.naittsConfig = {
+            customvoice: false,
+            voice: 'Anananan',
+            version: 'v2',
+        }
     }
 
     return data

--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -8,6 +8,15 @@ import { runVITS } from "./transformers";
 
 let sourceNode:AudioBufferSourceNode = null
 
+async function playAudio(audio: ArrayBuffer, _mimeType: string): Promise<void> {
+    const audioContext = new AudioContext();
+    const decoded = await audioContext.decodeAudioData(audio);
+    sourceNode = audioContext.createBufferSource();
+    sourceNode.buffer = decoded;
+    sourceNode.connect(audioContext.destination);
+    sourceNode.start();
+}
+
 export async function sayTTS(character:character,text:string) {
     try {
         if(!character){
@@ -52,7 +61,6 @@ export async function sayTTS(character:character,text:string) {
                 break
             }
             case "elevenlab": {
-                const audioContext = new AudioContext();
                 const da = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${character.ttsSpeech}`, {
                     body: JSON.stringify({
                         text: text,
@@ -65,11 +73,9 @@ export async function sayTTS(character:character,text:string) {
                     }
                 })
                 if(da.status >= 200 && da.status < 300){
-                    const audioBuffer = await audioContext.decodeAudioData(await da.arrayBuffer())
-                    sourceNode = audioContext.createBufferSource();
-                    sourceNode.buffer = audioBuffer;
-                    sourceNode.connect(audioContext.destination);            
-                    sourceNode.start();
+                    const buffer = await da.arrayBuffer()
+                    const mimeType = da.headers.get('content-type') || 'audio/mpeg'
+                    await playAudio(buffer, mimeType)
                 }
                 else{
                     alertError(await da.text())
@@ -78,7 +84,6 @@ export async function sayTTS(character:character,text:string) {
             }
             case "VOICEVOX": {
                 const jpText = await translateVox(text)
-                const audioContext = new AudioContext();
                 const query = await fetch(`${db.voicevoxUrl}/audio_query?text=${jpText}&speaker=${character.ttsSpeech}`, {
                     method: 'POST',
                     headers: { "Content-Type": "application/json"},
@@ -103,11 +108,7 @@ export async function sayTTS(character:character,text:string) {
                         body: JSON.stringify(bodyData),
                     })
                     if (getVoice.status == 200 && getVoice.headers.get('content-type') === 'audio/wav'){
-                        const audioBuffer = await audioContext.decodeAudioData(await getVoice.arrayBuffer())
-                        sourceNode = audioContext.createBufferSource();
-                        sourceNode.buffer = audioBuffer;
-                        sourceNode.connect(audioContext.destination);
-                        sourceNode.start();
+                        await playAudio(await getVoice.arrayBuffer(), 'audio/wav')
                     }
                 }
                 break
@@ -133,13 +134,8 @@ export async function sayTTS(character:character,text:string) {
                 if(res.ok){
                     try {
                         const audio = Buffer.from(dat).buffer
-                        const audioContext = new AudioContext();
-                        const audioBuffer = await audioContext.decodeAudioData(audio)
-                        sourceNode = audioContext.createBufferSource();
-                        sourceNode.buffer = audioBuffer;
-                        sourceNode.connect(audioContext.destination);
-                        sourceNode.start();
-                    } catch (error) {                    
+                        await playAudio(audio, 'audio/mpeg')
+                    } catch (error) {
                         alertError(language.errors.httpError + `${error}`)
                     }
                 }
@@ -155,15 +151,14 @@ export async function sayTTS(character:character,text:string) {
     
             }
             case 'novelai': {
-                const audioContext = new AudioContext();
                 if(text === ''){
                     break;
                 }
                 const encodedText = encodeURIComponent(text);
                 const encodedSeed = encodeURIComponent(character.naittsConfig.voice);
-    
+
                 const url = `https://api.novelai.net/ai/generate-voice?text=${encodedText}&voice=-1&seed=${encodedSeed}&opus=false&version=${character.naittsConfig.version}`;
-    
+
                 const response = await globalFetch(url, {
                     method: 'GET',
                     headers: {
@@ -171,15 +166,9 @@ export async function sayTTS(character:character,text:string) {
                     },
                     rawResponse: true
                 });
-            
+
                 if (response.ok) {
-                    const audioBuffer = response.data.buffer;
-                    audioContext.decodeAudioData(audioBuffer, (decodedData) => {
-                        const sourceNode = audioContext.createBufferSource();
-                        sourceNode.buffer = decodedData;
-                        sourceNode.connect(audioContext.destination);
-                        sourceNode.start();
-                    });
+                    await playAudio(response.data.buffer, 'audio/wav')
                 } else {
                     alertError("Error fetching or decoding audio data");
                 }
@@ -190,7 +179,6 @@ export async function sayTTS(character:character,text:string) {
                     if(character.hfTTS.language !== 'en'){
                         text = await runTranslator(text, false, 'en', character.hfTTS.language)
                     }
-                    const audioContext = new AudioContext();
                     const response = await fetch(`https://api-inference.huggingface.co/models/${character.hfTTS.model}`, {
                         method: 'POST',
                         headers: {
@@ -201,7 +189,7 @@ export async function sayTTS(character:character,text:string) {
                             inputs: text,
                         })
                     });
-        
+
                     if(response.status === 503 && response.headers.get('content-type') === 'application/json'){
                         const json = await response.json()
                         if(json.estimated_time){
@@ -214,13 +202,9 @@ export async function sayTTS(character:character,text:string) {
                         return
                     }
                     else if (response.status === 200) {
-                        const audioBuffer = await response.arrayBuffer();
-                        audioContext.decodeAudioData(audioBuffer, (decodedData) => {
-                            const sourceNode = audioContext.createBufferSource();
-                            sourceNode.buffer = decodedData;
-                            sourceNode.connect(audioContext.destination);
-                            sourceNode.start();
-                        });
+                        const buffer = await response.arrayBuffer();
+                        const mimeType = response.headers.get('content-type') || 'audio/wav'
+                        await playAudio(buffer, mimeType)
                     } else {
                         alertError("Error fetching or decoding audio data");
                     }
@@ -232,8 +216,6 @@ export async function sayTTS(character:character,text:string) {
                 break;
             }
             case 'gptsovits':{
-                const audioContext = new AudioContext();
-
                 const audio: Uint8Array = await loadAsset(character.gptSoVitsConfig.ref_audio_data.assetId);
                 const base64Audio = btoa(new Uint8Array(audio).reduce((data, byte) => data + String.fromCharCode(byte), ''));
 
@@ -292,19 +274,23 @@ export async function sayTTS(character:character,text:string) {
                 console.log(response)
 
                 if (response.ok) {
-                    const audioBuffer = response.data.buffer;
-                    audioContext.decodeAudioData(audioBuffer, (decodedData) => {
-                        const sourceNode = audioContext.createBufferSource();
-                        sourceNode.buffer = decodedData;
-                        
+                    const mimeType = 'audio/wav'
+                    const volume = character.gptSoVitsConfig.volume
+                    if (volume !== undefined && volume !== 1.0) {
+                        // Volume != 1.0 requires a GainNode in the graph, so route here
+                        // instead of playAudio to preserve existing per-character volume control.
+                        const audioContext = new AudioContext();
+                        const decoded = await audioContext.decodeAudioData(response.data.buffer);
+                        sourceNode = audioContext.createBufferSource();
+                        sourceNode.buffer = decoded;
                         const gainNode = audioContext.createGain();
-                        gainNode.gain.value = character.gptSoVitsConfig.volume || 1.0;
-                        
+                        gainNode.gain.value = volume;
                         sourceNode.connect(gainNode);
                         gainNode.connect(audioContext.destination);
-                        
                         sourceNode.start();
-                    });
+                    } else {
+                        await playAudio(response.data.buffer, mimeType)
+                    }
                 } else {
                     const textBuffer: Uint8Array = response.data.buffer
                     const text = Buffer.from(textBuffer).toString('utf-8')
@@ -316,7 +302,6 @@ export async function sayTTS(character:character,text:string) {
                 if (character.fishSpeechConfig.model._id === ''){
                     throw new Error('FishSpeech Model is not selected')
                 }
-                const audioContext = new AudioContext();
 
                 const body = {
                     text: text,
@@ -342,18 +327,13 @@ export async function sayTTS(character:character,text:string) {
                 console.log(response)
 
                 if (response.ok) {
-                    const audioBuffer = response.data.buffer;
-                    audioContext.decodeAudioData(audioBuffer, (decodedData) => {
-                        const sourceNode = audioContext.createBufferSource();
-                        sourceNode.buffer = decodedData;
-                        sourceNode.connect(audioContext.destination);
-                        sourceNode.start();
-                    });
+                    await playAudio(response.data.buffer, 'audio/mpeg')
                 } else {
                     const textBuffer: Uint8Array = response.data.buffer
                     const text = Buffer.from(textBuffer).toString('utf-8')
                     throw new Error(text);
                 }
+                break;
             }
         }   
     } catch (error) {
@@ -430,7 +410,7 @@ export function getNovelAIVoices(){
 
 export function FixNAITTS(data:character){
     if (data.naittsConfig === undefined){
-        data.naittsConfig.voice = 'Anananan'
+        data.naittsConfig = { voice: 'Anananan' }
     }
 
     return data

--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -5,12 +5,40 @@ import { globalFetch, loadAsset } from "../globalApi.svelte";
 import { language } from "src/lang";
 import { sleep } from "../util";
 import { runVITS } from "./transformers";
+import {
+    getTTSPreprocessors,
+    getTTSPostprocessors,
+    runHookPipeline,
+    type BeforeTTSContext,
+    type BeforeTTSResult,
+    type AfterTTSContext,
+    type AfterTTSResult,
+} from "./ttsHooks";
 
 let sourceNode:AudioBufferSourceNode = null
 
-async function playAudio(audio: ArrayBuffer, _mimeType: string): Promise<void> {
+async function playAudio(audio: ArrayBuffer, mimeType: string, ctx: { ttsMode: string; characterId: string }): Promise<void> {
+    const hooks = getTTSPostprocessors();
+    // The plugin sandbox transfers ArrayBuffer ownership across postMessage,
+    // which neuters the original on this side. Hand the hooks a disposable
+    // copy so the main thread always retains a usable buffer to play.
+    const audioForHook = hooks.length > 0 ? audio.slice(0) : audio;
+
+    const afterResult = await runHookPipeline<AfterTTSContext, AfterTTSResult>(
+        hooks,
+        { audio: audioForHook, mimeType, ttsMode: ctx.ttsMode, characterId: ctx.characterId },
+    );
+    if (afterResult.skip) return;
+
+    // If a hook returned replacement audio, use it. Otherwise the ctx still
+    // points at audioForHook, which is detached after being transferred —
+    // detect via byteLength === 0 and fall back to the untouched original.
+    const finalAudio = afterResult.ctx.audio.byteLength > 0
+        ? afterResult.ctx.audio
+        : audio;
+
     const audioContext = new AudioContext();
-    const decoded = await audioContext.decodeAudioData(audio);
+    const decoded = await audioContext.decodeAudioData(finalAudio);
     sourceNode = audioContext.createBufferSource();
     sourceNode.buffer = decoded;
     sourceNode.connect(audioContext.destination);
@@ -43,7 +71,16 @@ export async function sayTTS(character:character,text:string) {
                 text = ''
             }
         }
-    
+
+        const beforeResult = await runHookPipeline<BeforeTTSContext, BeforeTTSResult>(
+            getTTSPreprocessors(),
+            { text, ttsMode: character.ttsMode ?? '', characterId: character.chaId },
+        );
+        if (beforeResult.skip) {
+            return;
+        }
+        text = beforeResult.ctx.text;
+
         switch(character.ttsMode){
             case "webspeech":{
                 if(speechSynthesis && SpeechSynthesisUtterance){
@@ -75,7 +112,7 @@ export async function sayTTS(character:character,text:string) {
                 if(da.status >= 200 && da.status < 300){
                     const buffer = await da.arrayBuffer()
                     const mimeType = da.headers.get('content-type') || 'audio/mpeg'
-                    await playAudio(buffer, mimeType)
+                    await playAudio(buffer, mimeType, { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                 }
                 else{
                     alertError(await da.text())
@@ -108,7 +145,7 @@ export async function sayTTS(character:character,text:string) {
                         body: JSON.stringify(bodyData),
                     })
                     if (getVoice.status == 200 && getVoice.headers.get('content-type') === 'audio/wav'){
-                        await playAudio(await getVoice.arrayBuffer(), 'audio/wav')
+                        await playAudio(await getVoice.arrayBuffer(), 'audio/wav', { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                     }
                 }
                 break
@@ -134,7 +171,7 @@ export async function sayTTS(character:character,text:string) {
                 if(res.ok){
                     try {
                         const audio = Buffer.from(dat).buffer
-                        await playAudio(audio, 'audio/mpeg')
+                        await playAudio(audio, 'audio/mpeg', { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                     } catch (error) {
                         alertError(language.errors.httpError + `${error}`)
                     }
@@ -168,7 +205,7 @@ export async function sayTTS(character:character,text:string) {
                 });
 
                 if (response.ok) {
-                    await playAudio(response.data.buffer, 'audio/wav')
+                    await playAudio(response.data.buffer, 'audio/wav', { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                 } else {
                     alertError("Error fetching or decoding audio data");
                 }
@@ -204,7 +241,7 @@ export async function sayTTS(character:character,text:string) {
                     else if (response.status === 200) {
                         const buffer = await response.arrayBuffer();
                         const mimeType = response.headers.get('content-type') || 'audio/wav'
-                        await playAudio(buffer, mimeType)
+                        await playAudio(buffer, mimeType, { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                     } else {
                         alertError("Error fetching or decoding audio data");
                     }
@@ -289,7 +326,7 @@ export async function sayTTS(character:character,text:string) {
                         gainNode.connect(audioContext.destination);
                         sourceNode.start();
                     } else {
-                        await playAudio(response.data.buffer, mimeType)
+                        await playAudio(response.data.buffer, mimeType, { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                     }
                 } else {
                     const textBuffer: Uint8Array = response.data.buffer
@@ -327,7 +364,7 @@ export async function sayTTS(character:character,text:string) {
                 console.log(response)
 
                 if (response.ok) {
-                    await playAudio(response.data.buffer, 'audio/mpeg')
+                    await playAudio(response.data.buffer, 'audio/mpeg', { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                 } else {
                     const textBuffer: Uint8Array = response.data.buffer
                     const text = Buffer.from(textBuffer).toString('utf-8')
@@ -335,7 +372,7 @@ export async function sayTTS(character:character,text:string) {
                 }
                 break;
             }
-        }   
+        }
     } catch (error) {
         alertError(`TTS Error: ${error}`)
     }

--- a/src/ts/process/ttsHooks.test.ts
+++ b/src/ts/process/ttsHooks.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+    runHookPipeline,
+    type BeforeTTSContext,
+    type BeforeTTSResult,
+    type TTSHookFn,
+} from './ttsHooks';
+
+const makeCtx = (overrides: Partial<BeforeTTSContext> = {}): BeforeTTSContext => ({
+    text: 'hello',
+    ttsMode: 'openai',
+    characterId: 'char-1',
+    ...overrides,
+});
+
+describe('runHookPipeline', () => {
+    it('returns the original ctx when no hooks are registered', async () => {
+        const ctx = makeCtx();
+        const result = await runHookPipeline<BeforeTTSContext, BeforeTTSResult>([], ctx, 1000);
+        expect(result.skip).toBe(false);
+        expect(result.ctx).toEqual(ctx);
+    });
+
+    it('applies a single hook that transforms text', async () => {
+        const hook: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async (c) => ({ text: c.text + '!' });
+        const result = await runHookPipeline([hook], makeCtx(), 1000);
+        expect(result.skip).toBe(false);
+        expect(result.ctx.text).toBe('hello!');
+    });
+
+    it('chains two hooks — second sees the first\'s output', async () => {
+        const a: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async (c) => ({ text: c.text + ' A' });
+        const b: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async (c) => ({ text: c.text + ' B' });
+        const result = await runHookPipeline([a, b], makeCtx(), 1000);
+        expect(result.ctx.text).toBe('hello A B');
+    });
+
+    it('short-circuits on skip=true and does not call later hooks', async () => {
+        const a: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async () => ({ skip: true });
+        const b = vi.fn<TTSHookFn<BeforeTTSContext, BeforeTTSResult>>(async (c) => ({ text: c.text + ' B' }));
+        const result = await runHookPipeline([a, b], makeCtx(), 1000);
+        expect(result.skip).toBe(true);
+        expect(b).not.toHaveBeenCalled();
+    });
+
+    it('isolates a hook that throws — continues with next hook, keeps original ctx for the throwing one', async () => {
+        const a: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async () => { throw new Error('boom'); };
+        const b: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async (c) => ({ text: c.text + ' B' });
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            const result = await runHookPipeline([a, b], makeCtx(), 1000);
+            expect(result.skip).toBe(false);
+            expect(result.ctx.text).toBe('hello B');
+            expect(errSpy).toHaveBeenCalled();
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
+
+    it('isolates a hook that exceeds the timeout', async () => {
+        const slow: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = () => new Promise(() => { /* never resolves */ });
+        const fast: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async (c) => ({ text: c.text + ' F' });
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            const result = await runHookPipeline([slow, fast], makeCtx(), 50);
+            expect(result.skip).toBe(false);
+            expect(result.ctx.text).toBe('hello F');
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
+
+    it('treats an undefined return as a no-op', async () => {
+        const noop: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async () => undefined;
+        const next: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async (c) => ({ text: c.text + ' N' });
+        const result = await runHookPipeline([noop, next], makeCtx(), 1000);
+        expect(result.ctx.text).toBe('hello N');
+    });
+
+    it('ignores undefined fields in a result (does not overwrite ctx with undefined)', async () => {
+        const hook: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = async () => ({ text: undefined });
+        const result = await runHookPipeline([hook], makeCtx({ text: 'keep-me' }), 1000);
+        expect(result.ctx.text).toBe('keep-me');
+    });
+
+    it('accepts synchronous (non-Promise) returns', async () => {
+        const hook: TTSHookFn<BeforeTTSContext, BeforeTTSResult> = (c) => ({ text: c.text + ' S' });
+        const result = await runHookPipeline([hook], makeCtx(), 1000);
+        expect(result.ctx.text).toBe('hello S');
+    });
+});

--- a/src/ts/process/ttsHooks.ts
+++ b/src/ts/process/ttsHooks.ts
@@ -48,11 +48,14 @@ export function unregisterTTSPostprocessor(fn: TTSHookFn<AfterTTSContext, AfterT
 }
 
 export function getTTSPreprocessors(): ReadonlyArray<TTSHookFn<BeforeTTSContext, BeforeTTSResult>> {
-    return preprocessors;
+    // Defensive copy: callers iterate over this while hooks may be registered
+    // or unregistered mid-flight (e.g. a plugin unloading). Handing out the
+    // backing array would let such mutations skip or duplicate iterations.
+    return preprocessors.slice();
 }
 
 export function getTTSPostprocessors(): ReadonlyArray<TTSHookFn<AfterTTSContext, AfterTTSResult>> {
-    return postprocessors;
+    return postprocessors.slice();
 }
 
 export async function runHookPipeline<Ctx extends object, Res extends { skip?: boolean }>(

--- a/src/ts/process/ttsHooks.ts
+++ b/src/ts/process/ttsHooks.ts
@@ -1,0 +1,102 @@
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export interface BeforeTTSContext {
+    text: string;
+    ttsMode: string;
+    characterId: string;
+}
+
+export interface BeforeTTSResult {
+    text?: string;
+    skip?: boolean;
+}
+
+export interface AfterTTSContext {
+    audio: ArrayBuffer;
+    mimeType: string;
+    ttsMode: string;
+    characterId: string;
+}
+
+export interface AfterTTSResult {
+    audio?: ArrayBuffer;
+    mimeType?: string;
+    skip?: boolean;
+}
+
+export type TTSHookFn<Ctx, Res> = (ctx: Ctx) => Promise<Res | void> | Res | void;
+
+const preprocessors: TTSHookFn<BeforeTTSContext, BeforeTTSResult>[] = [];
+const postprocessors: TTSHookFn<AfterTTSContext, AfterTTSResult>[] = [];
+
+export function registerTTSPreprocessor(fn: TTSHookFn<BeforeTTSContext, BeforeTTSResult>): void {
+    preprocessors.push(fn);
+}
+
+export function unregisterTTSPreprocessor(fn: TTSHookFn<BeforeTTSContext, BeforeTTSResult>): void {
+    const idx = preprocessors.indexOf(fn);
+    if (idx !== -1) preprocessors.splice(idx, 1);
+}
+
+export function registerTTSPostprocessor(fn: TTSHookFn<AfterTTSContext, AfterTTSResult>): void {
+    postprocessors.push(fn);
+}
+
+export function unregisterTTSPostprocessor(fn: TTSHookFn<AfterTTSContext, AfterTTSResult>): void {
+    const idx = postprocessors.indexOf(fn);
+    if (idx !== -1) postprocessors.splice(idx, 1);
+}
+
+export function getTTSPreprocessors(): ReadonlyArray<TTSHookFn<BeforeTTSContext, BeforeTTSResult>> {
+    return preprocessors;
+}
+
+export function getTTSPostprocessors(): ReadonlyArray<TTSHookFn<AfterTTSContext, AfterTTSResult>> {
+    return postprocessors;
+}
+
+export async function runHookPipeline<Ctx extends object, Res extends { skip?: boolean }>(
+    hooks: ReadonlyArray<TTSHookFn<Ctx, Res>>,
+    ctx: Ctx,
+    timeoutMs?: number,
+): Promise<{ ctx: Ctx; skip: boolean }> {
+    const TIMEOUT = Symbol('TIMEOUT');
+    let current: Ctx = { ...ctx };
+
+    for (const hook of hooks) {
+        let result: Res | void | typeof TIMEOUT;
+        try {
+            const hookPromise = Promise.resolve().then(() => hook(current));
+            if (timeoutMs !== undefined && timeoutMs > 0) {
+                result = await Promise.race<Res | void | typeof TIMEOUT>([
+                    hookPromise,
+                    sleep(timeoutMs).then(() => TIMEOUT),
+                ]);
+            } else {
+                result = await hookPromise;
+            }
+        } catch (err) {
+            console.error('[TTS hook] threw, continuing with next hook:', err);
+            continue;
+        }
+
+        if (result === TIMEOUT) {
+            console.error('[TTS hook] timed out, continuing with next hook');
+            continue;
+        }
+
+        if (!result) continue;
+
+        if (result.skip) {
+            return { ctx: current, skip: true };
+        }
+
+        for (const key of Object.keys(result) as (keyof Res)[]) {
+            if (key === 'skip') continue;
+            const v = (result as any)[key];
+            if (v !== undefined) (current as any)[key] = v;
+        }
+    }
+
+    return { ctx: current, skip: false };
+}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?

## Summary

Two new Plugin API v3 methods — `addTTSPreprocessor` and `addTTSPostprocessor` — that let plugins transform TTS input text and output audio. Bundled with a `playAudio` refactor that fixes `stopTTS()` for four providers, and an `allowPlugins` opt-in on `runLLMModel` so plugins can legitimately reach a user's plugin-supplied main or aux model when they need to.

## Related Issues

None.

## Changes

**Plugin API v3** (`src/ts/plugins/apiV3/v3.svelte.ts`, `risuai.d.ts`)
- `addTTSPreprocessor(func)` / `addTTSPostprocessor(func)` — new hooks with full JSDoc and TypeScript types. Sequential pipeline, error isolation, skip short-circuit. No enforced timeout — same trust model as `addRisuScriptHandler` / `addRisuReplacer`.
- `runLLMModel` gains an optional `allowPlugins` parameter. Default stays `false` (blocked, same as today); plugins that need the user's plugin-supplied main or aux model can opt in explicitly.

**TTS runtime** (`src/ts/process/tts.ts`, new `src/ts/process/ttsHooks.ts`)
- Extract a shared `playAudio(audio, mimeType, ctx)` helper and route every audio-buffer provider through it.
- As a side benefit `stopTTS()` now reliably stops NovelAI, HuggingFace, GPT-SoVITS, and FishSpeech. Each previously declared a local `const sourceNode` inside its `decodeAudioData` callback, shadowing the module-level `let` so `stopTTS()` could not find the node to stop.
- Defensive buffer slice inside `playAudio` so the plugin sandbox's ArrayBuffer transfer does not leave the main thread with a detached buffer.

**Adjacent fixes folded into the refactor commit**
- `FixNAITTS` threw `TypeError` when `naittsConfig` was undefined.
- `fishspeech` case was missing its terminal `break`.

**Docs**
- New "TTS Hooks" section in `plugins.md` with two worked examples.
- Short note in `migrationGuide.md` under "API 3.0".

## Impact

- **Existing behavior is preserved.** The refactor does not change how any provider synthesizes audio; it only consolidates the decode-and-play sequence. `allowPlugins` defaults to `false`, so `runLLMModel` behaves exactly as before for existing plugins.
- **`stopTTS()` now works on every audio-buffer provider.** Before this PR only `elevenlab`, `VOICEVOX`, and `openai` actually stopped on user request. Four other providers silently ignored it.
- **No permission prompt on the new hooks** — same trust model as `addRisuScriptHandler`. Hooks that call slow services (aux LLMs, remote audio processors) are responsible for their own cancellation via `AbortController`.
- **`allowPlugins` is opt-in.** The existing blanket block inside `runLLMModel` prevents a common legitimate case: the user's main or aux model is supplied by a provider plugin (Copilot integrations, OpenRouter-via-plugin, custom proxies). Opt-in preserves the loop-protection default while unblocking those workflows. Opting-in plugins take responsibility for avoiding provider-to-provider call loops.

## Additional Notes

- `webspeech` calls only the preprocessor (no audio buffer exists) and `vits` goes through `runVITS` with its own playback path and bypasses both hooks. Both are documented in `plugins.md`.
- Manual smoke: web build verified — NovelAI plays unchanged; a preprocessor plugin using `allowPlugins: true` successfully routed through a plugin-provided aux model to rewrite a roleplay message into clean Japanese, and the rewritten text is what NovelAI spoke. Tauri desktop and node self-hosted builds are not yet smoke-tested — every changed path goes through shared infrastructure (`globalFetch`, `AudioContext`, plugin iframe postMessage) so target-specific regressions would be surprising, but happy to add those checks if preferred before merge.
- Commits are split so each stands alone. The first commit is a self-contained `stopTTS()` bug fix and could be reviewed / merged independently. If you'd rather see the `allowPlugins` change as its own PR, happy to split it out.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.