### PR TITLE
fix: remove duplicate anthropic beta declaration

### DIFF
--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -567,21 +567,6 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
         delete headers["x-api-key"]
     }
 
-    let betas:string[] = []
-
-    if(body.max_tokens > 8192){
-        betas.push('output-128k-2025-02-19')
-    }
-
-
-    if(db.claude1HourCaching){
-        betas.push('extended-cache-ttl-2025-04-11')
-    }
-
-    if(betas.length > 0){
-        headers['anthropic-beta'] = betas.join(',')
-    }
-
     if(db.usePlainFetch){
         headers['anthropic-dangerous-direct-browser-access'] = 'true'
     }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Removes a duplicate `betas` declaration in the Anthropic request builder that caused the production build parser to fail.

## Related Issues

None

## Changes

- Removed the earlier `betas` calculation block before additional parameters are applied.
- Kept the later `betas` calculation after `applyAdditionalParameters`, preserving custom `header::anthropic-beta` precedence.

## Impact

This fixes the build parse error without changing the intended Anthropic beta header behavior. Custom `anthropic-beta` headers supplied through additional parameters continue to take precedence over auto-generated beta headers.

## Additional Notes

Validation:

- `rg -n "let betas" src/ts/process/request/anthropic.ts` now reports a single declaration.
- `pnpm check` was run, but it still fails on pre-existing unrelated diagnostics in `src/lang/zh-Hant.ts` and the existing `src/lib/UI/GUI/SliderInput.svelte` a11y warning.
