### PR TITLE
feat: add Ollama Cloud provider support

### DIFF
--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -262,18 +262,18 @@
         />
 
         {#if DBState.db.ollamaInputMode === 'manual'}
-            <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaModel} placeholder="Model" oninput={() => DBState.db.ollamaModelName = ''} />
+            <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaCloudModel} placeholder="Model" oninput={() => DBState.db.ollamaCloudModelName = ''} />
         {:else}
             {#await getOllamaModels(DBState.db.ollamaURL, 'cloud', DBState.db.ollamaApiKey)}
-                <ModelGrid bind:value={DBState.db.ollamaModel} loading={true} />
+                <ModelGrid bind:value={DBState.db.ollamaCloudModel} loading={true} />
             {:then cloudModels}
                 <ModelGrid
-                    bind:value={DBState.db.ollamaModel}
+                    bind:value={DBState.db.ollamaCloudModel}
                     items={cloudModels ?? []}
-                    selectedLabelOverride={DBState.db.ollamaModel ? `Cloud / ${DBState.db.ollamaModelName || DBState.db.ollamaModel}` : undefined}
+                    selectedLabelOverride={DBState.db.ollamaCloudModel ? `Cloud / ${DBState.db.ollamaCloudModelName || DBState.db.ollamaCloudModel}` : undefined}
                     onselect={(_id, name) => {
                         DBState.db.ollamaModelSource = 'cloud'
-                        DBState.db.ollamaModelName = name
+                        DBState.db.ollamaCloudModelName = name
                     }}
                 />
             {/await}
@@ -305,7 +305,7 @@
             </div>
         {/if}
 
-        {#if usesOllamaLocal && !usesOllamaCloud}
+        {#if usesOllamaLocal}
         <span class="text-textcolor mt-4">Ollama Model</span>
         <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaModel} placeholder="Model" oninput={() => { DBState.db.ollamaModelSource = 'local'; DBState.db.ollamaModelName = '' }} />
         {/if}

--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -309,6 +309,30 @@
         <span class="text-textcolor mt-4">Ollama Model</span>
         <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaModel} placeholder="Model" oninput={() => { DBState.db.ollamaModelSource = 'local'; DBState.db.ollamaModelName = '' }} />
         {/if}
+
+        {#if usesOllamaLocal || (usesOllamaCloud && DBState.db.ollamaRequestFormat === LLMFormat.Ollama)}
+        <span class="text-textcolor mt-4">Ollama Thinking</span>
+        <SelectInput bind:value={DBState.db.ollamaThinkingMode}>
+            <OptionInput value="auto">
+                Auto
+            </OptionInput>
+            <OptionInput value="off">
+                Off
+            </OptionInput>
+            <OptionInput value="on">
+                On
+            </OptionInput>
+            <OptionInput value="low">
+                Low
+            </OptionInput>
+            <OptionInput value="medium">
+                Medium
+            </OptionInput>
+            <OptionInput value="high">
+                High
+            </OptionInput>
+        </SelectInput>
+        {/if}
     {/if}
     {#if DBState.db.aiModel === 'nanogpt' || DBState.db.subModel === 'nanogpt'}
         <span class="text-textcolor mt-4">NanoGPT {language.apiKey}</span>

--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -23,6 +23,7 @@
     import SegmentedControl from "src/lib/UI/GUI/SegmentedControl.svelte";
     import { getOpenRouterModels, toModelGridItem as orToGridItem } from "src/ts/model/openrouter";
     import { getNanoGPTModels, getNanoGPTSubscriptionModels, toModelGridItem as ngToGridItem } from "src/ts/model/nanogpt";
+    import { getOllamaModels } from "src/ts/model/ollama";
     import ModelGrid from "src/lib/UI/ModelGrid.svelte";
     import NanoGPTDashboard from "src/lib/UI/NanoGPTDashboard.svelte";
     import NanoGPTProviderPicker from "src/lib/UI/NanoGPTProviderPicker.svelte";
@@ -122,6 +123,9 @@
             prevNanogptInputMode = nanogptInputMode;
         }
     });
