### PR TITLE
feat: add xhigh adaptive thinking effort for Claude Opus 4.7

### DIFF
--- a/src/lib/Setting/Pages/ClaudeThinkingSeparateParams.svelte
+++ b/src/lib/Setting/Pages/ClaudeThinkingSeparateParams.svelte
@@ -1,16 +1,50 @@
 <script lang="ts">
     import { language } from 'src/lang';
     import { DBState } from 'src/ts/stores.svelte';
+    import { getModelInfo } from 'src/ts/model/modellist';
+    import { LLMFlags } from 'src/ts/model/types';
     import SliderInput from 'src/lib/UI/GUI/SliderInput.svelte';
     import SelectInput from 'src/lib/UI/GUI/SelectInput.svelte';
     import OptionInput from 'src/lib/UI/GUI/OptionInput.svelte';
     import type { SeparateParameters } from 'src/ts/storage/database.svelte';
+
+    type AuxModelKey = keyof typeof DBState.db.seperateModels
 
     let {
         value = $bindable()
     }:{
         value: SeparateParameters
     } = $props()
+
+    const auxModelKeys: AuxModelKey[] = ['memory', 'emotion', 'translate', 'otherAx']
+
+    let effectiveModel = $derived.by(() => {
+        if (!paramKey) return DBState.db.subModel
+        if (auxModelKeys.includes(paramKey as AuxModelKey)) {
+            if (DBState.db.seperateModelsForAxModels) {
+                return DBState.db.seperateModels[paramKey as AuxModelKey] || DBState.db.subModel
+            }
+            return DBState.db.subModel
+        }
+        return paramKey
+    })
+    let modelInfo = $derived(getModelInfo(effectiveModel))
+
+    let hasXHighEffort = $derived(modelInfo.flags.includes(LLMFlags.claudeXHighEffort))
+
+    let adaptiveThinkingEffortOptions = $derived([
+        { value: 'low', label: 'Low' },
+        { value: 'medium', label: 'Medium' },
+        { value: 'high', label: 'High' },
+        ...(hasXHighEffort ? [{ value: 'xhigh', label: 'XHigh' }] : []),
+        { value: 'max', label: 'Max' },
+    ])
+
+    $effect(() => {
+        if (value.adaptive_thinking_effort === 'xhigh' && !hasXHighEffort) {
+            value.adaptive_thinking_effort = 'high'
+        }
+    })
 </script>
 
 <span class="text-textcolor">{language.thinkingType ?? 'Thinking Mode'}</span>
