### PR TITLE
fix: add configurable trust proxy for reverse proxy deployments

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -1,5 +1,8 @@
 const express = require('express');
 const app = express();
+if (process.env.TRUST_PROXY) {
+    app.set('trust proxy', Number(process.env.TRUST_PROXY) || process.env.TRUST_PROXY);
+}
 const http = require('http');
 const path = require('path');
 const net = require('net');


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - N/A — this change does not affect model behavior.
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds an optional `TRUST_PROXY` environment variable to configure Express's `trust proxy` setting, fixing `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` errors from `express-rate-limit` when running behind a reverse proxy.

<img width="2301" height="287" alt="image" src="https://github.com/user-attachments/assets/1783bf38-53ef-4cd6-8616-53afd39bd1b2" />

## Related Issues

None

## Changes

- When `TRUST_PROXY` env var is set, `app.set('trust proxy', ...)` is called with the provided value (numeric or string).
- When unset, behavior is completely unchanged (default Express behavior).

## Impact

- **Users behind a reverse proxy** (e.g., NGINX, Caddy, Cloudflare): Setting `TRUST_PROXY=1` in their environment (docker-compose, `.env`, etc.) resolves the `express-rate-limit` validation error and enables correct per-client rate limiting via `X-Forwarded-For`.
- **Users connecting directly** (including those using the built-in SSL certificates): No impact — the env var is unset by default, so nothing changes.
- **Existing deployments**: No breaking changes. Opt-in only.

## Additional Notes

The value supports both numeric (`TRUST_PROXY=1` for one proxy hop) and string values (`TRUST_PROXY=loopback` etc.) to accommodate different proxy topologies.