+
+    let usesOllamaLocal = $derived(DBState.db.aiModel === 'ollama-hosted' || DBState.db.subModel === 'ollama-hosted')
+    let usesOllamaCloud = $derived(DBState.db.aiModel === 'ollama-cloud' || DBState.db.subModel === 'ollama-cloud')
 </script>
 <h2 class="mb-2 text-2xl font-bold mt-2">{language.chatBot}</h2>
 
@@ -240,12 +244,71 @@
         <span class="text-textcolor mt-4">Cohere {language.apiKey}</span>
         <TextInput hideText={DBState.db.hideApiKey} marginBottom={false} size={"sm"} bind:value={DBState.db.cohereAPIKey} />
     {/if}
-    {#if DBState.db.aiModel === 'ollama-hosted'}
+    {#if usesOllamaLocal || usesOllamaCloud}
+        {#if usesOllamaLocal}
         <span class="text-textcolor mt-4">Ollama URL</span>
         <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaURL} />
+        {/if}
 
+        {#if usesOllamaCloud}
+        <span class="text-textcolor mt-4">Ollama {language.model}</span>
+        <SegmentedControl
+            bind:value={DBState.db.ollamaInputMode}
+            options={[
+                { value: 'list', label: (language as any).nanoGPTSelectFromList || 'Select from List' },
+                { value: 'manual', label: (language as any).nanoGPTManualInput || 'Manual Input' }
+            ]}
+            size="md"
+        />
+
+        {#if DBState.db.ollamaInputMode === 'manual'}
+            <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaModel} placeholder="Model" oninput={() => DBState.db.ollamaModelName = ''} />
+        {:else}
+            {#await getOllamaModels(DBState.db.ollamaURL, 'cloud', DBState.db.ollamaApiKey)}
+                <ModelGrid bind:value={DBState.db.ollamaModel} loading={true} />
+            {:then cloudModels}
+                <ModelGrid
+                    bind:value={DBState.db.ollamaModel}
+                    items={cloudModels ?? []}
+                    selectedLabelOverride={DBState.db.ollamaModel ? `Cloud / ${DBState.db.ollamaModelName || DBState.db.ollamaModel}` : undefined}
+                    onselect={(_id, name) => {
+                        DBState.db.ollamaModelSource = 'cloud'
+                        DBState.db.ollamaModelName = name
+                    }}
+                />
+            {/await}
+        {/if}
+
+            <span class="text-textcolor mt-4">Ollama {language.apiKey}</span>
+            <TextInput hideText={DBState.db.hideApiKey} marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaApiKey} />
+
+            <span class="text-textcolor mt-4">Ollama {language.format}</span>
+            <SelectInput value={DBState.db.ollamaRequestFormat.toString()} onchange={(e) => {
+                DBState.db.ollamaRequestFormat = parseInt(e.currentTarget.value) as LLMFormat
+            }}>
+                <OptionInput value={LLMFormat.Ollama.toString()}>
+                    Ollama SDK
+                </OptionInput>
+                <OptionInput value={LLMFormat.OpenAICompatible.toString()}>
+                    OpenAI Compatible
+                </OptionInput>
+                <OptionInput value={LLMFormat.OpenAIResponseAPI.toString()}>
+                    OpenAI Response API
+                </OptionInput>
+                <OptionInput value={LLMFormat.Anthropic.toString()}>
+                    Anthropic Claude
+                </OptionInput>
+            </SelectInput>
+
+            <div class="mt-2">
+                <CheckInput bind:check={DBState.db.useStreaming} name={`Response ${language.streaming}`} />
+            </div>
+        {/if}
+
+        {#if usesOllamaLocal && !usesOllamaCloud}
         <span class="text-textcolor mt-4">Ollama Model</span>
-        <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaModel} />
+        <TextInput marginBottom={false} size={"sm"} bind:value={DBState.db.ollamaModel} placeholder="Model" oninput={() => { DBState.db.ollamaModelSource = 'local'; DBState.db.ollamaModelName = '' }} />
+        {/if}
     {/if}
     {#if DBState.db.aiModel === 'nanogpt' || DBState.db.subModel === 'nanogpt'}
         <span class="text-textcolor mt-4">NanoGPT {language.apiKey}</span>
@@ -327,7 +390,7 @@
     {/if}
 
     <div class="py-2 flex flex-col gap-2 mb-4">
-        {#if modelInfo.flags.includes(LLMFlags.hasStreaming) || subModelInfo.flags.includes(LLMFlags.hasStreaming)}
+        {#if !usesOllamaCloud && (modelInfo.flags.includes(LLMFlags.hasStreaming) || subModelInfo.flags.includes(LLMFlags.hasStreaming))}
             <Check bind:check={DBState.db.useStreaming} name={`Response ${language.streaming}`}/>
             
             {#if DBState.db.useStreaming && (modelInfo.flags.includes(LLMFlags.geminiThinking) || subModelInfo.flags.includes(LLMFlags.geminiThinking))}

--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -407,12 +407,25 @@ export const LLMModels: LLMModel[] = [
     // Ollama
     {
         id: 'ollama-hosted',
-        name: 'Ollama',
-        provider: LLMProvider.AsIs,
+        name: 'Local',
+        fullName: 'Ollama Local',
+        provider: LLMProvider.Ollama,
         format: LLMFormat.Ollama,
-        flags: [LLMFlags.hasFullSystemPrompt],
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasStreaming],
         parameters: OpenAIParameters,
-        tokenizer: LLMTokenizer.Unknown
+        tokenizer: LLMTokenizer.Unknown,
+        recommended: true
+    },
+    {
+        id: 'ollama-cloud',
+        name: 'Cloud',
+        fullName: 'Ollama Cloud',
+        provider: LLMProvider.Ollama,
+        format: LLMFormat.Ollama,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasStreaming],
+        parameters: OpenAIParameters,
+        tokenizer: LLMTokenizer.Unknown,
+        recommended: true
     },
     // WebLLM
     {

--- a/src/ts/model/ollama.ts
+++ b/src/ts/model/ollama.ts
@@ -1,0 +1,68 @@
+import { globalFetch } from '../globalApi.svelte'
+import type { ModelGridItem } from './modelGrid'
+
+export type OllamaModelSource = 'local' | 'cloud'
+
+type OllamaTagModel = {
+    name?: string
+    model?: string
+    remote_model?: string
+    remote_host?: string
+    modified_at?: string | Date
+    size?: number
+    digest?: string
+    details?: {
+        format?: string
+        family?: string
+        families?: string[] | null
+        parameter_size?: string
+        quantization_level?: string
+    }
+}
+
+export async function getOllamaModels(host: string, source: OllamaModelSource, apiKey = ''): Promise<ModelGridItem[]> {
+    try {
+        const baseUrl = source === 'cloud' ? 'https://ollama.com' : host.replace(/\/$/, '')
+        const headers: Record<string, string> = {}
+
+        if (source === 'cloud' && apiKey) {
+            headers.Authorization = `Bearer ${apiKey}`
+        }
+
+        const response = await globalFetch(`${baseUrl}/api/tags`, {
+            method: 'GET',
+            headers,
+            interceptor: 'ollama_models',
+        })
+
+        if (!response.ok) return []
+        const models: OllamaTagModel[] = response.data?.models ?? []
+
+        return models.map((model) => toModelGridItem(model, source))
+    } catch {
+        return []
+    }
+}
+
+export function toModelGridItem(model: OllamaTagModel, source: OllamaModelSource): ModelGridItem {
+    const id = model.model || model.name || ''
+    const details = model.details
+    const descriptionParts = [
+        model.remote_model ? `Remote: ${model.remote_model}` : null,
+        model.remote_host ? `Host: ${model.remote_host}` : null,
+        details?.parameter_size,
+        details?.quantization_level,
+        details?.format,
+        details?.family,
+    ].filter(Boolean)
+
+    return {
+        id,
+        displayName: model.name || id,
+        providerName: source === 'cloud' ? 'Cloud' : 'Local',
+        description: descriptionParts.join(' / '),
+        context_length: 0,
+        sortPrice: source === 'cloud' ? 1 : 0,
+        prices: [],
+    }
+}

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -43,7 +43,8 @@ export const LLMProvider = {
     DeepSeek: 12,
     DeepInfra: 13,
     Echo: 14,
-    NanoGPT: 15
+    NanoGPT: 15,
+    Ollama: 16
 } as const;
 export type LLMProvider = (typeof LLMProvider)[keyof typeof LLMProvider];
 
@@ -125,7 +126,8 @@ export const ProviderNames = new Map<LLMProvider, string>([
     [LLMProvider.DeepSeek, 'DeepSeek'],
     [LLMProvider.DeepInfra, 'DeepInfra'],
     [LLMProvider.Echo, 'For Developer'],
-    [LLMProvider.NanoGPT, 'NanoGPT']
+    [LLMProvider.NanoGPT, 'NanoGPT'],
+    [LLMProvider.Ollama, 'Ollama']
 ])
 
 export const OpenAIParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty']

--- a/src/ts/process/models/modelString.ts
+++ b/src/ts/process/models/modelString.ts
@@ -11,6 +11,11 @@ export function getGenerationModelString(name?:string){
             const modelLabel = db.nanogptRequestModelName || db.nanogptRequestModel
             return 'NanoGPT ' + modelLabel + (db.nanogptUseSubscriptionEndpoint ? ' [SUB]' : '')
         }
+        case 'ollama-hosted':
+        case 'ollama-cloud': {
+            const modelLabel = db.ollamaModelName || db.ollamaModel
+            return `Ollama ${name === 'ollama-cloud' ? 'Cloud' : 'Local'} ${modelLabel}`
+        }
         default:
             return name ?? db.aiModel
     }

--- a/src/ts/process/models/modelString.ts
+++ b/src/ts/process/models/modelString.ts
@@ -13,7 +13,9 @@ export function getGenerationModelString(name?:string){
         }
         case 'ollama-hosted':
         case 'ollama-cloud': {
-            const modelLabel = db.ollamaModelName || db.ollamaModel
+            const modelLabel = name === 'ollama-cloud'
+                ? db.ollamaCloudModelName || db.ollamaCloudModel
+                : db.ollamaModelName || db.ollamaModel
             return `Ollama ${name === 'ollama-cloud' ? 'Cloud' : 'Local'} ${modelLabel}`
         }
         default:

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -73,6 +73,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
     const db = getDatabase()
     const aiModel = arg.aiModel
     const useStreaming = arg.useStreaming
+    const ollamaCloudAnthropic = aiModel === 'ollama-cloud'
     let replacerURL = arg.customURL ?? ('https://api.anthropic.com/v1/messages')
     let apiKey = arg.key || ((aiModel === 'reverse_proxy') ? db.proxyKey : db.claudeAPIKey)
     const maxTokens = arg.maxTokens
@@ -546,6 +547,11 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
         "accept": "application/json",
     }
 
+    if(ollamaCloudAnthropic){
+        headers["Authorization"] = "Bearer " + apiKey
+        delete headers["x-api-key"]
+    }
+
     let betas:string[] = []
 
     if(body.max_tokens > 8192){
@@ -587,7 +593,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
         }
     }
 
-    if(db.claudeBatching){
+    if(db.claudeBatching && !ollamaCloudAnthropic){
         if(body.stream !== undefined){
             delete body.stream
         }

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -1096,7 +1096,7 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         modelId: arg.modelInfo.id
     })
 
-    if(aiModel === 'ollama-hosted'){
+    if(aiModel === 'ollama-cloud'){
         delete body.store
     }
 

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -1096,6 +1096,10 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         modelId: arg.modelInfo.id
     })
 
+    if(aiModel === 'ollama-hosted'){
+        delete body.store
+    }
+
     let requestURL = arg.customURL ?? "https://api.openai.com/v1/responses"
     if(arg.modelInfo?.endpoint){
         requestURL = arg.modelInfo.endpoint

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -1099,7 +1099,11 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
     if(isCloud && requestFormat === LLMFormat.Anthropic){
         arg.customURL = 'https://ollama.com/v1/messages'
         arg.key = db.ollamaApiKey
-        arg.modelInfo.internalID = ollamaModel
+        arg.modelInfo = {
+            ...arg.modelInfo,
+            internalID: ollamaModel,
+            parameters: ['temperature', 'top_k', 'top_p']
+        }
         return requestClaude(arg)
     }
 

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -92,6 +92,27 @@ export type requestDataResponse = {
 
 export interface StreamResponseChunk{[key:string]:string}
 
+type OllamaThinkMode = boolean | 'low' | 'medium' | 'high'
+
+function getOllamaThinkMode(mode: string): OllamaThinkMode | undefined {
+    switch (mode) {
+        case 'off':
+            return false
+        case 'on':
+            return true
+        case 'low':
+        case 'medium':
+        case 'high':
+            return mode
+        default:
+            return undefined
+    }
+}
+
+function formatThinkingOutput(thinking: string, content: string): string {
+    return thinking ? `<Thoughts>\n${thinking}\n</Thoughts>\n\n${content}` : content
+}
+
 function normalizeFetchHeaders(headers?: HeadersInit): { [key: string]: string } {
     if (!headers) {
         return {}
@@ -1081,6 +1102,7 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
     const isCloud = arg.aiModel === 'ollama-cloud'
     const requestFormat = isCloud ? db.ollamaRequestFormat : LLMFormat.Ollama
     const ollamaModel = isCloud ? db.ollamaCloudModel : db.ollamaModel
+    const ollamaThinkMode = getOllamaThinkMode(db.ollamaThinkingMode)
 
     if(isCloud && requestFormat === LLMFormat.OpenAICompatible){
         arg.customURL = 'https://ollama.com/v1/chat/completions'
@@ -1115,6 +1137,7 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
                 model: ollamaModel,
                 source: db.ollamaModelSource,
                 stream: arg.useStreaming,
+                think: ollamaThinkMode,
                 headers: isCloud ? { Authorization: 'Bearer ' + db.ollamaApiKey } : {}
             })
         }
@@ -1140,12 +1163,14 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
         const response = await ollama.chat({
             model: ollamaModel,
             messages: messages,
-            stream: false
+            stream: false,
+            think: ollamaThinkMode
         })
 
+        const result = formatThinkingOutput(response.message.thinking ?? '', response.message.content)
         return {
             type: 'success',
-            result: unstringlizeChat(response.message.content, formated, arg.currentChar?.name ?? ''),
+            result: unstringlizeChat(result, formated, arg.currentChar?.name ?? ''),
             model: arg.aiModel
         }
     }
@@ -1153,16 +1178,19 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
     const response = await ollama.chat({
         model: ollamaModel,
         messages: messages,
-        stream: true
+        stream: true,
+        think: ollamaThinkMode
     })
 
     const readableStream = new ReadableStream<StreamResponseChunk>({
         async start(controller){
             let content = ''
+            let thinking = ''
             for await(const chunk of response){
+                thinking += chunk.message.thinking ?? ''
                 content += chunk.message.content ?? ''
                 controller.enqueue({
-                    "0": content
+                    "0": formatThinkingOutput(thinking, content)
                 })
             }
             controller.close()

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -1080,25 +1080,26 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
     const db = getDatabase()
     const isCloud = arg.aiModel === 'ollama-cloud'
     const requestFormat = isCloud ? db.ollamaRequestFormat : LLMFormat.Ollama
+    const ollamaModel = isCloud ? db.ollamaCloudModel : db.ollamaModel
 
     if(isCloud && requestFormat === LLMFormat.OpenAICompatible){
         arg.customURL = 'https://ollama.com/v1/chat/completions'
         arg.key = db.ollamaApiKey
-        arg.modelInfo.internalID = db.ollamaModel
+        arg.modelInfo.internalID = ollamaModel
         return requestOpenAI(arg)
     }
 
     if(isCloud && requestFormat === LLMFormat.OpenAIResponseAPI){
         arg.customURL = 'https://ollama.com/v1/responses'
         arg.key = db.ollamaApiKey
-        arg.modelInfo.internalID = db.ollamaModel
+        arg.modelInfo.internalID = ollamaModel
         return requestOpenAIResponseAPI(arg)
     }
 
     if(isCloud && requestFormat === LLMFormat.Anthropic){
         arg.customURL = 'https://ollama.com/v1/messages'
         arg.key = db.ollamaApiKey
-        arg.modelInfo.internalID = db.ollamaModel
+        arg.modelInfo.internalID = ollamaModel
         return requestClaude(arg)
     }
 
@@ -1107,7 +1108,7 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
             type: 'success',
             result: JSON.stringify({
                 url: isCloud ? 'https://ollama.com/api/chat' : `${db.ollamaURL}/api/chat`,
-                model: db.ollamaModel,
+                model: ollamaModel,
                 source: db.ollamaModelSource,
                 stream: arg.useStreaming,
                 headers: isCloud ? { Authorization: 'Bearer ' + db.ollamaApiKey } : {}
@@ -1133,7 +1134,7 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
 
     if(!arg.useStreaming){
         const response = await ollama.chat({
-            model: db.ollamaModel,
+            model: ollamaModel,
             messages: messages,
             stream: false
         })
@@ -1146,7 +1147,7 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
     }
 
     const response = await ollama.chat({
-        model: db.ollamaModel,
+        model: ollamaModel,
         messages: messages,
         stream: true
     })

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -1,6 +1,6 @@
 import { Ollama } from 'ollama/dist/browser.mjs';
 import { language } from "../../../lang";
-import { globalFetch } from "../../globalApi.svelte";
+import { fetchNative, globalFetch } from "../../globalApi.svelte";
 import { getModelInfo, LLMFlags, LLMFormat, type LLMModel } from "../../model/modellist";
 import { risuChatParser, risuEscape, risuUnescape } from "../../parser/parser.svelte";
 import { pluginProcess, pluginV2 } from "../../plugins/plugins.svelte";
@@ -91,6 +91,95 @@ export type requestDataResponse = {
 }
 
 export interface StreamResponseChunk{[key:string]:string}
+
+function normalizeFetchHeaders(headers?: HeadersInit): { [key: string]: string } {
+    if (!headers) {
+        return {}
+    }
+    if (headers instanceof Headers) {
+        return Object.fromEntries(headers.entries())
+    }
+    if (Array.isArray(headers)) {
+        return Object.fromEntries(headers)
+    }
+    return headers as { [key: string]: string }
+}
+
+async function ollamaCloudFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+    const url = input instanceof Request ? input.url : input.toString()
+    const method = (init.method ?? (input instanceof Request ? input.method : 'GET')) as 'POST' | 'GET' | 'PUT' | 'DELETE'
+    const headers = normalizeFetchHeaders(init.headers ?? (input instanceof Request ? input.headers : undefined))
+    const body = init.body ?? (input instanceof Request ? await input.arrayBuffer() : undefined)
+
+    const response = await fetchNative(url, {
+        body: body as string | Uint8Array | ArrayBuffer | undefined,
+        headers,
+        method,
+        signal: init.signal as AbortSignal,
+        interceptor: 'ollama_sdk',
+    })
+
+    return normalizeOllamaStreamResponse(response)
+}
+
+function normalizeOllamaStreamResponse(response: Response): Response {
+    if (!response.body) {
+        return response
+    }
+
+    const decoder = new TextDecoder()
+    const encoder = new TextEncoder()
+    let depth = 0
+    let inString = false
+    let escaped = false
+
+    const stream = response.body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+            let out = ''
+            const text = decoder.decode(chunk, { stream: true })
+
+            for (const char of text) {
+                out += char
+
+                if (escaped) {
+                    escaped = false
+                    continue
+                }
+                if (char === '\\' && inString) {
+                    escaped = true
+                    continue
+                }
+                if (char === '"') {
+                    inString = !inString
+                    continue
+                }
+                if (inString) {
+                    continue
+                }
+                if (char === '{') {
+                    depth++
+                    continue
+                }
+                if (char === '}') {
+                    depth = Math.max(0, depth - 1)
+                    if (depth === 0) {
+                        out += '\n'
+                    }
+                }
+            }
+
+            if (out) {
+                controller.enqueue(encoder.encode(out))
+            }
+        }
+    }))
+
+    return new Response(stream, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+    })
+}
 
 export async function requestChatData(arg:requestDataArgument, model:ModelModeExtended, abortSignal:AbortSignal=null):Promise<requestDataResponse> {
     const db = getDatabase()
@@ -203,10 +292,11 @@ export async function requestChatData(arg:requestDataArgument, model:ModelModeEx
             }
     
             if(da.type !== 'fail' || da.noRetry){
-                return {
+                const usedModel = fallBackModels[fallbackIndex] || da.model
+                return usedModel ? {
                     ...da,
-                    model: fallBackModels[fallbackIndex]
-                }
+                    model: usedModel
+                } : da
             }
     
             if(da.failByServerError){
@@ -988,17 +1078,48 @@ async function requestNovelList(arg:RequestDataArgumentExtended):Promise<request
 async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDataResponse> {
     const formated = arg.formated
     const db = getDatabase()
+    const isCloud = arg.aiModel === 'ollama-cloud'
+    const requestFormat = isCloud ? db.ollamaRequestFormat : LLMFormat.Ollama
+
+    if(isCloud && requestFormat === LLMFormat.OpenAICompatible){
+        arg.customURL = 'https://ollama.com/v1/chat/completions'
+        arg.key = db.ollamaApiKey
+        arg.modelInfo.internalID = db.ollamaModel
+        return requestOpenAI(arg)
+    }
+
+    if(isCloud && requestFormat === LLMFormat.OpenAIResponseAPI){
+        arg.customURL = 'https://ollama.com/v1/responses'
+        arg.key = db.ollamaApiKey
+        arg.modelInfo.internalID = db.ollamaModel
+        return requestOpenAIResponseAPI(arg)
+    }
+
+    if(isCloud && requestFormat === LLMFormat.Anthropic){
+        arg.customURL = 'https://ollama.com/v1/messages'
+        arg.key = db.ollamaApiKey
+        arg.modelInfo.internalID = db.ollamaModel
+        return requestClaude(arg)
+    }
 
     if(arg.previewBody){
         return {
             type: 'success',
             result: JSON.stringify({
-                error: "Preview body is not supported for Ollama"
+                url: isCloud ? 'https://ollama.com/api/chat' : `${db.ollamaURL}/api/chat`,
+                model: db.ollamaModel,
+                source: db.ollamaModelSource,
+                stream: arg.useStreaming,
+                headers: isCloud ? { Authorization: 'Bearer ' + db.ollamaApiKey } : {}
             })
         }
     }
 
-    const ollama = new Ollama({host: db.ollamaURL})
+    const ollama = new Ollama({
+        host: isCloud ? 'https://ollama.com' : db.ollamaURL,
+        headers: isCloud && db.ollamaApiKey ? { Authorization: 'Bearer ' + db.ollamaApiKey } : undefined,
+        fetch: isCloud ? ollamaCloudFetch : undefined
+    })
 
     const messages = []
     for (const v of formated) {
@@ -1010,6 +1131,20 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
         }
     }
 
+    if(!arg.useStreaming){
+        const response = await ollama.chat({
+            model: db.ollamaModel,
+            messages: messages,
+            stream: false
+        })
+
+        return {
+            type: 'success',
+            result: unstringlizeChat(response.message.content, formated, arg.currentChar?.name ?? ''),
+            model: arg.aiModel
+        }
+    }
+
     const response = await ollama.chat({
         model: db.ollamaModel,
         messages: messages,
@@ -1018,9 +1153,11 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
 
     const readableStream = new ReadableStream<StreamResponseChunk>({
         async start(controller){
+            let content = ''
             for await(const chunk of response){
+                content += chunk.message.content ?? ''
                 controller.enqueue({
-                    "0": chunk.message.content
+                    "0": content
                 })
             }
             controller.close()
@@ -1029,7 +1166,8 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
 
     return {
         type: 'streaming',
-        result: readableStream
+        result: readableStream,
+        model: arg.aiModel
     }
 }
 

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -454,6 +454,12 @@ export function setDatabase(data:Database){
     data.ollamaRequestFormat ??= LLMFormat.Ollama
     data.ollamaApiKey ??= ''
     data.ollamaModelName ??= ''
+    data.ollamaCloudModel ??= ''
+    data.ollamaCloudModelName ??= ''
+    if ((data.aiModel === 'ollama-cloud' || data.subModel === 'ollama-cloud') && !data.ollamaCloudModel) {
+        data.ollamaCloudModel = data.ollamaModel
+        data.ollamaCloudModelName = data.ollamaModelName
+    }
     data.autoContinueChat ??= false
     data.autoContinueMinTokens ??= 0
     data.repetition_penalty ??= 1
@@ -990,6 +996,8 @@ export interface Database{
     ollamaRequestFormat:LLMFormat
     ollamaApiKey:string
     ollamaModelName:string
+    ollamaCloudModel:string
+    ollamaCloudModelName:string
     autoContinueChat:boolean
     autoContinueMinTokens:number
     removeIncompleteResponse:boolean

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -456,6 +456,7 @@ export function setDatabase(data:Database){
     data.ollamaModelName ??= ''
     data.ollamaCloudModel ??= ''
     data.ollamaCloudModelName ??= ''
+    data.ollamaThinkingMode ??= 'auto'
     if ((data.aiModel === 'ollama-cloud' || data.subModel === 'ollama-cloud') && !data.ollamaCloudModel) {
         data.ollamaCloudModel = data.ollamaModel
         data.ollamaCloudModelName = data.ollamaModelName
@@ -998,6 +999,7 @@ export interface Database{
     ollamaModelName:string
     ollamaCloudModel:string
     ollamaCloudModelName:string
+    ollamaThinkingMode:'auto'|'off'|'on'|'low'|'medium'|'high'
     autoContinueChat:boolean
     autoContinueMinTokens:number
     removeIncompleteResponse:boolean

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -449,6 +449,11 @@ export function setDatabase(data:Database){
     data.maxSupaChunkSize ??= 1200
     data.ollamaURL ??= ''
     data.ollamaModel ??= ''
+    data.ollamaModelSource ??= data.aiModel === 'ollama-cloud' || data.subModel === 'ollama-cloud' ? 'cloud' : 'local'
+    data.ollamaInputMode ??= 'manual'
+    data.ollamaRequestFormat ??= LLMFormat.Ollama
+    data.ollamaApiKey ??= ''
+    data.ollamaModelName ??= ''
     data.autoContinueChat ??= false
     data.autoContinueMinTokens ??= 0
     data.repetition_penalty ??= 1
@@ -980,6 +985,11 @@ export interface Database{
     maxSupaChunkSize:number
     ollamaURL:string
     ollamaModel:string
+    ollamaModelSource:'local'|'cloud'
+    ollamaInputMode:'list'|'manual'
+    ollamaRequestFormat:LLMFormat
+    ollamaApiKey:string
+    ollamaModelName:string
     autoContinueChat:boolean
     autoContinueMinTokens:number
     removeIncompleteResponse:boolean


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This PR adds Ollama Cloud support alongside the existing local Ollama provider. Ollama now exposes separate Local and Cloud entries in the model picker, with Cloud supporting model list selection, manual model input, API key configuration, request format selection, and streaming control.

## Related Issues

None

## Changes

- Added Ollama Cloud as a separate Ollama model option while keeping existing local Ollama behavior.
- Added Ollama Cloud settings for API key, model selection mode, request format, and response streaming.
- Added proxied Ollama Cloud model list fetching from `/api/tags` to avoid browser CORS issues.
- Added support for Ollama Cloud request routing through:
  - Ollama SDK format
  - OpenAI-compatible chat completions
  - OpenAI Responses API
  - Anthropic-compatible messages
- Routed Ollama Cloud SDK requests through the existing native/proxy fetch path.
- Normalized Ollama SDK streaming chunks so proxied NDJSON responses are parsed correctly.
- Fixed Ollama SDK streaming output to accumulate response text instead of replacing the visible message with each token.
- Fixed generation metadata so Ollama Cloud requests display as `Ollama Cloud <model>` instead of `Ollama Local <model>`.

## Impact

Users can now use Ollama Cloud directly from RisuAI without replacing their existing local Ollama setup. Existing local Ollama settings remain available as `Ollama Local`, while cloud-specific behavior is isolated under `Ollama Cloud`.

The request path now supports both streaming and non-streaming Ollama SDK calls. The model list uses the existing proxy/native fetch path, so web builds avoid direct CORS failures when fetching Ollama Cloud tags.

## Additional Notes

`pnpm check` was run. It still reports the existing baseline `zh-Hant.ts` type errors and `SliderInput.svelte` accessibility warning unrelated to this change.

| from List | from Settings |
|----|----|
| <img width="574" height="238" alt="vgashbelifseT" src="https://github.com/user-attachments/assets/567d381d-157b-46f2-bd48-df1d42ac54b6" /> | <img width="1142" height="1015" alt="vjgksdbzjrtkrzdgt" src="https://github.com/user-attachments/assets/91562765-d3e5-484b-882d-c6c226e25b44" /> |