@@ -26,9 +60,8 @@
 {#if value.thinking_type === 'adaptive'}
     <span class="text-textcolor">{language.adaptiveThinkingEffort ?? 'Adaptive Thinking Effort'}</span>
     <SelectInput bind:value={value.adaptive_thinking_effort}>
-        <OptionInput value="low">Low</OptionInput>
-        <OptionInput value="medium">Medium</OptionInput>
-        <OptionInput value="high">High</OptionInput>
-        <OptionInput value="max">Max</OptionInput>
+        {#each adaptiveThinkingEffortOptions as option}
+            <OptionInput value={option.value}>{option.label}</OptionInput>
+        {/each}
     </SelectInput>
 {/if}

--- a/src/ts/model/providers/anthropic.ts
+++ b/src/ts/model/providers/anthropic.ts
@@ -35,7 +35,8 @@ export const AnthropicModels: LLMModel[] = [
             LLMFlags.claudeAdaptiveThinking
         ],
         parameters: [...ClaudeParameters, 'thinking_tokens'],
-        tokenizer: LLMTokenizer.Claude
+        tokenizer: LLMTokenizer.Claude,
+        recommended: true
     },
 
     // Claude 4.6 (No Date)

--- a/src/ts/model/providers/anthropic.ts
+++ b/src/ts/model/providers/anthropic.ts
@@ -2,6 +2,24 @@ import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, ClaudeParameters, type 
 
 export const AnthropicModels: LLMModel[] = [
 
+    // Claude 4.7 (No Date)
+    {
+        name: "Claude 4.7 Opus",
+        id: 'claude-opus-4-7',
+        shortName: "4.7 Opus",
+        provider: LLMProvider.Anthropic,
+        format: LLMFormat.Anthropic,
+        flags: [
+            LLMFlags.hasImageInput,
+            LLMFlags.hasFirstSystemPrompt,
+            LLMFlags.hasStreaming,
+            LLMFlags.claudeAdaptiveThinking
+        ],
+        parameters: [],
+        tokenizer: LLMTokenizer.Claude,
+        recommended: true
+    },
+
     // Claude 4.6 (No Date)
     {
         name: "Claude 4.6 Opus",
@@ -17,8 +35,7 @@ export const AnthropicModels: LLMModel[] = [
             LLMFlags.claudeAdaptiveThinking
         ],
         parameters: [...ClaudeParameters, 'thinking_tokens'],
-        tokenizer: LLMTokenizer.Claude,
-        recommended: true
+        tokenizer: LLMTokenizer.Claude
     },
 
     // Claude 4.6 (No Date)

--- a/src/ts/model/providers/anthropic.ts
+++ b/src/ts/model/providers/anthropic.ts
@@ -13,7 +13,8 @@ export const AnthropicModels: LLMModel[] = [
             LLMFlags.hasImageInput,
             LLMFlags.hasFirstSystemPrompt,
             LLMFlags.hasStreaming,
-            LLMFlags.claudeAdaptiveThinking
+            LLMFlags.claudeAdaptiveThinking,
+            LLMFlags.claudeXHighEffort
         ],
         parameters: [],
         tokenizer: LLMTokenizer.Claude,

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -23,7 +23,8 @@ export const LLMFlags = {
     deepSeekThinkingOutput: 19,
     noCivilIntegrity: 20,
     claudeThinking: 21,
-    claudeAdaptiveThinking: 22
+    claudeAdaptiveThinking: 22,
+    claudeXHighEffort: 23
 } as const;
 export type LLMFlags = (typeof LLMFlags)[keyof typeof LLMFlags];
 

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -366,7 +366,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
     else if(db.thinkingType === 'adaptive' && arg.modelInfo.flags.includes(LLMFlags.claudeAdaptiveThinking)){
         // Adaptive thinking mode
         delete body.thinking
-        body.thinking = { type: 'adaptive' }
+        body.thinking = { type: 'adaptive', display: 'summarized' }
         body.output_config = { effort: db.adaptiveThinkingEffort ?? 'high' }
     }
     else if(body?.thinking?.budget_tokens === 0){

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -374,6 +374,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
     }
     else if(body?.thinking?.budget_tokens && body?.thinking?.budget_tokens > 0){
         body.thinking.type = 'enabled'
+        body.thinking.display = 'summarized'
     }
     else if(body?.thinking?.budget_tokens === null){
         delete body.thinking

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -367,7 +367,11 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
         // Adaptive thinking mode
         delete body.thinking
         body.thinking = { type: 'adaptive', display: 'summarized' }
-        body.output_config = { effort: db.adaptiveThinkingEffort ?? 'high' }
+        let effort = db.adaptiveThinkingEffort ?? 'high'
+        if(effort === 'xhigh' && !arg.modelInfo.flags.includes(LLMFlags.claudeXHighEffort)){
+            effort = 'high'
+        }
+        body.output_config = { effort }
     }
     else if(body?.thinking?.budget_tokens === 0){
         delete body.thinking

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -55,6 +55,7 @@ export const samplingParameterItems: SettingItem[] = [
         labelKey: 'temperature',
         helpKey: 'tempature',
         bindKey: 'temperature',
+        condition: (ctx) => ctx.modelInfo.parameters.includes('temperature'),
         options: {
             min: 0,
             max: 200,

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -169,6 +169,7 @@ export const modelSpecificParameterItems: SettingItem[] = [
                 { value: 'low', label: 'Low' },
                 { value: 'medium', label: 'Medium' },
                 { value: 'high', label: 'High' },
+                { value: 'xhigh', label: 'XHigh', condition: (ctx) => ctx.modelInfo.flags.includes(LLMFlags.claudeXHighEffort) },
                 { value: 'max', label: 'Max' },
             ]
         },

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1098,7 +1098,7 @@ export interface Database{
     useExperimentalGoogleTranslator:boolean
     thinkingTokens: number
     thinkingType: 'off' | 'budget' | 'adaptive'
-    adaptiveThinkingEffort: 'low' | 'medium' | 'high' | 'max'
+    adaptiveThinkingEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max'
     antiServerOverloads: boolean
     hypaCustomSettings: {
         url: string,
@@ -1233,7 +1233,7 @@ export interface SeparateParameters{
     reasoning_effort?:number
     thinking_tokens?:number
     thinking_type?: 'off' | 'budget' | 'adaptive'
-    adaptive_thinking_effort?: 'low' | 'medium' | 'high' | 'max'
+    adaptive_thinking_effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max'
     outputImageModal?:boolean
     verbosity?:number
 }
@@ -1577,7 +1577,7 @@ export interface botPreset{
     reasonEffort?:number
     thinkingTokens?:number
     thinkingType?: 'off' | 'budget' | 'adaptive'
-    adaptiveThinkingEffort?: 'low' | 'medium' | 'high' | 'max'
+    adaptiveThinkingEffort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max'
     outputImageModal?:boolean
     seperateModelsForAxModels?:boolean
     seperateModels?:{


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add the `xhigh` adaptive thinking effort level, gated to models with `LLMFlags.claudeXHighEffort` (currently only Claude Opus 4.7).

## Dependencies

- Depends on #1397 for the Claude Opus 4.7 model entry
  - To see diff between these two branches, go to [this link](https://github.com/tasoo-oos/Risuai/compare/feat-claude-opus-47...feat-xhigh-thinking)

## Changes

- Added `LLMFlags.claudeXHighEffort` flag and applied it to Claude Opus 4.7
- Added `xhigh` to adaptive thinking effort type unions (`Database`, `SeparateParameters`, `botPreset`)
- Added `xhigh` option in bot settings, visible only when the model has `claudeXHighEffort`
- Added `xhigh` option in `ClaudeThinkingSeparateParams` with model-aware gating via `paramKey`
- Added request-time fallback so stale `xhigh` values downgrade to `high` on unsupported models

## Impact

- Currently, `xhigh` is only selectable for Claude Opus 4.7
- If a saved config has `xhigh` on an unsupported model: the UI hides it, separate params reset to `high`, and the request path downgrades as a final guard
- No change to existing models or effort levels