### PR TITLE
fix: persist reroll variants and prevent data loss

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -578,6 +578,8 @@ export const languageChinese = {
     "emotion": "情绪名称",
     "value": "值",
     "reroll": "重新生成",
+    "deleteRerollMessage": "删除此版本",
+    "deleteRerollMessageConfirm": "删除当前选中的重新生成消息？",
     "chatList": "聊天列表",
     "removeChat": "确定要移除此消息吗？",
     "loreBook": "世界书",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -578,6 +578,8 @@ export const languageGerman = {
     "emotion": "Emotionsname",
     "value": "Wert",
     "reroll": "Regenerieren",
+    "deleteRerollMessage": "Variante löschen",
+    "deleteRerollMessageConfirm": "Aktuell ausgewählte Reroll-Nachricht löschen?",
     "chatList": "Chatliste",
     "removeChat": "Diese Nachricht entfernen?",
     "loreBook": "Lore-Buch",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -727,6 +727,8 @@ export const languageEnglish = {
     emotion: "Emotion Name",
     value: "Value",
     reroll: "Regenerate",
+    deleteRerollMessage: "Delete this reroll",
+    deleteRerollMessageConfirm: "Delete the currently selected reroll message?",
     chatList: "Chat List",
     removeChat: "Remove this message?",
     loreBook: "Lorebook",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -578,6 +578,8 @@ export const languageSpanish = {
     "emotion": "Nombre de la Emoción",
     "value": "Valor",
     "reroll": "Regenerar",
+    "deleteRerollMessage": "Eliminar variante",
+    "deleteRerollMessageConfirm": "¿Eliminar el mensaje reroll seleccionado?",
     "chatList": "Lista de Chats",
     "removeChat": "¿Eliminar este mensaje?",
     "loreBook": "Libro de Lore",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -596,6 +596,8 @@ export const languageKorean = {
     "emotion": "감정 이름",
     "value": "값",
     "reroll": "재생성",
+    "deleteRerollMessage": "이 버전 삭제",
+    "deleteRerollMessageConfirm": "현재 선택한 재생성 메시지를 삭제하시겠습니까?",
     "chatList": "채팅 리스트",
     "removeChat": "이 메시지를 삭제하시겠습니까?",
     "loreBook": "로어북",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -578,6 +578,8 @@ export const languageVietnamese = {
     "emotion": "Tên cảm xúc",
     "value": "Giá trị",
     "reroll": "tái sinh",
+    "deleteRerollMessage": "Xóa bản này",
+    "deleteRerollMessageConfirm": "Xóa tin nhắn reroll đang chọn?",
     "chatList": "Danh sách trò chuyện",
     "removeChat": "Xóa tin nhắn này?",
     "loreBook": "Sách truyền thuyết",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -642,7 +642,7 @@ export const languageChineseTraditional = {
     "value": "值",
     "reroll": "重新生成",
     "hideMessagePageCount": "隱藏訊息頁數計數器",
-    "deleteRerollMessage": "刪除重新生成的訊息",
+    "deleteRerollMessage": "刪除此版本",
     "deleteRerollMessageConfirm": "刪除目前選取的重新生成訊息？",
     "rerollConfirm": "生成新訊息並加入列表嗎？",
     "noSwipesRerollConfirm": "沒有其他重新生成的訊息。生成新訊息並加入列表嗎？",

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -853,6 +853,7 @@
         const newChat = $state.snapshot(currentChat)
         newChat.name = createChatCopyName(newChat.name, 'Branch')
         newChat.id = v4()
+        delete newChat.rerollState
         newChat.message = newChat.message.slice(0, idx + 1).map((message) => {
             delete message.swipes
             delete message.swipeId

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -53,7 +53,10 @@
         totalPages?: number;
         isComment?: boolean;
         disabled?: boolean | 'allBefore';
+        isLastAssistantMessage?: boolean;
         onEdit?: (idx: number, data: string) => void;
+        onDeleteReroll?: (idx: number) => void;
+        canDeleteReroll?: (idx: number) => boolean;
     }
 
     let {
@@ -76,7 +79,10 @@
         totalPages = 1,
         isComment = false,
         disabled = false,
+        isLastAssistantMessage = false,
         onEdit = () => {},
+        onDeleteReroll = () => {},
+        canDeleteReroll = () => false,
     }: Props = $props();
 
     let msgDisplay = $state('')
@@ -109,6 +115,16 @@
                 msg.splice(idx, 1)
                 DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message = msg
             }
+        }
+    }
+
+    async function deleteReroll(){
+        if(idx < 0){
+            return
+        }
+        const remove = DBState.db.askRemoval ? await alertConfirm(language.deleteRerollMessageConfirm) : true
+        if(remove){
+            onDeleteReroll(idx)
         }
     }
 
@@ -739,6 +755,15 @@
                 <span class="ml-1">{language.remove}</span>
             {/if}
         </button>
+        {#if role !== 'user' && isLastAssistantMessage && canDeleteReroll(idx)}
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-remove-reroll" onclick={deleteReroll}>
+                <TrashIcon size={20}/>
+
+                {#if showNames}
+                    <span class="ml-1">{language.deleteRerollMessage}</span>
+                {/if}
+            </button>
+        {/if}
     {/if}
 {/if}
 {/snippet}
@@ -774,7 +799,7 @@
 {/snippet}
 
 {#snippet rerolls()}
-    {#if (rerollIcon && role !== 'user') || altGreeting}
+    {#if (rerollIcon && role !== 'user' && isLastAssistantMessage) || altGreeting}
         {#if DBState.db.swipe || altGreeting}
             <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={unReroll}>
                 <ArrowLeft size={22}/>
@@ -826,7 +851,11 @@
         const newChat = $state.snapshot(currentChat)
         newChat.name = createChatCopyName(newChat.name, 'Branch')
         newChat.id = v4()
-        newChat.message = newChat.message.slice(0, idx + 1)
+        newChat.message = newChat.message.slice(0, idx + 1).map((message) => {
+            delete message.swipes
+            delete message.swipeId
+            return message
+        })
         newChat.message.push({
             role: 'char',
             data: '{{specialcomment::branchedfrom::' + currentChat.id + '::' + currentChat.name + '::' + currentMessage.chatId + '::}}',

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -113,6 +113,9 @@
     }
 
     function saveMessageData(data:string){
+        if(idx < 0){
+            return
+        }
         DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].data = data
         onEdit(idx, data)
     }

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -44,8 +44,8 @@
         rerollIcon?: boolean|'dynamic';
         role?: string;
         totalLength?: number;
-        onReroll?: () => void;
-        unReroll?: () => void;
+        onReroll?: (idx?: number) => void;
+        unReroll?: (idx?: number) => void;
         character?: simpleCharacterArgument|string|null;
         firstMessage?: boolean;
         altGreeting?: boolean;
@@ -790,19 +790,19 @@
 {/snippet}
 
 {#snippet rerolls()}
-    {#if (rerollIcon && role !== 'user' && isLastAssistantMessage) || altGreeting}
+    {#if (rerollIcon && role !== 'user' && (isLastAssistantMessage || canDeleteReroll(idx))) || altGreeting}
         {#if DBState.db.swipe || altGreeting}
-            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={unReroll}>
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={() => unReroll(idx)}>
                 <ArrowLeft size={22}/>
             </button>
             {#if firstMessage && DBState.db.swipe && DBState.db.showFirstMessagePages}
                 <span class="flex items-center text-xs text-textcolor2">{currentPage}/{totalPages}</span>
             {/if}
-            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={onReroll}>
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={() => onReroll(idx)}>
                 <ArrowRight size={22}/>
             </button>
         {:else}
-            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={onReroll}>
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={() => onReroll(idx)}>
                 <RefreshCcwIcon size={20}/>
             </button>
         {/if}
@@ -811,7 +811,7 @@
 
 {#snippet minorIconButtonsBody(showNames:boolean)}
     {#if idx > -1 && !$ConnectionOpenStore}
-        {#if role !== 'user' && isLastAssistantMessage && canDeleteReroll(idx)}
+        {#if role !== 'user' && canDeleteReroll(idx)}
             <button class="flex items-center hover:text-blue-500 transition-colors button-icon-remove-reroll" onclick={deleteReroll}>
                 <RefreshCwOffIcon size={20}/>
 

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { ArrowLeft, ArrowLeftRightIcon, ArrowRight, BookmarkIcon, BotIcon, CopyIcon, PowerOff, GitBranch, HamburgerIcon, LanguagesIcon, MenuIcon, PencilIcon, RefreshCcwIcon, SplitIcon, TrashIcon, UserIcon, Volume2Icon, Scissors } from "@lucide/svelte"
+    import { ArrowLeft, ArrowLeftRightIcon, ArrowRight, BookmarkIcon, BotIcon, CopyIcon, PowerOff, GitBranch, HamburgerIcon, LanguagesIcon, MenuIcon, PencilIcon, RefreshCcwIcon, RefreshCwOffIcon, SplitIcon, TrashIcon, UserIcon, Volume2Icon, Scissors } from "@lucide/svelte"
     import { aiLawApplies, changeChatTo, foldChatToMessage, getFileSrc, createChatCopyName } from "src/ts/globalApi.svelte"
     import { ColorSchemeTypeStore } from "src/ts/gui/colorscheme"
     import { longpress } from "src/ts/gui/longtouch"
@@ -755,15 +755,6 @@
                 <span class="ml-1">{language.remove}</span>
             {/if}
         </button>
-        {#if role !== 'user' && isLastAssistantMessage && canDeleteReroll(idx)}
-            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-remove-reroll" onclick={deleteReroll}>
-                <TrashIcon size={20}/>
-
-                {#if showNames}
-                    <span class="ml-1">{language.deleteRerollMessage}</span>
-                {/if}
-            </button>
-        {/if}
     {/if}
 {/if}
 {/snippet}
@@ -819,7 +810,18 @@
 {/snippet}
 
 {#snippet minorIconButtonsBody(showNames:boolean)}
-    
+    {#if idx > -1 && !$ConnectionOpenStore}
+        {#if role !== 'user' && isLastAssistantMessage && canDeleteReroll(idx)}
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-remove-reroll" onclick={deleteReroll}>
+                <RefreshCwOffIcon size={20}/>
+
+                {#if showNames}
+                    <span class="ml-1">{language.deleteRerollMessage}</span>
+                {/if}
+            </button>
+        {/if}
+    {/if}
+
     {#if DBState.db.enableBookmark}
         <button class="flex items-center hover:text-blue-500 transition-colors button-icon-bookmark {isBookmarked ? 'text-yellow-400' : ''}" onclick={async () => {
             await sleep(1)

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -53,6 +53,7 @@
         totalPages?: number;
         isComment?: boolean;
         disabled?: boolean | 'allBefore';
+        onEdit?: (idx: number, data: string) => void;
     }
 
     let {
@@ -75,6 +76,7 @@
         totalPages = 1,
         isComment = false,
         disabled = false,
+        onEdit = () => {},
     }: Props = $props();
 
     let msgDisplay = $state('')
@@ -110,14 +112,19 @@
         }
     }
 
+    function saveMessageData(data:string){
+        DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].data = data
+        onEdit(idx, data)
+    }
+
     async function edit(){
-        DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].data = message
+        saveMessageData(message)
     }
 
     function handlePartialEditSave(e: CustomEvent<{ newData: string }>) {
         if (idx >= 0) {
             message = e.detail.newData
-            DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].data = e.detail.newData
+            saveMessageData(e.detail.newData)
             displaya(e.detail.newData)
         }
     }

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -57,6 +57,8 @@
         onEdit?: (idx: number, data: string) => void;
         onDeleteReroll?: (idx: number) => void;
         canDeleteReroll?: (idx: number) => boolean;
+        getSwipeInfo?: (idx: number) => { current: number, total: number } | null;
+        onMessageDeleted?: (idx: number) => void;
     }
 
     let {
@@ -83,6 +85,8 @@
         onEdit = () => {},
         onDeleteReroll = () => {},
         canDeleteReroll = () => false,
+        getSwipeInfo = () => null,
+        onMessageDeleted = () => {},
     }: Props = $props();
 
     let msgDisplay = $state('')
@@ -94,6 +98,7 @@
             let msg = DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message
             msg = msg.slice(0, idx)
             DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message = msg
+            onMessageDeleted(idx)
             return
         }
 
@@ -109,11 +114,13 @@
                     msg.splice(idx, 1)
                 }
                 DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message = msg
+                onMessageDeleted(idx)
             }
             else{
                 let msg = DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message
                 msg.splice(idx, 1)
                 DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message = msg
+                onMessageDeleted(idx)
             }
         }
     }
@@ -790,13 +797,18 @@
 {/snippet}
 
 {#snippet rerolls()}
-    {#if (rerollIcon && role !== 'user' && (isLastAssistantMessage || canDeleteReroll(idx))) || altGreeting}
+    {@const swipeInfo = idx >= 0 && !altGreeting ? getSwipeInfo(idx) : null}
+    {@const hasSwipes = swipeInfo !== null && swipeInfo.total > 1}
+    {@const showReroll = (rerollIcon && role !== 'user' && (isLastAssistantMessage || hasSwipes)) || altGreeting}
+    {#if showReroll}
         {#if DBState.db.swipe || altGreeting}
             <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={() => unReroll(idx)}>
                 <ArrowLeft size={22}/>
             </button>
             {#if firstMessage && DBState.db.swipe && DBState.db.showFirstMessagePages}
                 <span class="flex items-center text-xs text-textcolor2">{currentPage}/{totalPages}</span>
+            {:else if hasSwipes}
+                <span class="flex items-center text-xs text-textcolor2">{swipeInfo.current}/{swipeInfo.total}</span>
             {/if}
             <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={() => onReroll(idx)}>
                 <ArrowRight size={22}/>

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -774,7 +774,7 @@
 {/snippet}
 
 {#snippet rerolls()}
-    {#if rerollIcon || altGreeting}
+    {#if (rerollIcon && role !== 'user') || altGreeting}
         {#if DBState.db.swipe || altGreeting}
             <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={unReroll}>
                 <ArrowLeft size={22}/>

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -31,8 +31,8 @@
     }:{
         messages: Message[]
         currentCharacter: character|groupChat
-        onReroll: () => void
-        unReroll: () => void
+        onReroll: (idx?: number) => void
+        unReroll: (idx?: number) => void
         onEdit?: (idx: number, data: string) => void
         onDeleteReroll?: (idx: number) => void
         canDeleteReroll?: (idx: number) => boolean

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -20,6 +20,7 @@
         currentCharacter,
         onReroll,
         unReroll,
+        onEdit = () => {},
         currentUsername,
         userIcon,
         loadPages,
@@ -30,6 +31,7 @@
         currentCharacter: character|groupChat
         onReroll: () => void
         unReroll: () => void
+        onEdit?: (idx: number, data: string) => void
         currentUsername: string
         userIcon: string
         loadPages: number
@@ -97,6 +99,7 @@
                         img: message.role === 'user' ? userImage : charImage,
                         onReroll: onReroll,
                         unReroll: unReroll,
+                        onEdit: onEdit,
                         rerollIcon: 'dynamic',
                         character: simpleChar,
                         largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false),

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -23,6 +23,8 @@
         onEdit = () => {},
         onDeleteReroll = () => {},
         canDeleteReroll = () => false,
+        getSwipeInfo = () => null,
+        onMessageDeleted = () => {},
         currentUsername,
         userIcon,
         loadPages,
@@ -36,6 +38,8 @@
         onEdit?: (idx: number, data: string) => void
         onDeleteReroll?: (idx: number) => void
         canDeleteReroll?: (idx: number) => boolean
+        getSwipeInfo?: (idx: number) => { current: number, total: number } | null
+        onMessageDeleted?: (idx: number) => void
         currentUsername: string
         userIcon: string
         loadPages: number
@@ -108,6 +112,8 @@
                         onEdit: onEdit,
                         onDeleteReroll: onDeleteReroll,
                         canDeleteReroll: canDeleteReroll,
+                        getSwipeInfo: getSwipeInfo,
+                        onMessageDeleted: onMessageDeleted,
                         rerollIcon: 'dynamic',
                         character: simpleChar,
                         largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false),

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -21,6 +21,8 @@
         onReroll,
         unReroll,
         onEdit = () => {},
+        onDeleteReroll = () => {},
+        canDeleteReroll = () => false,
         currentUsername,
         userIcon,
         loadPages,
@@ -32,6 +34,8 @@
         onReroll: () => void
         unReroll: () => void
         onEdit?: (idx: number, data: string) => void
+        onDeleteReroll?: (idx: number) => void
+        canDeleteReroll?: (idx: number) => boolean
         currentUsername: string
         userIcon: string
         loadPages: number
@@ -76,13 +80,15 @@
         }
 
         const reloadPointerMap = get(ReloadChatPointer);
+        const lastMessageIndex = messages.length - 1
 
         for(let i=loadStart ; i >= loadEnd; i--){
             if(i < 0) break; // Prevent out of bounds
             const message = messages[i];
+            const isLastAssistantMessage = i === lastMessageIndex && message.role === 'char' && !message.isComment;
             const messageLargePortrait = message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false);
             const reloadPointer = reloadPointerMap[i] ?? 0;
-            let hashd = message.data + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + reloadPointer.toString();
+            let hashd = message.data + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + isLastAssistantMessage.toString() + (message.swipeId ?? '').toString() + (message.swipes?.length ?? '').toString() + reloadPointer.toString();
             const currentHash = hashCode(hashd);
             currentHashes.add(currentHash);
             if(!hashes.has(currentHash)){
@@ -100,6 +106,8 @@
                         onReroll: onReroll,
                         unReroll: unReroll,
                         onEdit: onEdit,
+                        onDeleteReroll: onDeleteReroll,
+                        canDeleteReroll: canDeleteReroll,
                         rerollIcon: 'dynamic',
                         character: simpleChar,
                         largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false),
@@ -108,6 +116,7 @@
                         name: message.role === 'user' ? currentUsername : currentCharacter.name,
                         isComment: message.isComment ?? false,
                         disabled: message.disabled ?? false,
+                        isLastAssistantMessage: isLastAssistantMessage,
                     },
 
                 })

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -135,7 +135,7 @@
         }
         activeMessage.swipes = cloneSwipeSegments(rerolls)
         activeMessage.swipeId = rerollIndex
-        persistRerollStateOnChat(chat)
+        clearRerollStateOnChat(chat)
     }
 
     function clearPersistedRerolls(messages:Message[], chat = getVisibleChat()){

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -116,6 +116,18 @@
         activeMessage.swipeId = rerollIndex
     }
 
+    function clearPersistedRerolls(messages:Message[]){
+        if(rerollStartIndex < 0){
+            return
+        }
+        const activeMessage = messages[rerollStartIndex]
+        if(!activeMessage){
+            return
+        }
+        delete activeMessage.swipes
+        delete activeMessage.swipeId
+    }
+
     function loadPersistedRerolls(){
         if(rerolls.length > 0){
             return
@@ -124,9 +136,16 @@
         for(let i = messages.length - 1; i >= 0; i--){
             const message = messages[i]
             if(Array.isArray(message.swipes) && message.swipes.length > 0){
+                const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), message.swipes.length - 1)
+                const activeSwipeLength = message.swipes[swipeId]?.length ?? 0
+                if(activeSwipeLength === 0 || activeSwipeLength !== messages.length - i){
+                    delete message.swipes
+                    delete message.swipeId
+                    continue
+                }
                 rerollStartIndex = i
                 rerolls = cloneSwipeSegments(message.swipes)
-                rerollIndex = Math.min(Math.max(message.swipeId ?? 0, 0), rerolls.length - 1)
+                rerollIndex = swipeId
                 rerolls[rerollIndex] = cloneSwipeSegment(messages.slice(i))
                 const genId = rerolls[rerollIndex]?.[0]?.generationInfo?.generationId
                 if(genId){
@@ -308,6 +327,10 @@
             return
         }
         const savedMessages = safeStructuredClone(DBState.db.characters[selectedChar].chats[selectedChat].message)
+        const lastMessage = savedMessages.at(-1)
+        if(lastMessage?.role !== 'char' || lastMessage.isComment){
+            return
+        }
         let cha = safeStructuredClone(savedMessages)
         if(cha.length === 0 ){
             return
@@ -403,6 +426,45 @@
         }
         rerollData[rerollMessageIndex].data = data
         persistRerollsOnMessages(getVisibleMessages())
+    }
+
+    function canDeleteCurrentReroll(idx:number){
+        if($doingChat){
+            return false
+        }
+        const messages = getVisibleMessages()
+        const lastMessageIndex = messages.length - 1
+        if(idx !== lastMessageIndex || messages[idx]?.role !== 'char' || messages[idx]?.isComment){
+            return false
+        }
+        const activeRerollLength = rerolls[rerollIndex]?.length ?? 0
+        if(rerollStartIndex >= 0 && idx >= rerollStartIndex && idx < rerollStartIndex + activeRerollLength && rerolls.length > 1){
+            return true
+        }
+        return messages.some((message, index) => {
+            const swipes = message.swipes
+            const activeSwipeLength = swipes?.[message.swipeId ?? 0]?.length ?? 0
+            return index <= idx && idx < index + activeSwipeLength && Array.isArray(swipes) && swipes.length > 1
+        })
+    }
+
+    function deleteCurrentReroll(idx:number){
+        if($doingChat){
+            return
+        }
+        loadPersistedRerolls()
+        importGeneratedRerolls()
+        if(!canDeleteCurrentReroll(idx)){
+            return
+        }
+
+        rerolls.splice(rerollIndex, 1)
+        rerollIndex = Math.min(rerollIndex, rerolls.length - 1)
+        applyRerollData(rerolls[rerollIndex])
+
+        if(rerolls.length <= 1){
+            clearPersistedRerolls(getVisibleMessages())
+        }
     }
 
     function hasRerollContent(segment:Message[]){
@@ -961,6 +1023,8 @@
                 onReroll={reroll}
                 unReroll={unReroll}
                 onEdit={updateCurrentRerollMessage}
+                onDeleteReroll={deleteCurrentReroll}
+                canDeleteReroll={canDeleteCurrentReroll}
                 currentCharacter={currentCharacter}
                 currentUsername={currentUsername}
                 userIcon={userIcon}

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -3,7 +3,7 @@
     import Suggestion from './Suggestion.svelte';
     import { CameraIcon, DatabaseIcon, DicesIcon, GlobeIcon, ImagePlusIcon, LanguagesIcon, Laugh, MenuIcon, MicOffIcon, PackageIcon, Plus, RefreshCcwIcon, ReplyIcon, Send, StepForwardIcon, XIcon, BrainIcon, ArrowDown, SparkleIcon } from "@lucide/svelte";
     import { selectedCharID, PlaygroundStore, createSimpleCharacter, hypaV3ModalOpen, ScrollToMessageStore, additionalChatMenu, additionalFloatingActionButtons, easyPanelStore } from "../../ts/stores.svelte";
-    import { tick } from 'svelte';
+    import { tick, untrack } from 'svelte';
     import Chat from "./Chat.svelte";
     import { type Chat as ChatData, type Message } from "../../ts/storage/database.svelte";
     import { DBState } from 'src/ts/stores.svelte';
@@ -22,7 +22,7 @@
     import { aiLawApplies, chatFoldedState, chatFoldedStateMessageIndex, downloadFile } from 'src/ts/globalApi.svelte';
     import { runTrigger } from 'src/ts/process/triggers';
     import { v4 } from 'uuid';
-    import { getRerolls } from 'src/ts/process/prereroll';
+    import { RerollManager } from 'src/ts/process/rerollState';
     import { processMultiCommand } from 'src/ts/process/command';
     import { postChatFile } from 'src/ts/process/files/multisend';
     import { getInlayAsset } from 'src/ts/process/files/inlays';
@@ -45,12 +45,7 @@
     let openMenu = $state(false)
     let loadPages = $state(30)
     let autoMode = $state(false)
-    let rerolls:Message[][] = []
-    let rerollIndex = -1
-    let rerollStartIndex = -1
-    let importedGeneratedRerollIdSet = new Set<string>()
-    let lastCharId = -1
-    let lastChatPage = -1
+    const rerollManager = new RerollManager()
     let doingChatInputTranslate = false
     let toggleStickers:boolean = $state(false)
     let fileInput:string[] = $state([])
@@ -60,13 +55,6 @@
     let { openModuleList = $bindable(false), openChatList = $bindable(false), customStyle = '' }: Props = $props();
     let currentCharacter = $derived(DBState.db.characters[$selectedCharID])
     let currentChat = $derived(currentCharacter?.chats[currentCharacter.chatPage]?.message ?? [])
-
-    function resetRerolls(){
-        rerolls = []
-        rerollIndex = -1
-        rerollStartIndex = -1
-        importedGeneratedRerollIdSet = new Set<string>()
-    }
 
     function getVisibleMessages():Message[]{
         const char = DBState.db.characters[$selectedCharID]
@@ -78,216 +66,20 @@
         return char.chats[char.chatPage]
     }
 
-    function setVisibleMessages(messages:Message[]){
-        const char = DBState.db.characters[$selectedCharID]
-        char.chats[char.chatPage].message = messages
-    }
-
-    function persistRerollStateOnChat(chat = getVisibleChat()){
-        if(rerollStartIndex < 0 || rerollIndex < 0 || rerolls.length === 0){
-            delete chat.rerollState
-            return
-        }
-        chat.rerollState = {
-            segments: cloneSwipeSegments(rerolls),
-            index: Math.min(Math.max(rerollIndex, 0), rerolls.length - 1),
-            startIndex: rerollStartIndex
-        }
-    }
-
-    function clearRerollStateOnChat(chat = getVisibleChat()){
-        delete chat.rerollState
-    }
-
-    function rememberRerollSelection(charId = $selectedCharID, chatPage = DBState.db.characters[charId]?.chatPage ?? -1){
-        lastCharId = charId
-        lastChatPage = chatPage
-    }
-
-    function resetRerollsIfSelectionChanged(){
-        const charId = $selectedCharID
-        const chatPage = DBState.db.characters[charId]?.chatPage ?? -1
-        if(lastCharId !== charId || lastChatPage !== chatPage){
-            resetRerolls()
-            rememberRerollSelection(charId, chatPage)
-        }
-    }
-
-    function cloneSwipeSegment(segment:Message[]):Message[]{
-        return safeStructuredClone(segment).map((message) => {
-            delete message.swipes
-            delete message.swipeId
-            return message
-        })
-    }
-
-    function cloneSwipeSegments(segments:Message[][]):Message[][]{
-        return segments.map(cloneSwipeSegment)
-    }
-
-    function persistRerollsOnMessages(messages:Message[], chat = getVisibleChat()){
-        if(rerollStartIndex < 0 || rerollIndex < 0 || rerolls.length <= 1){
-            return
-        }
-        const activeMessage = messages[rerollStartIndex]
-        if(!activeMessage){
-            return
-        }
-        activeMessage.swipes = cloneSwipeSegments(rerolls)
-        activeMessage.swipeId = rerollIndex
-        clearRerollStateOnChat(chat)
-    }
-
-    function clearPersistedRerolls(messages:Message[], chat = getVisibleChat()){
-        if(rerollStartIndex < 0){
-            clearRerollStateOnChat(chat)
-            return
-        }
-        const activeMessage = messages[rerollStartIndex]
-        if(!activeMessage){
-            clearRerollStateOnChat(chat)
-            return
-        }
-        delete activeMessage.swipes
-        delete activeMessage.swipeId
-        clearRerollStateOnChat(chat)
-    }
-
-    function loadPersistedRerollState(messages:Message[]){
-        const chat = getVisibleChat()
-        const state = chat.rerollState
-        if(!state || !Array.isArray(state.segments) || state.segments.length === 0){
-            return false
-        }
-
-        const startIndex = Math.max(0, state.startIndex)
-        const swipeId = Math.min(Math.max(state.index ?? 0, 0), state.segments.length - 1)
-        rerollStartIndex = startIndex
-        rerolls = cloneSwipeSegments(state.segments)
-        rerollIndex = swipeId
-
-        const visibleSegment = messages.slice(startIndex)
-        if(visibleSegment.length > 0 && hasRerollContent(visibleSegment)){
-            rerolls[rerollIndex] = cloneSwipeSegment(visibleSegment)
-        }
-        else{
-            const activeSegment = rerolls[rerollIndex]
-            if(Array.isArray(activeSegment) && activeSegment.length > 0){
-                const nextMessages = [
-                    ...messages.slice(0, startIndex),
-                    ...cloneSwipeSegment(activeSegment)
-                ]
-                setVisibleMessages(nextMessages)
-                messages = nextMessages
-            }
-        }
-
-        const genId = rerolls[rerollIndex]?.[0]?.generationInfo?.generationId
-        if(genId){
-            importedGeneratedRerollIdSet.add(genId)
-        }
-        if(rerolls.length > 1){
-            persistRerollsOnMessages(messages)
-        }
-        else{
-            clearRerollStateOnChat(chat)
-        }
-        return true
-    }
-
-    function getActiveSwipeLength(message?:Message){
-        const swipes = message?.swipes
-        if(!Array.isArray(swipes) || swipes.length === 0){
-            return 0
-        }
-        const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), swipes.length - 1)
-        return swipes[swipeId]?.length ?? 0
-    }
-
-    function findPersistedRerollStartIndex(idx:number, messages = getVisibleMessages()){
-        for(let i = Math.min(idx, messages.length - 1); i >= 0; i--){
-            const message = messages[i]
-            const activeSwipeLength = getActiveSwipeLength(message)
-            if(activeSwipeLength > 0 && i <= idx && idx < i + activeSwipeLength){
-                return i
-            }
-        }
-        return -1
-    }
-
-    function currentRerollContainsIndex(idx:number){
-        const activeRerollLength = rerolls[rerollIndex]?.length ?? 0
-        return rerollStartIndex >= 0 && idx >= rerollStartIndex && idx < rerollStartIndex + activeRerollLength
-    }
-
-    function loadPersistedRerollsAtIndex(idx:number){
-        const messages = getVisibleMessages()
-        const startIndex = findPersistedRerollStartIndex(idx, messages)
-        if(startIndex < 0){
-            return false
-        }
-
-        const message = messages[startIndex]
-        if(!Array.isArray(message.swipes) || message.swipes.length === 0){
-            return false
-        }
-
-        const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), message.swipes.length - 1)
-        const activeSwipeLength = message.swipes[swipeId]?.length ?? 0
-        if(activeSwipeLength === 0){
-            return false
-        }
-
-        rerollStartIndex = startIndex
-        rerolls = cloneSwipeSegments(message.swipes)
-        rerollIndex = swipeId
-        rerolls[rerollIndex] = cloneSwipeSegment(messages.slice(startIndex, startIndex + activeSwipeLength))
-        const genId = rerolls[rerollIndex]?.[0]?.generationInfo?.generationId
-        if(genId){
-            importedGeneratedRerollIdSet.add(genId)
-        }
-        return true
-    }
-
-    function loadPersistedRerolls(){
-        if(rerolls.length > 0){
-            return
-        }
-        const messages = getVisibleMessages()
-        if(loadPersistedRerollState(messages)){
-            return
-        }
-        for(let i = messages.length - 1; i >= 0; i--){
-            const message = messages[i]
-            if(Array.isArray(message.swipes) && message.swipes.length > 0){
-                const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), message.swipes.length - 1)
-                const activeSwipeLength = getActiveSwipeLength(message)
-                if(activeSwipeLength === 0 || activeSwipeLength !== messages.length - i){
-                    continue
-                }
-                rerollStartIndex = i
-                rerolls = cloneSwipeSegments(message.swipes)
-                rerollIndex = swipeId
-                rerolls[rerollIndex] = cloneSwipeSegment(messages.slice(i))
-                const genId = rerolls[rerollIndex]?.[0]?.generationInfo?.generationId
-                if(genId){
-                    importedGeneratedRerollIdSet.add(genId)
-                }
-                persistRerollsOnMessages(messages)
-                return
-            }
-        }
-    }
-
     function scrollToBottom() {
         chatsInstance?.scrollToLatestMessage();
     }
+
+    // Load persisted rerolls when character or chat page changes (Review 4.4: untrack inner work)
     $effect(() => {
         const charId = $selectedCharID
         const chatPage = DBState.db.characters[charId]?.chatPage ?? -1
         if(charId >= 0 && chatPage >= 0){
-            resetRerollsIfSelectionChanged()
-            loadPersistedRerolls()
+            untrack(() => {
+                rerollManager.resetIfSelectionChanged(charId, chatPage)
+                const chat = DBState.db.characters[charId].chats[chatPage]
+                rerollManager.loadPersisted(chat.message, chat)
+            })
         }
     })
     $effect(() => {
@@ -374,9 +166,10 @@
         if($doingChat){
             return
         }
-        resetRerollsIfSelectionChanged()
+        const chatPage = DBState.db.characters[selectedChar].chatPage
+        rerollManager.resetIfSelectionChanged(selectedChar, chatPage)
 
-        let cha = DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message
+        let cha = DBState.db.characters[selectedChar].chats[chatPage].message
 
         if(messageInput.startsWith('/')){
             const commandProcessed = await processMultiCommand(messageInput)
@@ -432,13 +225,13 @@
         }
         messageInput = ''
         messageInputTranslate = ''
-        DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message = cha
-        clearRerollStateOnChat(DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage])
-        resetRerolls()
+        const chat = DBState.db.characters[selectedChar].chats[chatPage]
+        chat.message = cha
+        rerollManager.clearTransient(chat)
+        rerollManager.reset()
         await sleep(10)
         updateInputSizeAll()
         await sendChatMain(continueResponse)
-
     }
 
     async function reroll(idx = -1) {
@@ -447,24 +240,20 @@
         }
         const selectedChar = $selectedCharID
         const selectedChat = DBState.db.characters[selectedChar].chatPage
-        resetRerollsIfSelectionChanged()
-        if(idx >= 0 && !currentRerollContainsIndex(idx)){
-            if(!loadPersistedRerollsAtIndex(idx)){
-                resetRerolls()
-            }
-        }
-        else{
-            loadPersistedRerolls()
-        }
-        importGeneratedRerolls()
-        if(rerollIndex < rerolls.length - 1){
-            if(Array.isArray(rerolls[rerollIndex + 1])){
-                rerollIndex += 1
-                applyRerollData(rerolls[rerollIndex])
-            }
+        rerollManager.resetIfSelectionChanged(selectedChar, selectedChat)
+
+        const messages = getVisibleMessages()
+        const chat = getVisibleChat()
+
+        // Try to navigate to the next existing variant first
+        if(rerollManager.navigateNext(idx, messages, chat)){
             return
         }
-        const savedMessages = safeStructuredClone(DBState.db.characters[selectedChar].chats[selectedChat].message)
+
+        // No next variant — generate a new one
+        const savedMessages = safeStructuredClone(getVisibleMessages())
+
+        // Review 5.1: only trigger generation on the last assistant message
         if(idx >= 0 && idx !== savedMessages.length - 1){
             return
         }
@@ -473,7 +262,7 @@
             return
         }
         let cha = safeStructuredClone(savedMessages)
-        if(cha.length === 0 ){
+        if(cha.length === 0){
             return
         }
         openMenu = false
@@ -495,194 +284,64 @@
         if(removedMessages.length === 0){
             return
         }
-        rerollStartIndex = cha.length
-        if(rerolls.length === 0){
-            rerolls.push(cloneSwipeSegment(removedMessages))
-            rerollIndex = rerolls.length - 1
-        }
-        persistRerollStateOnChat(DBState.db.characters[selectedChar].chats[selectedChat])
+
+        rerollManager.saveBeforeGeneration(removedMessages, cha.length, DBState.db.characters[selectedChar].chats[selectedChat])
         DBState.db.characters[selectedChar].chats[selectedChat].message = cha
+
         const success = await sendChatMain()
-        if(!success && DBState.db.characters[selectedChar]?.chats?.[selectedChat]){
-            DBState.db.characters[selectedChar].chats[selectedChat].message = savedMessages
-            if(rerolls.length > 1){
-                persistRerollsOnMessages(savedMessages, DBState.db.characters[selectedChar].chats[selectedChat])
-            }
-            else{
-                clearRerollStateOnChat(DBState.db.characters[selectedChar].chats[selectedChat])
-            }
-        }
-    }
 
-    function applyRerollData(rerollData:Message[]){
-        const messages = getVisibleMessages()
-        const startIndex = rerollStartIndex >= 0 ? rerollStartIndex : Math.max(0, messages.length - rerollData.length)
-        const activeSwipeLength = getActiveSwipeLength(messages[startIndex]) || rerollData.length
-        const nextRerollData = cloneSwipeSegment(rerollData)
-        const nextMessages = [
-            ...messages.slice(0, startIndex),
-            ...nextRerollData,
-            ...messages.slice(startIndex + activeSwipeLength)
-        ]
-        setVisibleMessages(nextMessages)
-        persistRerollsOnMessages(nextMessages)
-    }
-
-    function importGeneratedRerolls(){
-        const messages = getVisibleMessages()
-        const currentReroll = rerolls[rerollIndex]
-        const activeMessage = Array.isArray(currentReroll) && currentReroll.length === 1
-            ? currentReroll[0]
-            : messages.at(-1)
-        const genId = activeMessage?.generationInfo?.generationId
-        const cachedRerolls = genId ? getRerolls(genId) : null
-        if(!activeMessage || !genId || !cachedRerolls || cachedRerolls.length <= 1 || importedGeneratedRerollIdSet.has(genId)){
-            return
+        // Review 2.3: guard against char/chat switch during await
+        if(!success && $selectedCharID === selectedChar && DBState.db.characters[selectedChar]?.chats?.[selectedChat]){
+            rerollManager.handleFailedGeneration(savedMessages, DBState.db.characters[selectedChar].chats[selectedChat])
         }
-
-        if(rerollStartIndex < 0){
-            rerollStartIndex = Math.max(0, messages.length - 1)
-        }
-
-        const baseMessage = cloneSwipeSegment([activeMessage])[0]
-        const generatedRerollData = [activeMessage.data, ...cachedRerolls.slice(1)]
-        const generatedRerolls = generatedRerollData.map((data) => [{
-            ...cloneSwipeSegment([baseMessage])[0],
-            data
-        }])
-        const replaceIndex = rerollIndex >= 0 ? rerollIndex : rerolls.length
-
-        if(rerollIndex < 0){
-            rerolls.push(...generatedRerolls)
-            rerollIndex = 0
-        }
-        else{
-            rerolls.splice(replaceIndex, 1, ...generatedRerolls)
-            rerollIndex = replaceIndex
-        }
-        importedGeneratedRerollIdSet.add(genId)
-        persistRerollsOnMessages(messages)
     }
 
     function updateCurrentRerollMessage(idx:number, data:string){
-        if(!currentRerollContainsIndex(idx)){
-            if(!loadPersistedRerollsAtIndex(idx)){
-                return
-            }
-        }
-        else{
-            loadPersistedRerolls()
-        }
-        const rerollData = rerolls[rerollIndex]
-        if(!Array.isArray(rerollData)){
-            return
-        }
-        const rerollMessageIndex = idx - rerollStartIndex
-        if(rerollMessageIndex < 0 || rerollMessageIndex >= rerollData.length){
-            return
-        }
-        rerollData[rerollMessageIndex].data = data
-        persistRerollsOnMessages(getVisibleMessages())
+        const messages = getVisibleMessages()
+        const chat = getVisibleChat()
+        rerollManager.updateMessageData(idx, data, messages, chat)
     }
 
     function canDeleteCurrentReroll(idx:number){
-        if($doingChat){
-            return false
-        }
         const messages = getVisibleMessages()
-        if(messages[idx]?.role !== 'char' || messages[idx]?.isComment){
-            return false
-        }
-        const activeRerollLength = rerolls[rerollIndex]?.length ?? 0
-        if(rerollStartIndex >= 0 && idx >= rerollStartIndex && idx < rerollStartIndex + activeRerollLength && rerolls.length > 1){
-            return true
-        }
-        return messages.some((message, index) => {
-            const swipes = message.swipes
-            const activeSwipeLength = swipes?.[message.swipeId ?? 0]?.length ?? 0
-            return index <= idx && idx < index + activeSwipeLength && Array.isArray(swipes) && swipes.length > 1
-        })
+        return rerollManager.canDeleteReroll(idx, messages, $doingChat)
     }
 
     function deleteCurrentReroll(idx:number){
-        if($doingChat){
-            return
-        }
-        if(!currentRerollContainsIndex(idx)){
-            if(!loadPersistedRerollsAtIndex(idx)){
-                return
-            }
-        }
-        else{
-            loadPersistedRerolls()
-        }
-        importGeneratedRerolls()
-        if(!canDeleteCurrentReroll(idx)){
-            return
-        }
-
-        rerolls.splice(rerollIndex, 1)
-        rerollIndex = Math.min(rerollIndex, rerolls.length - 1)
-        applyRerollData(rerolls[rerollIndex])
-
-        if(rerolls.length <= 1){
-            clearPersistedRerolls(getVisibleMessages())
-        }
-    }
-
-    function hasRerollContent(segment:Message[]){
-        return segment.some((message) => message.data !== '')
-    }
-
-    function registerRerollSegment(previousLength:number, requireContent = false){
+        if($doingChat) return
         const messages = getVisibleMessages()
-        if(previousLength >= messages.length){
-            return false
-        }
-        const newSegment = messages.slice(previousLength)
-        if(requireContent && !hasRerollContent(newSegment)){
-            return false
-        }
-        if(rerollStartIndex >= 0 && rerollStartIndex !== previousLength){
-            resetRerolls()
-        }
-        if(rerollStartIndex < 0 || rerolls.length === 0){
-            rerollStartIndex = previousLength
-        }
-        rerolls.push(cloneSwipeSegment(newSegment))
-        rerollIndex = rerolls.length - 1
-        importGeneratedRerolls()
-        persistRerollsOnMessages(getVisibleMessages())
-        return true
+        const chat = getVisibleChat()
+        rerollManager.deleteVariant(idx, messages, chat)
+    }
+
+    function getSwipeInfo(idx:number):{ current:number, total:number }|null{
+        const messages = getVisibleMessages()
+        return rerollManager.getSwipeInfo(idx, messages)
+    }
+
+    function handleMessageDeleted(idx:number){
+        const messages = getVisibleMessages()
+        const chat = getVisibleChat()
+        rerollManager.handleMessageDeletion(idx, messages, chat)
     }
 
     async function unReroll(idx = -1) {
-        if($doingChat){
-            return
-        }
-        resetRerollsIfSelectionChanged()
-        if(idx >= 0 && !currentRerollContainsIndex(idx)){
-            if(!loadPersistedRerollsAtIndex(idx)){
-                resetRerolls()
-            }
-        }
-        else{
-            loadPersistedRerolls()
-        }
-        importGeneratedRerolls()
-        if(Array.isArray(rerolls[rerollIndex - 1])){
-            rerollIndex -= 1
-            applyRerollData(rerolls[rerollIndex])
-            return
-        }
+        if($doingChat) return
+        const charId = $selectedCharID
+        const chatPage = DBState.db.characters[charId]?.chatPage ?? -1
+        rerollManager.resetIfSelectionChanged(charId, chatPage)
+        const messages = getVisibleMessages()
+        const chat = getVisibleChat()
+        rerollManager.navigatePrev(idx, messages, chat)
     }
-
 
     let abortController:null|AbortController = null
 
     async function sendChatMain(continued:boolean = false):Promise<boolean> {
-
-        let previousLength = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length
+        const charId = $selectedCharID
+        const chatPage = DBState.db.characters[charId].chatPage
+        const chat = DBState.db.characters[charId].chats[chatPage]
+        let previousLength = chat.message.length
         messageInput = ''
         abortController = new AbortController()
         let success = false
@@ -692,17 +351,18 @@
                 signal:abortController.signal,
                 continue:continued
             })
+            // Review 2.5: only register on success or non-empty abort; never both register and rollback
             if(success){
-                registeredReroll = registerRerollSegment(previousLength)
+                registeredReroll = rerollManager.registerSegment(previousLength, getVisibleMessages(), getVisibleChat())
             }
             else if(abortController.signal.aborted){
-                registeredReroll = registerRerollSegment(previousLength, true)
+                registeredReroll = rerollManager.registerSegment(previousLength, getVisibleMessages(), getVisibleChat(), true)
             }
         } catch (error) {
             console.error(error)
             alertError(error)
         }
-        rememberRerollSelection()
+        rerollManager.rememberSelection($selectedCharID, DBState.db.characters[$selectedCharID]?.chatPage ?? -1)
         $doingChat = false
         if(DBState.db.playMessage){
             const audio = new Audio(sendSound);
@@ -1198,6 +858,8 @@
                 onEdit={updateCurrentRerollMessage}
                 onDeleteReroll={deleteCurrentReroll}
                 canDeleteReroll={canDeleteCurrentReroll}
+                {getSwipeInfo}
+                onMessageDeleted={handleMessageDeleted}
                 currentCharacter={currentCharacter}
                 currentUsername={currentUsername}
                 userIcon={userIcon}

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -46,10 +46,11 @@
     let loadPages = $state(30)
     let autoMode = $state(false)
     let rerolls:Message[][] = []
-    let rerollid = -1
+    let rerollIndex = -1
     let rerollStartIndex = -1
-    let importedGeneratedRerollIds = new Set<string>()
+    let importedGeneratedRerollIdSet = new Set<string>()
     let lastCharId = -1
+    let lastChatPage = -1
     let doingChatInputTranslate = false
     let toggleStickers:boolean = $state(false)
     let fileInput:string[] = $state([])
@@ -62,12 +63,36 @@
 
     function resetRerolls(){
         rerolls = []
-        rerollid = -1
+        rerollIndex = -1
         rerollStartIndex = -1
-        importedGeneratedRerollIds = new Set<string>()
+        importedGeneratedRerollIdSet = new Set<string>()
     }
 
-    function cloneSwipeSegment(segment:Message[]){
+    function getVisibleMessages():Message[]{
+        const char = DBState.db.characters[$selectedCharID]
+        return char.chats[char.chatPage].message
+    }
+
+    function setVisibleMessages(messages:Message[]){
+        const char = DBState.db.characters[$selectedCharID]
+        char.chats[char.chatPage].message = messages
+    }
+
+    function rememberRerollSelection(charId = $selectedCharID, chatPage = DBState.db.characters[charId]?.chatPage ?? -1){
+        lastCharId = charId
+        lastChatPage = chatPage
+    }
+
+    function resetRerollsIfSelectionChanged(){
+        const charId = $selectedCharID
+        const chatPage = DBState.db.characters[charId]?.chatPage ?? -1
+        if(lastCharId !== charId || lastChatPage !== chatPage){
+            resetRerolls()
+            rememberRerollSelection(charId, chatPage)
+        }
+    }
+
+    function cloneSwipeSegment(segment:Message[]):Message[]{
         return safeStructuredClone(segment).map((message) => {
             delete message.swipes
             delete message.swipeId
@@ -75,40 +100,39 @@
         })
     }
 
-    function cloneSwipeSegments(segments:Message[][]){
+    function cloneSwipeSegments(segments:Message[][]):Message[][]{
         return segments.map(cloneSwipeSegment)
     }
 
-    function persistRerollsOnVisibleChat(){
-        if(rerollStartIndex < 0 || rerollid < 0 || rerolls.length <= 1){
+    function persistRerollsOnMessages(messages:Message[]){
+        if(rerollStartIndex < 0 || rerollIndex < 0 || rerolls.length <= 1){
             return
         }
-        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
         const activeMessage = messages[rerollStartIndex]
         if(!activeMessage){
             return
         }
         activeMessage.swipes = cloneSwipeSegments(rerolls)
-        activeMessage.swipeId = rerollid
+        activeMessage.swipeId = rerollIndex
     }
 
     function loadPersistedRerolls(){
         if(rerolls.length > 0){
             return
         }
-        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+        const messages = getVisibleMessages()
         for(let i = messages.length - 1; i >= 0; i--){
             const message = messages[i]
             if(Array.isArray(message.swipes) && message.swipes.length > 0){
                 rerollStartIndex = i
                 rerolls = cloneSwipeSegments(message.swipes)
-                rerollid = Math.min(Math.max(message.swipeId ?? 0, 0), rerolls.length - 1)
-                rerolls[rerollid] = cloneSwipeSegment(messages.slice(i))
-                const genId = rerolls[rerollid]?.[0]?.generationInfo?.generationId
+                rerollIndex = Math.min(Math.max(message.swipeId ?? 0, 0), rerolls.length - 1)
+                rerolls[rerollIndex] = cloneSwipeSegment(messages.slice(i))
+                const genId = rerolls[rerollIndex]?.[0]?.generationInfo?.generationId
                 if(genId){
-                    importedGeneratedRerollIds.add(genId)
+                    importedGeneratedRerollIdSet.add(genId)
                 }
-                persistRerollsOnVisibleChat()
+                persistRerollsOnMessages(messages)
                 return
             }
         }
@@ -201,9 +225,7 @@
         if($doingChat){
             return
         }
-        if(lastCharId !== $selectedCharID){
-            resetRerolls()
-        }
+        resetRerollsIfSelectionChanged()
 
         let cha = DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message
 
@@ -275,15 +297,13 @@
         }
         const selectedChar = $selectedCharID
         const selectedChat = DBState.db.characters[selectedChar].chatPage
-        if(lastCharId !== $selectedCharID){
-            resetRerolls()
-        }
+        resetRerollsIfSelectionChanged()
         loadPersistedRerolls()
         importGeneratedRerolls()
-        if(rerollid < rerolls.length - 1){
-            if(Array.isArray(rerolls[rerollid + 1])){
-                rerollid += 1
-                applyRerollData(rerolls[rerollid])
+        if(rerollIndex < rerolls.length - 1){
+            if(Array.isArray(rerolls[rerollIndex + 1])){
+                rerollIndex += 1
+                applyRerollData(rerolls[rerollIndex])
             }
             return
         }
@@ -314,7 +334,7 @@
         rerollStartIndex = cha.length
         if(rerolls.length === 0){
             rerolls.push(cloneSwipeSegment(removedMessages))
-            rerollid = rerolls.length - 1
+            rerollIndex = rerolls.length - 1
         }
         DBState.db.characters[selectedChar].chats[selectedChat].message = cha
         const success = await sendChatMain()
@@ -324,25 +344,26 @@
     }
 
     function applyRerollData(rerollData:Message[]){
-        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+        const messages = getVisibleMessages()
         const startIndex = rerollStartIndex >= 0 ? rerollStartIndex : Math.max(0, messages.length - rerollData.length)
         const nextRerollData = cloneSwipeSegment(rerollData)
-        DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = [
+        const nextMessages = [
             ...messages.slice(0, startIndex),
             ...nextRerollData
         ]
-        persistRerollsOnVisibleChat()
+        setVisibleMessages(nextMessages)
+        persistRerollsOnMessages(nextMessages)
     }
 
     function importGeneratedRerolls(){
-        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-        const currentReroll = rerolls[rerollid]
+        const messages = getVisibleMessages()
+        const currentReroll = rerolls[rerollIndex]
         const activeMessage = Array.isArray(currentReroll) && currentReroll.length === 1
             ? currentReroll[0]
             : messages.at(-1)
         const genId = activeMessage?.generationInfo?.generationId
         const cachedRerolls = genId ? getRerolls(genId) : null
-        if(!activeMessage || !genId || !cachedRerolls || cachedRerolls.length <= 1 || importedGeneratedRerollIds.has(genId)){
+        if(!activeMessage || !genId || !cachedRerolls || cachedRerolls.length <= 1 || importedGeneratedRerollIdSet.has(genId)){
             return
         }
 
@@ -351,28 +372,28 @@
         }
 
         const baseMessage = cloneSwipeSegment([activeMessage])[0]
-        cachedRerolls[0] = activeMessage.data
-        const generatedRerolls = cachedRerolls.map((data) => [{
+        const generatedRerollData = [activeMessage.data, ...cachedRerolls.slice(1)]
+        const generatedRerolls = generatedRerollData.map((data) => [{
             ...cloneSwipeSegment([baseMessage])[0],
             data
         }])
-        const replaceIndex = rerollid >= 0 ? rerollid : rerolls.length
+        const replaceIndex = rerollIndex >= 0 ? rerollIndex : rerolls.length
 
-        if(rerollid < 0){
+        if(rerollIndex < 0){
             rerolls.push(...generatedRerolls)
-            rerollid = 0
+            rerollIndex = 0
         }
         else{
             rerolls.splice(replaceIndex, 1, ...generatedRerolls)
-            rerollid = replaceIndex
+            rerollIndex = replaceIndex
         }
-        importedGeneratedRerollIds.add(genId)
-        persistRerollsOnVisibleChat()
+        importedGeneratedRerollIdSet.add(genId)
+        persistRerollsOnMessages(messages)
     }
 
     function updateCurrentRerollMessage(idx:number, data:string){
         loadPersistedRerolls()
-        const rerollData = rerolls[rerollid]
+        const rerollData = rerolls[rerollIndex]
         if(!Array.isArray(rerollData)){
             return
         }
@@ -381,21 +402,42 @@
             return
         }
         rerollData[rerollMessageIndex].data = data
-        persistRerollsOnVisibleChat()
+        persistRerollsOnMessages(getVisibleMessages())
+    }
+
+    function hasRerollContent(segment:Message[]){
+        return segment.some((message) => message.data !== '')
+    }
+
+    function registerRerollSegment(previousLength:number, requireContent = false){
+        const messages = getVisibleMessages()
+        if(previousLength >= messages.length){
+            return false
+        }
+        const newSegment = messages.slice(previousLength)
+        if(requireContent && !hasRerollContent(newSegment)){
+            return false
+        }
+        if(rerollStartIndex < 0 || rerolls.length === 0){
+            rerollStartIndex = previousLength
+        }
+        rerolls.push(cloneSwipeSegment(newSegment))
+        rerollIndex = rerolls.length - 1
+        importGeneratedRerolls()
+        persistRerollsOnMessages(getVisibleMessages())
+        return true
     }
 
     async function unReroll() {
         if($doingChat){
             return
         }
-        if(lastCharId !== $selectedCharID){
-            resetRerolls()
-        }
+        resetRerollsIfSelectionChanged()
         loadPersistedRerolls()
         importGeneratedRerolls()
-        if(Array.isArray(rerolls[rerollid - 1])){
-            rerollid -= 1
-            applyRerollData(rerolls[rerollid])
+        if(Array.isArray(rerolls[rerollIndex - 1])){
+            rerollIndex -= 1
+            applyRerollData(rerolls[rerollIndex])
             return
         }
     }
@@ -409,31 +451,29 @@
         messageInput = ''
         abortController = new AbortController()
         let success = false
+        let registeredReroll = false
         try {
             success = await sendChat(-1, {
                 signal:abortController.signal,
                 continue:continued
             })
-            if(success && previousLength < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
-                if(rerollStartIndex < 0 || rerolls.length === 0){
-                    rerollStartIndex = previousLength
-                }
-                rerolls.push(cloneSwipeSegment(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.slice(previousLength)))
-                rerollid = rerolls.length - 1
-                importGeneratedRerolls()
-                persistRerollsOnVisibleChat()
+            if(success){
+                registeredReroll = registerRerollSegment(previousLength)
+            }
+            else if(abortController.signal.aborted){
+                registeredReroll = registerRerollSegment(previousLength, true)
             }
         } catch (error) {
             console.error(error)
             alertError(error)
         }
-        lastCharId = $selectedCharID
+        rememberRerollSelection()
         $doingChat = false
         if(DBState.db.playMessage){
             const audio = new Audio(sendSound);
             audio.play().catch(() => {});
         }
-        return success
+        return success || registeredReroll
     }
 
     function abortChat(){

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -5,7 +5,7 @@
     import { selectedCharID, PlaygroundStore, createSimpleCharacter, hypaV3ModalOpen, ScrollToMessageStore, additionalChatMenu, additionalFloatingActionButtons, easyPanelStore } from "../../ts/stores.svelte";
     import { tick } from 'svelte';
     import Chat from "./Chat.svelte";
-    import { type Message } from "../../ts/storage/database.svelte";
+    import { type Chat as ChatData, type Message } from "../../ts/storage/database.svelte";
     import { DBState } from 'src/ts/stores.svelte';
     import { getCharImage } from "../../ts/characters";
     import { chatProcessStage, doingChat, sendChat } from "../../ts/process/index.svelte";
@@ -73,9 +73,30 @@
         return char.chats[char.chatPage].message
     }
 
+    function getVisibleChat():ChatData{
+        const char = DBState.db.characters[$selectedCharID]
+        return char.chats[char.chatPage]
+    }
+
     function setVisibleMessages(messages:Message[]){
         const char = DBState.db.characters[$selectedCharID]
         char.chats[char.chatPage].message = messages
+    }
+
+    function persistRerollStateOnChat(chat = getVisibleChat()){
+        if(rerollStartIndex < 0 || rerollIndex < 0 || rerolls.length === 0){
+            delete chat.rerollState
+            return
+        }
+        chat.rerollState = {
+            segments: cloneSwipeSegments(rerolls),
+            index: Math.min(Math.max(rerollIndex, 0), rerolls.length - 1),
+            startIndex: rerollStartIndex
+        }
+    }
+
+    function clearRerollStateOnChat(chat = getVisibleChat()){
+        delete chat.rerollState
     }
 
     function rememberRerollSelection(charId = $selectedCharID, chatPage = DBState.db.characters[charId]?.chatPage ?? -1){
@@ -104,7 +125,7 @@
         return segments.map(cloneSwipeSegment)
     }
 
-    function persistRerollsOnMessages(messages:Message[]){
+    function persistRerollsOnMessages(messages:Message[], chat = getVisibleChat()){
         if(rerollStartIndex < 0 || rerollIndex < 0 || rerolls.length <= 1){
             return
         }
@@ -114,18 +135,64 @@
         }
         activeMessage.swipes = cloneSwipeSegments(rerolls)
         activeMessage.swipeId = rerollIndex
+        persistRerollStateOnChat(chat)
     }
 
-    function clearPersistedRerolls(messages:Message[]){
+    function clearPersistedRerolls(messages:Message[], chat = getVisibleChat()){
         if(rerollStartIndex < 0){
+            clearRerollStateOnChat(chat)
             return
         }
         const activeMessage = messages[rerollStartIndex]
         if(!activeMessage){
+            clearRerollStateOnChat(chat)
             return
         }
         delete activeMessage.swipes
         delete activeMessage.swipeId
+        clearRerollStateOnChat(chat)
+    }
+
+    function loadPersistedRerollState(messages:Message[]){
+        const chat = getVisibleChat()
+        const state = chat.rerollState
+        if(!state || !Array.isArray(state.segments) || state.segments.length === 0){
+            return false
+        }
+
+        const startIndex = Math.max(0, state.startIndex)
+        const swipeId = Math.min(Math.max(state.index ?? 0, 0), state.segments.length - 1)
+        rerollStartIndex = startIndex
+        rerolls = cloneSwipeSegments(state.segments)
+        rerollIndex = swipeId
+
+        const visibleSegment = messages.slice(startIndex)
+        if(visibleSegment.length > 0 && hasRerollContent(visibleSegment)){
+            rerolls[rerollIndex] = cloneSwipeSegment(visibleSegment)
+        }
+        else{
+            const activeSegment = rerolls[rerollIndex]
+            if(Array.isArray(activeSegment) && activeSegment.length > 0){
+                const nextMessages = [
+                    ...messages.slice(0, startIndex),
+                    ...cloneSwipeSegment(activeSegment)
+                ]
+                setVisibleMessages(nextMessages)
+                messages = nextMessages
+            }
+        }
+
+        const genId = rerolls[rerollIndex]?.[0]?.generationInfo?.generationId
+        if(genId){
+            importedGeneratedRerollIdSet.add(genId)
+        }
+        if(rerolls.length > 1){
+            persistRerollsOnMessages(messages)
+        }
+        else{
+            clearRerollStateOnChat(chat)
+        }
+        return true
     }
 
     function loadPersistedRerolls(){
@@ -133,6 +200,9 @@
             return
         }
         const messages = getVisibleMessages()
+        if(loadPersistedRerollState(messages)){
+            return
+        }
         for(let i = messages.length - 1; i >= 0; i--){
             const message = messages[i]
             if(Array.isArray(message.swipes) && message.swipes.length > 0){
@@ -160,6 +230,14 @@
     function scrollToBottom() {
         chatsInstance?.scrollToLatestMessage();
     }
+    $effect(() => {
+        const charId = $selectedCharID
+        const chatPage = DBState.db.characters[charId]?.chatPage ?? -1
+        if(charId >= 0 && chatPage >= 0){
+            resetRerollsIfSelectionChanged()
+            loadPersistedRerolls()
+        }
+    })
     $effect(() => {
         if(ScrollToMessageStore.value !== -1){
             const index = ScrollToMessageStore.value
@@ -303,6 +381,7 @@
         messageInput = ''
         messageInputTranslate = ''
         DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message = cha
+        clearRerollStateOnChat(DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage])
         resetRerolls()
         await sleep(10)
         updateInputSizeAll()
@@ -359,10 +438,17 @@
             rerolls.push(cloneSwipeSegment(removedMessages))
             rerollIndex = rerolls.length - 1
         }
+        persistRerollStateOnChat(DBState.db.characters[selectedChar].chats[selectedChat])
         DBState.db.characters[selectedChar].chats[selectedChat].message = cha
         const success = await sendChatMain()
         if(!success && DBState.db.characters[selectedChar]?.chats?.[selectedChat]){
             DBState.db.characters[selectedChar].chats[selectedChat].message = savedMessages
+            if(rerolls.length > 1){
+                persistRerollsOnMessages(savedMessages, DBState.db.characters[selectedChar].chats[selectedChat])
+            }
+            else{
+                clearRerollStateOnChat(DBState.db.characters[selectedChar].chats[selectedChat])
+            }
         }
     }
 

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -195,6 +195,60 @@
         return true
     }
 
+    function getActiveSwipeLength(message?:Message){
+        const swipes = message?.swipes
+        if(!Array.isArray(swipes) || swipes.length === 0){
+            return 0
+        }
+        const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), swipes.length - 1)
+        return swipes[swipeId]?.length ?? 0
+    }
+
+    function findPersistedRerollStartIndex(idx:number, messages = getVisibleMessages()){
+        for(let i = Math.min(idx, messages.length - 1); i >= 0; i--){
+            const message = messages[i]
+            const activeSwipeLength = getActiveSwipeLength(message)
+            if(activeSwipeLength > 0 && i <= idx && idx < i + activeSwipeLength){
+                return i
+            }
+        }
+        return -1
+    }
+
+    function currentRerollContainsIndex(idx:number){
+        const activeRerollLength = rerolls[rerollIndex]?.length ?? 0
+        return rerollStartIndex >= 0 && idx >= rerollStartIndex && idx < rerollStartIndex + activeRerollLength
+    }
+
+    function loadPersistedRerollsAtIndex(idx:number){
+        const messages = getVisibleMessages()
+        const startIndex = findPersistedRerollStartIndex(idx, messages)
+        if(startIndex < 0){
+            return false
+        }
+
+        const message = messages[startIndex]
+        if(!Array.isArray(message.swipes) || message.swipes.length === 0){
+            return false
+        }
+
+        const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), message.swipes.length - 1)
+        const activeSwipeLength = message.swipes[swipeId]?.length ?? 0
+        if(activeSwipeLength === 0){
+            return false
+        }
+
+        rerollStartIndex = startIndex
+        rerolls = cloneSwipeSegments(message.swipes)
+        rerollIndex = swipeId
+        rerolls[rerollIndex] = cloneSwipeSegment(messages.slice(startIndex, startIndex + activeSwipeLength))
+        const genId = rerolls[rerollIndex]?.[0]?.generationInfo?.generationId
+        if(genId){
+            importedGeneratedRerollIdSet.add(genId)
+        }
+        return true
+    }
+
     function loadPersistedRerolls(){
         if(rerolls.length > 0){
             return
@@ -207,10 +261,8 @@
             const message = messages[i]
             if(Array.isArray(message.swipes) && message.swipes.length > 0){
                 const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), message.swipes.length - 1)
-                const activeSwipeLength = message.swipes[swipeId]?.length ?? 0
+                const activeSwipeLength = getActiveSwipeLength(message)
                 if(activeSwipeLength === 0 || activeSwipeLength !== messages.length - i){
-                    delete message.swipes
-                    delete message.swipeId
                     continue
                 }
                 rerollStartIndex = i
@@ -389,14 +441,21 @@
 
     }
 
-    async function reroll() {
+    async function reroll(idx = -1) {
         if($doingChat){
             return
         }
         const selectedChar = $selectedCharID
         const selectedChat = DBState.db.characters[selectedChar].chatPage
         resetRerollsIfSelectionChanged()
-        loadPersistedRerolls()
+        if(idx >= 0 && !currentRerollContainsIndex(idx)){
+            if(!loadPersistedRerollsAtIndex(idx)){
+                resetRerolls()
+            }
+        }
+        else{
+            loadPersistedRerolls()
+        }
         importGeneratedRerolls()
         if(rerollIndex < rerolls.length - 1){
             if(Array.isArray(rerolls[rerollIndex + 1])){
@@ -406,6 +465,9 @@
             return
         }
         const savedMessages = safeStructuredClone(DBState.db.characters[selectedChar].chats[selectedChat].message)
+        if(idx >= 0 && idx !== savedMessages.length - 1){
+            return
+        }
         const lastMessage = savedMessages.at(-1)
         if(lastMessage?.role !== 'char' || lastMessage.isComment){
             return
@@ -455,10 +517,12 @@
     function applyRerollData(rerollData:Message[]){
         const messages = getVisibleMessages()
         const startIndex = rerollStartIndex >= 0 ? rerollStartIndex : Math.max(0, messages.length - rerollData.length)
+        const activeSwipeLength = getActiveSwipeLength(messages[startIndex]) || rerollData.length
         const nextRerollData = cloneSwipeSegment(rerollData)
         const nextMessages = [
             ...messages.slice(0, startIndex),
-            ...nextRerollData
+            ...nextRerollData,
+            ...messages.slice(startIndex + activeSwipeLength)
         ]
         setVisibleMessages(nextMessages)
         persistRerollsOnMessages(nextMessages)
@@ -501,7 +565,14 @@
     }
 
     function updateCurrentRerollMessage(idx:number, data:string){
-        loadPersistedRerolls()
+        if(!currentRerollContainsIndex(idx)){
+            if(!loadPersistedRerollsAtIndex(idx)){
+                return
+            }
+        }
+        else{
+            loadPersistedRerolls()
+        }
         const rerollData = rerolls[rerollIndex]
         if(!Array.isArray(rerollData)){
             return
@@ -519,8 +590,7 @@
             return false
         }
         const messages = getVisibleMessages()
-        const lastMessageIndex = messages.length - 1
-        if(idx !== lastMessageIndex || messages[idx]?.role !== 'char' || messages[idx]?.isComment){
+        if(messages[idx]?.role !== 'char' || messages[idx]?.isComment){
             return false
         }
         const activeRerollLength = rerolls[rerollIndex]?.length ?? 0
@@ -538,7 +608,14 @@
         if($doingChat){
             return
         }
-        loadPersistedRerolls()
+        if(!currentRerollContainsIndex(idx)){
+            if(!loadPersistedRerollsAtIndex(idx)){
+                return
+            }
+        }
+        else{
+            loadPersistedRerolls()
+        }
         importGeneratedRerolls()
         if(!canDeleteCurrentReroll(idx)){
             return
@@ -566,6 +643,9 @@
         if(requireContent && !hasRerollContent(newSegment)){
             return false
         }
+        if(rerollStartIndex >= 0 && rerollStartIndex !== previousLength){
+            resetRerolls()
+        }
         if(rerollStartIndex < 0 || rerolls.length === 0){
             rerollStartIndex = previousLength
         }
@@ -576,12 +656,19 @@
         return true
     }
 
-    async function unReroll() {
+    async function unReroll(idx = -1) {
         if($doingChat){
             return
         }
         resetRerollsIfSelectionChanged()
-        loadPersistedRerolls()
+        if(idx >= 0 && !currentRerollContainsIndex(idx)){
+            if(!loadPersistedRerollsAtIndex(idx)){
+                resetRerolls()
+            }
+        }
+        else{
+            loadPersistedRerolls()
+        }
         importGeneratedRerolls()
         if(Array.isArray(rerolls[rerollIndex - 1])){
             rerollIndex -= 1
@@ -1325,7 +1412,7 @@
                     </div>
 
                     {#if DBState.db.sideMenuRerollButton}
-                        <div class="flex items-center cursor-pointer hover:text-green-500 transition-colors" onclick={reroll}>
+                        <div class="flex items-center cursor-pointer hover:text-green-500 transition-colors" onclick={() => reroll()}>
                             <RefreshCcwIcon />
                             <span class="ml-2">{language.reroll}</span>
                         </div>

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -22,7 +22,7 @@
     import { aiLawApplies, chatFoldedState, chatFoldedStateMessageIndex, downloadFile } from 'src/ts/globalApi.svelte';
     import { runTrigger } from 'src/ts/process/triggers';
     import { v4 } from 'uuid';
-    import { PreUnreroll, Prereroll } from 'src/ts/process/prereroll';
+    import { getRerolls } from 'src/ts/process/prereroll';
     import { processMultiCommand } from 'src/ts/process/command';
     import { postChatFile } from 'src/ts/process/files/multisend';
     import { getInlayAsset } from 'src/ts/process/files/inlays';
@@ -47,6 +47,8 @@
     let autoMode = $state(false)
     let rerolls:Message[][] = []
     let rerollid = -1
+    let rerollStartIndex = -1
+    let importedGeneratedRerollIds = new Set<string>()
     let lastCharId = -1
     let doingChatInputTranslate = false
     let toggleStickers:boolean = $state(false)
@@ -57,6 +59,60 @@
     let { openModuleList = $bindable(false), openChatList = $bindable(false), customStyle = '' }: Props = $props();
     let currentCharacter = $derived(DBState.db.characters[$selectedCharID])
     let currentChat = $derived(currentCharacter?.chats[currentCharacter.chatPage]?.message ?? [])
+
+    function resetRerolls(){
+        rerolls = []
+        rerollid = -1
+        rerollStartIndex = -1
+        importedGeneratedRerollIds = new Set<string>()
+    }
+
+    function cloneSwipeSegment(segment:Message[]){
+        return safeStructuredClone(segment).map((message) => {
+            delete message.swipes
+            delete message.swipeId
+            return message
+        })
+    }
+
+    function cloneSwipeSegments(segments:Message[][]){
+        return segments.map(cloneSwipeSegment)
+    }
+
+    function persistRerollsOnVisibleChat(){
+        if(rerollStartIndex < 0 || rerollid < 0 || rerolls.length <= 1){
+            return
+        }
+        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+        const activeMessage = messages[rerollStartIndex]
+        if(!activeMessage){
+            return
+        }
+        activeMessage.swipes = cloneSwipeSegments(rerolls)
+        activeMessage.swipeId = rerollid
+    }
+
+    function loadPersistedRerolls(){
+        if(rerolls.length > 0){
+            return
+        }
+        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+        for(let i = messages.length - 1; i >= 0; i--){
+            const message = messages[i]
+            if(Array.isArray(message.swipes) && message.swipes.length > 0){
+                rerollStartIndex = i
+                rerolls = cloneSwipeSegments(message.swipes)
+                rerollid = Math.min(Math.max(message.swipeId ?? 0, 0), rerolls.length - 1)
+                rerolls[rerollid] = cloneSwipeSegment(messages.slice(i))
+                const genId = rerolls[rerollid]?.[0]?.generationInfo?.generationId
+                if(genId){
+                    importedGeneratedRerollIds.add(genId)
+                }
+                persistRerollsOnVisibleChat()
+                return
+            }
+        }
+    }
 
     function scrollToBottom() {
         chatsInstance?.scrollToLatestMessage();
@@ -146,8 +202,7 @@
             return
         }
         if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
+            resetRerolls()
         }
 
         let cha = DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message
@@ -207,7 +262,7 @@
         messageInput = ''
         messageInputTranslate = ''
         DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message = cha
-        rerolls = []
+        resetRerolls()
         await sleep(10)
         updateInputSizeAll()
         await sendChatMain(continueResponse)
@@ -218,35 +273,22 @@
         if($doingChat){
             return
         }
+        const selectedChar = $selectedCharID
+        const selectedChat = DBState.db.characters[selectedChar].chatPage
         if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
+            resetRerolls()
         }
-        const genId = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)?.generationInfo?.generationId
-        if(genId){
-            const r = Prereroll(genId)
-            if(r){
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - 1].data = r
-                return
-            }
-        }
+        loadPersistedRerolls()
+        importGeneratedRerolls()
         if(rerollid < rerolls.length - 1){
             if(Array.isArray(rerolls[rerollid + 1])){
                 rerollid += 1
-                let rerollData = safeStructuredClone(rerolls[rerollid])
-                let msgs = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-                for(let i = 0; i < rerollData.length; i++){
-                    msgs[msgs.length - rerollData.length + i] = rerollData[i]
-                }
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = msgs
+                applyRerollData(rerolls[rerollid])
             }
             return
         }
-        if(rerolls.length === 0){
-            rerolls.push(safeStructuredClone([DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)]))
-            rerollid = rerolls.length - 1
-        }
-        let cha = safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message)
+        const savedMessages = safeStructuredClone(DBState.db.characters[selectedChar].chats[selectedChat].message)
+        let cha = safeStructuredClone(savedMessages)
         if(cha.length === 0 ){
             return
         }
@@ -265,8 +307,81 @@
                 return
             }
         }
-        DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = cha
-        await sendChatMain()
+        const removedMessages = safeStructuredClone(savedMessages.slice(cha.length))
+        if(removedMessages.length === 0){
+            return
+        }
+        rerollStartIndex = cha.length
+        if(rerolls.length === 0){
+            rerolls.push(cloneSwipeSegment(removedMessages))
+            rerollid = rerolls.length - 1
+        }
+        DBState.db.characters[selectedChar].chats[selectedChat].message = cha
+        const success = await sendChatMain()
+        if(!success && DBState.db.characters[selectedChar]?.chats?.[selectedChat]){
+            DBState.db.characters[selectedChar].chats[selectedChat].message = savedMessages
+        }
+    }
+
+    function applyRerollData(rerollData:Message[]){
+        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+        const startIndex = rerollStartIndex >= 0 ? rerollStartIndex : Math.max(0, messages.length - rerollData.length)
+        const nextRerollData = cloneSwipeSegment(rerollData)
+        DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = [
+            ...messages.slice(0, startIndex),
+            ...nextRerollData
+        ]
+        persistRerollsOnVisibleChat()
+    }
+
+    function importGeneratedRerolls(){
+        const messages = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+        const currentReroll = rerolls[rerollid]
+        const activeMessage = Array.isArray(currentReroll) && currentReroll.length === 1
+            ? currentReroll[0]
+            : messages.at(-1)
+        const genId = activeMessage?.generationInfo?.generationId
+        const cachedRerolls = genId ? getRerolls(genId) : null
+        if(!activeMessage || !genId || !cachedRerolls || cachedRerolls.length <= 1 || importedGeneratedRerollIds.has(genId)){
+            return
+        }
+
+        if(rerollStartIndex < 0){
+            rerollStartIndex = Math.max(0, messages.length - 1)
+        }
+
+        const baseMessage = cloneSwipeSegment([activeMessage])[0]
+        cachedRerolls[0] = activeMessage.data
+        const generatedRerolls = cachedRerolls.map((data) => [{
+            ...cloneSwipeSegment([baseMessage])[0],
+            data
+        }])
+        const replaceIndex = rerollid >= 0 ? rerollid : rerolls.length
+
+        if(rerollid < 0){
+            rerolls.push(...generatedRerolls)
+            rerollid = 0
+        }
+        else{
+            rerolls.splice(replaceIndex, 1, ...generatedRerolls)
+            rerollid = replaceIndex
+        }
+        importedGeneratedRerollIds.add(genId)
+        persistRerollsOnVisibleChat()
+    }
+
+    function updateCurrentRerollMessage(idx:number, data:string){
+        loadPersistedRerolls()
+        const rerollData = rerolls[rerollid]
+        if(!Array.isArray(rerollData)){
+            return
+        }
+        const rerollMessageIndex = idx - rerollStartIndex
+        if(rerollMessageIndex < 0 || rerollMessageIndex >= rerollData.length){
+            return
+        }
+        rerollData[rerollMessageIndex].data = data
+        persistRerollsOnVisibleChat()
     }
 
     async function unReroll() {
@@ -274,46 +389,39 @@
             return
         }
         if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
+            resetRerolls()
         }
-        const genId = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)?.generationInfo?.generationId
-        if(genId){
-            const r = PreUnreroll(genId)
-            if(r){
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - 1].data = r
-                return
-            }
-        }
-        if(rerollid <= 0){
-            return
-        }
+        loadPersistedRerolls()
+        importGeneratedRerolls()
         if(Array.isArray(rerolls[rerollid - 1])){
             rerollid -= 1
-            let rerollData = safeStructuredClone(rerolls[rerollid])
-            let msgs = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-            for(let i = 0; i < rerollData.length; i++){
-                msgs[msgs.length - rerollData.length + i] = rerollData[i]
-            }
-            DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = msgs
+            applyRerollData(rerolls[rerollid])
+            return
         }
     }
 
+
     let abortController:null|AbortController = null
 
-    async function sendChatMain(continued:boolean = false) {
+    async function sendChatMain(continued:boolean = false):Promise<boolean> {
 
         let previousLength = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length
         messageInput = ''
         abortController = new AbortController()
+        let success = false
         try {
-            await sendChat(-1, {
+            success = await sendChat(-1, {
                 signal:abortController.signal,
                 continue:continued
             })
-            if(previousLength < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
-                rerolls.push(safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message).slice(previousLength))
+            if(success && previousLength < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
+                if(rerollStartIndex < 0 || rerolls.length === 0){
+                    rerollStartIndex = previousLength
+                }
+                rerolls.push(cloneSwipeSegment(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.slice(previousLength)))
                 rerollid = rerolls.length - 1
+                importGeneratedRerolls()
+                persistRerollsOnVisibleChat()
             }
         } catch (error) {
             console.error(error)
@@ -325,6 +433,7 @@
             const audio = new Audio(sendSound);
             audio.play().catch(() => {});
         }
+        return success
     }
 
     function abortChat(){
@@ -811,6 +920,7 @@
                 loadPages={loadPages}
                 onReroll={reroll}
                 unReroll={unReroll}
+                onEdit={updateCurrentRerollMessage}
                 currentCharacter={currentCharacter}
                 currentUsername={currentUsername}
                 userIcon={userIcon}

--- a/src/ts/process/prereroll.ts
+++ b/src/ts/process/prereroll.ts
@@ -27,3 +27,7 @@ export function addRerolls(genId:string, values:string[]){
     rerolls[genId] = values;
     rerollIndex[genId] = 0;
 }
+
+export function getRerolls(genId:string):string[]|null{
+    return rerolls[genId] ?? null
+}

--- a/src/ts/process/prereroll.ts
+++ b/src/ts/process/prereroll.ts
@@ -1,31 +1,7 @@
 let rerolls:{[key:string]:string[]} = {};
-let rerollIndex:{[key:string]:number} = {};
-
-export function Prereroll(genId:string){
-    if(rerolls[genId]){
-        let index = rerollIndex[genId];
-        index += 1;
-        rerollIndex[genId] = index;
-        return rerolls[genId][index] ?? null;
-    }
-    return null;
-}
-export function PreUnreroll(genId:string){
-    if(rerolls[genId]){
-        let index = rerollIndex[genId];
-        index -= 1;
-        if(index < 0){
-            return null
-        }
-        rerollIndex[genId] = index;
-        return rerolls[genId][index] ?? null;
-    }
-    return null;
-}
 
 export function addRerolls(genId:string, values:string[]){
     rerolls[genId] = values;
-    rerollIndex[genId] = 0;
 }
 
 export function getRerolls(genId:string):string[]|null{

--- a/src/ts/process/rerollState.ts
+++ b/src/ts/process/rerollState.ts
@@ -1,0 +1,499 @@
+import type { Chat, ChatRerollState, Message } from '../storage/database.svelte'
+import { getRerolls } from './prereroll'
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Deep-clone a segment, stripping nested swipe metadata to avoid recursion. */
+export function cloneSwipeSegment(segment: Message[]): Message[] {
+    return safeStructuredClone(segment).map((m) => {
+        delete m.swipes
+        delete m.swipeId
+        return m
+    })
+}
+
+function cloneSwipeSegments(segments: Message[][]): Message[][] {
+    return segments.map(cloneSwipeSegment)
+}
+
+function hasRerollContent(segment: Message[]): boolean {
+    return segment.some((m) => m.data !== '')
+}
+
+/** Safely read the length of the active swipe segment on a message. */
+function getActiveSwipeLength(message?: Message): number {
+    const swipes = message?.swipes
+    if (!Array.isArray(swipes) || swipes.length === 0) {
+        return 0
+    }
+    const swipeId = Math.min(Math.max(message.swipeId ?? 0, 0), swipes.length - 1)
+    const segment = swipes[swipeId]
+    if (!Array.isArray(segment)) {
+        return 0
+    }
+    return segment.length
+}
+
+/** Validate that a swipes array is well-formed (Review 6.1). */
+function isValidSwipes(swipes: unknown): swipes is Message[][] {
+    if (!Array.isArray(swipes)) return false
+    return swipes.every(
+        (seg) =>
+            Array.isArray(seg) &&
+            seg.length > 0 &&
+            seg.every((m: unknown) => m != null && typeof (m as Message).data === 'string')
+    )
+}
+
+// ---------------------------------------------------------------------------
+// RerollManager — encapsulates all reroll state and persistence
+// ---------------------------------------------------------------------------
+
+export class RerollManager {
+    private segments: Message[][] = []
+    private segmentIndex = -1
+    private startIndex = -1
+    private importedGenIds = new Set<string>()
+    private lastCharId = -1
+    private lastChatPage = -1
+
+    // -----------------------------------------------------------------------
+    // Public read-only accessors
+    // -----------------------------------------------------------------------
+
+    get currentIndex(): number {
+        return this.segmentIndex
+    }
+
+    get total(): number {
+        return this.segments.length
+    }
+
+    /** Whether there are persisted swipes available for a given message index. */
+    canDeleteReroll(idx: number, messages: Message[], isDoingChat: boolean): boolean {
+        if (isDoingChat) return false
+        const msg = messages[idx]
+        if (!msg || msg.role !== 'char' || msg.isComment) return false
+
+        // Check in-memory reroll state first
+        const activeLen = this.segments[this.segmentIndex]?.length ?? 0
+        if (
+            this.startIndex >= 0 &&
+            idx >= this.startIndex &&
+            idx < this.startIndex + activeLen &&
+            this.segments.length > 1
+        ) {
+            return true
+        }
+
+        // Check persisted swipes on the specific message (Review 2.2: O(1) not O(n))
+        const si = this.findPersistedStartIndex(idx, messages)
+        if (si < 0) return false
+        const swipes = messages[si]?.swipes
+        return isValidSwipes(swipes) && swipes.length > 1
+    }
+
+    /** Get the swipe counter info for a message index, if applicable. */
+    getSwipeInfo(idx: number, messages: Message[]): { current: number; total: number } | null {
+        // Check in-memory state
+        if (this.containsIndex(idx) && this.segments.length > 1) {
+            return { current: this.segmentIndex + 1, total: this.segments.length }
+        }
+        // Check persisted swipes
+        const si = this.findPersistedStartIndex(idx, messages)
+        if (si >= 0) {
+            const msg = messages[si]
+            if (isValidSwipes(msg?.swipes) && msg.swipes.length > 1) {
+                const swipeId = Math.min(Math.max(msg.swipeId ?? 0, 0), msg.swipes.length - 1)
+                return { current: swipeId + 1, total: msg.swipes.length }
+            }
+        }
+        return null
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    reset(): void {
+        this.segments = []
+        this.segmentIndex = -1
+        this.startIndex = -1
+        this.importedGenIds = new Set()
+    }
+
+    /** Call when the active character or chat page may have changed. */
+    resetIfSelectionChanged(charId: number, chatPage: number): void {
+        if (this.lastCharId !== charId || this.lastChatPage !== chatPage) {
+            this.reset()
+            this.rememberSelection(charId, chatPage)
+        }
+    }
+
+    rememberSelection(charId: number, chatPage: number): void {
+        this.lastCharId = charId
+        this.lastChatPage = chatPage
+    }
+
+    /** Call when a message is deleted so in-memory state doesn't reference stale indices (Review 3.3). */
+    handleMessageDeletion(deletedIdx: number, messages: Message[], chat: Chat): void {
+        if (this.segments.length === 0) return
+
+        const activeLen = this.segments[this.segmentIndex]?.length ?? 0
+
+        // If the deleted index falls within the active reroll range, reset
+        if (this.startIndex >= 0 && deletedIdx >= this.startIndex && deletedIdx < this.startIndex + activeLen) {
+            this.clearPersistedSwipes(messages, chat)
+            this.reset()
+            return
+        }
+
+        // If a message before the reroll was deleted, shift startIndex down
+        if (this.startIndex > 0 && deletedIdx < this.startIndex) {
+            this.startIndex -= 1
+            this.persistSwipesOnMessages(messages, chat)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Navigation
+    // -----------------------------------------------------------------------
+
+    /** Navigate to the next reroll variant. Returns true if navigation occurred. */
+    navigateNext(idx: number, messages: Message[], chat: Chat): boolean {
+        this.ensureLoaded(idx, messages, chat)
+        this.importGeneratedRerolls(messages, chat)
+
+        if (this.segmentIndex < this.segments.length - 1 && Array.isArray(this.segments[this.segmentIndex + 1])) {
+            this.segmentIndex += 1
+            this.applySegment(messages, chat)
+            return true
+        }
+        return false
+    }
+
+    /** Navigate to the previous reroll variant. Returns true if navigation occurred. */
+    navigatePrev(idx: number, messages: Message[], chat: Chat): boolean {
+        this.ensureLoaded(idx, messages, chat)
+        this.importGeneratedRerolls(messages, chat)
+
+        if (this.segmentIndex > 0 && Array.isArray(this.segments[this.segmentIndex - 1])) {
+            this.segmentIndex -= 1
+            this.applySegment(messages, chat)
+            return true
+        }
+        return false
+    }
+
+    /** Delete the currently selected reroll variant. */
+    deleteVariant(idx: number, messages: Message[], chat: Chat): void {
+        this.ensureLoaded(idx, messages, chat)
+        this.importGeneratedRerolls(messages, chat)
+
+        if (this.segments.length <= 1) return
+
+        this.segments.splice(this.segmentIndex, 1)
+        this.segmentIndex = Math.min(this.segmentIndex, this.segments.length - 1)
+        this.applySegment(messages, chat)
+
+        if (this.segments.length <= 1) {
+            this.clearPersistedSwipes(chat.message, chat)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Registration (called after a generation completes)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Register a new reroll segment from messages added after `previousLength`.
+     * Returns true if a segment was registered.
+     */
+    registerSegment(previousLength: number, messages: Message[], chat: Chat, requireContent = false): boolean {
+        if (previousLength >= messages.length) return false
+
+        const newSegment = messages.slice(previousLength)
+        if (requireContent && !hasRerollContent(newSegment)) return false
+
+        if (this.startIndex >= 0 && this.startIndex !== previousLength) {
+            this.reset()
+        }
+        if (this.startIndex < 0 || this.segments.length === 0) {
+            this.startIndex = previousLength
+        }
+
+        this.segments.push(cloneSwipeSegment(newSegment))
+        this.segmentIndex = this.segments.length - 1
+        this.importGeneratedRerolls(messages, chat)
+        this.persistSwipesOnMessages(messages, chat)
+        return true
+    }
+
+    /**
+     * Save the current messages as the initial reroll segment before a new generation.
+     * Also persists transient state on the chat for crash recovery.
+     */
+    saveBeforeGeneration(removedMessages: Message[], messageLength: number, chat: Chat): void {
+        this.startIndex = messageLength
+        if (this.segments.length === 0) {
+            this.segments.push(cloneSwipeSegment(removedMessages))
+            this.segmentIndex = this.segments.length - 1
+        }
+        this.persistTransientState(chat)
+    }
+
+    /**
+     * Handle a failed generation: restore messages and clean up transient state.
+     */
+    handleFailedGeneration(savedMessages: Message[], chat: Chat): void {
+        chat.message = savedMessages
+        if (this.segments.length > 1) {
+            this.persistSwipesOnMessages(savedMessages, chat)
+        } else {
+            this.clearTransientState(chat)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Edit-through: update reroll data when message text is edited
+    // -----------------------------------------------------------------------
+
+    updateMessageData(idx: number, data: string, messages: Message[], chat: Chat): void {
+        this.ensureLoaded(idx, messages, chat)
+
+        const segment = this.segments[this.segmentIndex]
+        if (!Array.isArray(segment)) return
+
+        const rerollMsgIdx = idx - this.startIndex
+        if (rerollMsgIdx < 0 || rerollMsgIdx >= segment.length) return
+
+        segment[rerollMsgIdx].data = data
+        this.persistSwipesOnMessages(messages, chat)
+    }
+
+    // -----------------------------------------------------------------------
+    // Loading persisted state
+    // -----------------------------------------------------------------------
+
+    /**
+     * Load reroll state on component mount / chat switch.
+     * Tries transient state first, then scans message.swipes.
+     */
+    loadPersisted(messages: Message[], chat: Chat): void {
+        if (this.segments.length > 0) return
+
+        if (this.loadTransientState(messages, chat)) return
+
+        // Scan from the end for the last message with swipes
+        for (let i = messages.length - 1; i >= 0; i--) {
+            const msg = messages[i]
+            if (!isValidSwipes(msg?.swipes) || msg.swipes.length === 0) continue
+
+            const activeLen = getActiveSwipeLength(msg)
+            if (activeLen === 0 || activeLen !== messages.length - i) continue
+
+            this.startIndex = i
+            this.segments = cloneSwipeSegments(msg.swipes)
+            this.segmentIndex = Math.min(Math.max(msg.swipeId ?? 0, 0), this.segments.length - 1)
+            this.segments[this.segmentIndex] = cloneSwipeSegment(messages.slice(i))
+            this.markGenIdImported(this.segments[this.segmentIndex])
+            this.persistSwipesOnMessages(messages, chat)
+            return
+        }
+    }
+
+    /** Clear transient reroll state from chat (used when sending new user messages). */
+    clearTransient(chat: Chat): void {
+        this.clearTransientState(chat)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal persistence helpers
+    // -----------------------------------------------------------------------
+
+    /** Write swipe data onto the message at startIndex (long-term persistence). */
+    private persistSwipesOnMessages(messages: Message[], chat: Chat): void {
+        if (this.startIndex < 0 || this.segmentIndex < 0 || this.segments.length <= 1) return
+
+        const msg = messages[this.startIndex]
+        if (!msg) return
+
+        msg.swipes = cloneSwipeSegments(this.segments)
+        msg.swipeId = this.segmentIndex
+        this.clearTransientState(chat)
+    }
+
+    /** Clear swipe data from the message at startIndex. */
+    private clearPersistedSwipes(messages: Message[], chat: Chat): void {
+        if (this.startIndex >= 0) {
+            const msg = messages[this.startIndex]
+            if (msg) {
+                delete msg.swipes
+                delete msg.swipeId
+            }
+        }
+        this.clearTransientState(chat)
+    }
+
+    /** Write transient reroll snapshot to the Chat object (for crash recovery during generation). */
+    private persistTransientState(chat: Chat): void {
+        if (this.startIndex < 0 || this.segmentIndex < 0 || this.segments.length === 0) {
+            delete chat.rerollState
+            return
+        }
+        chat.rerollState = {
+            segments: cloneSwipeSegments(this.segments),
+            index: Math.min(Math.max(this.segmentIndex, 0), this.segments.length - 1),
+            startIndex: this.startIndex,
+        }
+    }
+
+    private clearTransientState(chat: Chat): void {
+        delete chat.rerollState
+    }
+
+    /** Restore from transient state (chat.rerollState). Returns true if loaded (Review 2.1: no misleading param reassign). */
+    private loadTransientState(messages: Message[], chat: Chat): boolean {
+        const state = chat.rerollState
+        if (!state || !Array.isArray(state.segments) || state.segments.length === 0) return false
+        // Validate segments (Review 6.1)
+        if (!state.segments.every((seg: unknown) => Array.isArray(seg) && (seg as Message[]).length > 0)) return false
+
+        const si = Math.max(0, state.startIndex)
+        const idx = Math.min(Math.max(state.index ?? 0, 0), state.segments.length - 1)
+        this.startIndex = si
+        this.segments = cloneSwipeSegments(state.segments)
+        this.segmentIndex = idx
+
+        const visibleTail = messages.slice(si)
+        if (visibleTail.length > 0 && hasRerollContent(visibleTail)) {
+            this.segments[this.segmentIndex] = cloneSwipeSegment(visibleTail)
+        } else {
+            const active = this.segments[this.segmentIndex]
+            if (Array.isArray(active) && active.length > 0) {
+                const restored = [...messages.slice(0, si), ...cloneSwipeSegment(active)]
+                chat.message = restored
+            }
+        }
+
+        this.markGenIdImported(this.segments[this.segmentIndex])
+
+        if (this.segments.length > 1) {
+            this.persistSwipesOnMessages(chat.message, chat)
+        } else {
+            this.clearTransientState(chat)
+        }
+        return true
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    private containsIndex(idx: number): boolean {
+        const len = this.segments[this.segmentIndex]?.length ?? 0
+        return this.startIndex >= 0 && idx >= this.startIndex && idx < this.startIndex + len
+    }
+
+    /** Ensure reroll data is loaded for the given message index. */
+    private ensureLoaded(idx: number, messages: Message[], chat: Chat): void {
+        if (idx >= 0 && !this.containsIndex(idx)) {
+            if (!this.loadPersistedAtIndex(idx, messages)) {
+                this.reset()
+            }
+        } else {
+            this.loadPersisted(messages, chat)
+        }
+    }
+
+    /** Load persisted swipes from the message that covers `idx`. */
+    private loadPersistedAtIndex(idx: number, messages: Message[]): boolean {
+        const si = this.findPersistedStartIndex(idx, messages)
+        if (si < 0) return false
+
+        const msg = messages[si]
+        if (!isValidSwipes(msg?.swipes) || msg.swipes.length === 0) return false
+
+        const swipeId = Math.min(Math.max(msg.swipeId ?? 0, 0), msg.swipes.length - 1)
+        const activeLen = msg.swipes[swipeId]?.length ?? 0
+        if (activeLen === 0) return false
+
+        this.startIndex = si
+        this.segments = cloneSwipeSegments(msg.swipes)
+        this.segmentIndex = swipeId
+        this.segments[this.segmentIndex] = cloneSwipeSegment(messages.slice(si, si + activeLen))
+        this.markGenIdImported(this.segments[this.segmentIndex])
+        return true
+    }
+
+    /** Find the message index that has swipes covering `idx`. */
+    private findPersistedStartIndex(idx: number, messages: Message[]): number {
+        for (let i = Math.min(idx, messages.length - 1); i >= 0; i--) {
+            const activeLen = getActiveSwipeLength(messages[i])
+            if (activeLen > 0 && i <= idx && idx < i + activeLen) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    private markGenIdImported(segment?: Message[]): void {
+        const genId = segment?.[0]?.generationInfo?.generationId
+        if (genId) this.importedGenIds.add(genId)
+    }
+
+    /**
+     * Apply the current segment to the message array (Review 2.6: use segment length, not stale swipe length).
+     */
+    private applySegment(messages: Message[], chat: Chat): void {
+        const segment = this.segments[this.segmentIndex]
+        if (!Array.isArray(segment) || segment.length === 0) return
+
+        const si = this.startIndex >= 0 ? this.startIndex : Math.max(0, messages.length - segment.length)
+        const cloned = cloneSwipeSegment(segment)
+
+        // Determine how many messages to replace: use the persisted swipe length at si,
+        // falling back to the new segment length. This prevents stale data issues.
+        const currentActiveLen = getActiveSwipeLength(messages[si])
+        const tailStart = currentActiveLen > 0 ? si + currentActiveLen : si + segment.length
+
+        const next = [...messages.slice(0, si), ...cloned, ...messages.slice(tailStart)]
+        chat.message = next
+        this.persistSwipesOnMessages(next, chat)
+    }
+
+    /** Import generated reroll alternatives from the prereroll cache (Review 2.4: clone once). */
+    private importGeneratedRerolls(messages: Message[], chat: Chat): void {
+        const currentSeg = this.segments[this.segmentIndex]
+        const activeMsg = Array.isArray(currentSeg) && currentSeg.length === 1 ? currentSeg[0] : messages.at(-1)
+        const genId = activeMsg?.generationInfo?.generationId
+        const cached = genId ? getRerolls(genId) : null
+
+        if (!activeMsg || !genId || !cached || cached.length <= 1 || this.importedGenIds.has(genId)) {
+            return
+        }
+
+        if (this.startIndex < 0) {
+            this.startIndex = Math.max(0, messages.length - 1)
+        }
+
+        // Clone baseMessage once, then spread for each variant (Review 2.4)
+        const baseMessage = cloneSwipeSegment([activeMsg])[0]
+        const generatedRerolls = [activeMsg.data, ...cached.slice(1)].map((data) => [
+            { ...safeStructuredClone(baseMessage), data },
+        ])
+
+        const replaceIdx = this.segmentIndex >= 0 ? this.segmentIndex : this.segments.length
+        if (this.segmentIndex < 0) {
+            this.segments.push(...generatedRerolls)
+            this.segmentIndex = 0
+        } else {
+            this.segments.splice(replaceIdx, 1, ...generatedRerolls)
+            this.segmentIndex = replaceIdx
+        }
+        this.importedGenIds.add(genId)
+        this.persistSwipesOnMessages(messages, chat)
+    }
+}

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1770,6 +1770,13 @@ export interface Chat{
     lastDate?:number
     bookmarks?: string[];
     bookmarkNames?: { [chatId: string]: string };
+    rerollState?: ChatRerollState
+}
+
+export interface ChatRerollState{
+    segments: Message[][]
+    index:number
+    startIndex:number
 }
 
 export interface ChatFolder{

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1791,6 +1791,8 @@ export interface Message{
     otherUser?:boolean
     disabled?:false|true|'allBefore'
     isComment?:boolean
+    swipes?:Message[][]
+    swipeId?:number
 }
 
 export interface MessageGenerationInfo{


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Reroll (swipe) variants were stored only in ephemeral UI-local state, causing them to be silently lost on component remounts, chat/character switches, and page reloads. This PR persists reroll variants directly on chat messages and adds the ability to delete individual variants.

## Related Issues

None

## Changes

### Core: Persistent reroll storage
- Added `swipes` (`Message[][]`) and `swipeId` (`number`) fields to the `Message` interface. Reroll variants are now written onto the first message of the active reroll segment and restored on load.
- Dual-persistence mechanism: `message.swipes`/`swipeId` (long-term) for 2+ variants, `chat.rerollState` (transient) for crash recovery during generation. On load, transient state is checked first, then `message.swipes`.

### Architecture: RerollManager class (`src/ts/process/rerollState.ts`)
- Extracted ~300 lines of reroll state management from `DefaultChatScreen.svelte` into a dedicated, testable `RerollManager` class.
- Clean public API: `navigateNext`, `navigatePrev`, `deleteVariant`, `registerSegment`, `saveBeforeGeneration`, `handleFailedGeneration`, `updateMessageData`, `handleMessageDeletion`, `canDeleteReroll`, `getSwipeInfo`, `loadPersisted`, `reset`, `resetIfSelectionChanged`.
- All internal state (segments, indices, imported generation IDs) is encapsulated.

### Bug fixes addressed in refactor
- **Race condition after `await`** — `reroll()` now guards rollback against character/chat switches during async generation.
- **Stale reroll state after message deletion** — Added `handleMessageDeletion` callback from `Chat.svelte` to `RerollManager`, resetting or adjusting indices when messages are removed.
- **O(n^2) `canDeleteReroll` scan** — Replaced full-message scan with targeted `findPersistedStartIndex` lookup.
- **Triple-cloning in `importGeneratedRerolls`** — `baseMessage` is cloned once and shallow-copied per variant.
- **Stale `activeSwipeLength` in `applySegment`** — Uses current persisted swipe length to determine replacement range.
- **Misleading parameter reassignment** — `loadTransientState` now mutates `chat.message` directly instead of reassigning a local parameter.
- **Malformed data validation** — `isValidSwipes()` validates `swipes` arrays before use, preventing crashes on corrupted save data.
- **$effect over-firing** — Reroll loading in the `$effect` is wrapped in `untrack()` to prevent re-execution on unrelated DB mutations.

### UI improvements
- **Swipe counter** — Reroll arrows now display a `current/total` counter (e.g. "2/5") when multiple variants exist.
- **Reroll arrow visibility** — Arrows are shown on non-last assistant messages only when they have persisted swipes for navigation (no silent no-ops).
- **Reroll deletion** — Users can delete the currently selected reroll variant via a [refresh-cw-off](https://lucide.dev/icons/refresh-cw-off) button in the popup menu.

### Cleanup
- **Removed dead exports** — `Prereroll` and `PreUnreroll` in `prereroll.ts` were unused after the refactor and have been removed.
- **Branch cleanup** — Branching a chat strips `swipes`/`swipeId`/`rerollState` from copied messages.
- **i18n** — Added `deleteRerollMessage` and `deleteRerollMessageConfirm` keys across all 7 supported languages.

## Impact

- Reroll variants now survive component remounts and chat reloads, fixing the core data-loss issue.
- The `Message` interface gains two new optional fields (`swipes`, `swipeId`); existing saved data without these fields is unaffected (they default to `undefined`).
- The reroll deletion button appears inside the popup menu on both large and small viewports.

## Additional Notes

This patch was inspired by [mrbart3885/Risuai-NodeOnly](https://github.com/mrbart3885/Risuai-NodeOnly)'s features.

## Question

Now exported json chat log also contains `swipes` and `swipeId` in it.
It is backwards-compatible with Version 2026.4.181 (tested with risuai.xyz) by ignoring swipes and using only the displayed chats, but the change is change.

Also, I'll let you know that the swipe information in exported risuChat are stored into the DB even in the old codebase, and it is not interactable unless that instance is updated to the one with this PR's code.

Should the risuChat version be raised from 2 to 3? Or should I let it be?

<details>
<summary>
json
</summary>

```json
{
  "type": "risuChat",
  "ver": 2,
  "data": {
    "message": [
      {
        "role": "user",
        "data": "Good, write that down again.",
        "time": 1777534661660,
        "name": null,
        "chatId": "e336d1de-bffd-472b-8bbe-c0fe776e0f0e"
      },
      {
        "role": "char",
        "data": "<Thoughts>\n*   The user says: \"Good, write that down again.\"\n    *   The previous turn was: User sent nothing (or the assistant replied \"a4\" based on previous context/hidden state, though the prompt history shows \"a4\" as the assistant's previous response).\n    *   *Wait*, looking at the context:\n        *   Assistant said: \"a4\"\n        *   User says: \"Good, write that down again.\"\n\n    *   The user is asking the assistant to repeat the previous output (\"a4\").\n\n    *   Repeat the text \"a4\".\n</Thoughts>\na4",
        "saying": "34e1b808-4020-49f0-9506-e082916afad2",
        "time": 1777565928757,
        "generationInfo": {
          "model": "custom-gemma-4-31b-it-ud",
          "generationId": "d2440f82-0516-4263-9e60-c3484227c9b6",
          "inputTokens": 33,
          "outputTokens": 5000,
          "maxContext": 80000,
          "stageTiming": {
            "stage1": 3,
            "stage2": 0,
            "stage3": 3869,
            "stage4": 0
          }
        },
        "promptInfo": {},
        "chatId": "d2440f82-0516-4263-9e60-c3484227c9b6",
        "swipeId": 3,
        "swipes": [
          [
            {
              "role": "char",
              "data": "<Thoughts>\n*   The user said: \"Good, write that down again.\"\n    *   The previous output was: \"a1\" (which was a response to a likely empty or systemic prompt, or just a starting token).\n    *   Context: The user is asking me to repeat the phrase \"a1\".\n\n    *   The user wants me to repeat the previous output.\n    *   Previous output: \"a1\".\n\n    *   Output: \"a1\"\n</Thoughts>\na1",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777564797973,
              "generationInfo": {
                "model": "custom-gemma-4-31b-it-ud",
                "generationId": "b0ed85f8-1e60-4b1e-a4bd-0bd2816f6531",
                "inputTokens": 33,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 4,
                  "stage2": 0,
                  "stage3": 3045,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "b0ed85f8-1e60-4b1e-a4bd-0bd2816f6531"
            }
          ],
          [
            {
              "role": "char",
              "data": "<Thoughts>\n*   User input: \"Good, write that down again.\"\n    *   Previous input: User sent \"a2\" (or I responded with \"a2\" - looking at the history, the user sent nothing, and I responded \"a2\", or the user sent something and I replied \"a2\". Wait, looking at the transcript:\n        *   User: (blank/start)\n        *   Assistant: \"a2\"\n        *   User: \"Good, write that down again.\"\n    *   Context: The previous output was \"a2\". The user is asking me to repeat it.\n\n    *   The user wants me to repeat the previous output.\n    *   Previous output: \"a2\".\n\n    *   Repeat \"a2\".\n</Thoughts>\na2",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777564805470,
              "generationInfo": {
                "model": "custom-gemma-4-31b-it-ud",
                "generationId": "43789f74-f01c-451d-815d-7dab0a6db06e",
                "inputTokens": 33,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 3,
                  "stage2": 0,
                  "stage3": 4764,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "43789f74-f01c-451d-815d-7dab0a6db06e"
            }
          ],
          [
            {
              "role": "char",
              "data": "<Thoughts>\nThe user said \"Good, write that down again.\"\nThe previous response was \"a3\".\nThe user wants me to repeat \"a3\".\n\nPlan:\n1.  Output \"a3\".\n</Thoughts>\na3",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777565921695,
              "generationInfo": {
                "model": "custom-gemma-4-31b-it-ud",
                "generationId": "0174f3bb-ecba-4026-9751-5d98d5ef0417",
                "inputTokens": 33,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 4,
                  "stage2": 0,
                  "stage3": 1539,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "0174f3bb-ecba-4026-9751-5d98d5ef0417"
            }
          ],
          [
            {
              "role": "char",
              "data": "<Thoughts>\n*   The user says: \"Good, write that down again.\"\n    *   The previous turn was: User sent nothing (or the assistant replied \"a4\" based on previous context/hidden state, though the prompt history shows \"a4\" as the assistant's previous response).\n    *   *Wait*, looking at the context:\n        *   Assistant said: \"a4\"\n        *   User says: \"Good, write that down again.\"\n\n    *   The user is asking the assistant to repeat the previous output (\"a4\").\n\n    *   Repeat the text \"a4\".\n</Thoughts>\na4",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777565928757,
              "generationInfo": {
                "model": "custom-gemma-4-31b-it-ud",
                "generationId": "d2440f82-0516-4263-9e60-c3484227c9b6",
                "inputTokens": 33,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 3,
                  "stage2": 0,
                  "stage3": 3869,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "d2440f82-0516-4263-9e60-c3484227c9b6"
            }
          ]
        ]
      },
      {
        "role": "user",
        "data": "No, again.",
        "time": 1777565938379,
        "name": null,
        "chatId": "6b14cb05-d4de-4b5d-b181-1967f7886cac"
      },
      {
        "role": "char",
        "data": "a5",
        "saying": "34e1b808-4020-49f0-9506-e082916afad2",
        "time": 1777609116173,
        "generationInfo": {
          "model": "deepseek-chat",
          "generationId": "21559aa2-4cb5-4fe4-ac3a-cf4ed1df3f7f",
          "inputTokens": 45,
          "outputTokens": 5000,
          "maxContext": 80000,
          "stageTiming": {
            "stage1": 4,
            "stage2": 0,
            "stage3": 617,
            "stage4": 0
          }
        },
        "promptInfo": {},
        "chatId": "21559aa2-4cb5-4fe4-ac3a-cf4ed1df3f7f",
        "swipeId": 5,
        "swipes": [
          [
            {
              "role": "char",
              "data": "<Thoughts>\nThe user is asking me to \"write that down again\" and then says \"No, again\" after my previous response.\n\nThe conversation history is:\n1. User: (Implied start - maybe a prompt I don't see, or just a test) -> Assistant: \"a1\"\n2. User: \"Good, write that down again.\" -> Assistant: \"a4\"\n3. User: \"No, again.\"\n\nLooking at the sequence:\n\"a1\" -> \"a4\" -> ?\n\nWait, \"a1\" and \"a4\" aren't standard English responses. They look like identifiers or perhaps a pattern.\nMaybe it's a game or a specific test of repetition/sequence?\nOr maybe the user is trying to get me to repeat a specific string?\n\nLet's look at the inputs:\nUser: \"Good, write that down again.\" (Assistant responded \"a4\"). \nThe user says \"No, again.\"\n\nThe user likely wanted me to repeat exactly what I wrote first (\"a1\"), or they are looking for a specific sequence.\nIf \"a1\" was the first response, and the user said \"write that down again\", the expected response would be \"a1\". Instead, I wrote \"a4\".\nNow the user is correcting me: \"No, again.\"\n\nGoal: Repeat the very first thing I wrote in this conversation.\n\nFirst response: \"a1\".\n\nWait, why did I write \"a4\" last time? It seems the previous turn was an error or a random generation.\n\nIf the user says \"write that down again\" referring to the first prompt, they want \"a1\".\n\nLet's check if there's a pattern. \na1 ... a4 ...\nMaybe it's a sequence? 1, 4... 7? \nBut \"write that down again\" usually implies literal repetition.\n\nThe user is rejecting \"a4\" and asking me to do it \"again\" (meaning correctly this time).\n\nTherefore, I should write \"a1\".\n</Thoughts>\na1",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777565950895,
              "generationInfo": {
                "model": "custom-gemma-4-31b-it-ud",
                "generationId": "068e546b-197a-4175-9cde-e662a2cc042d",
                "inputTokens": 45,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 7,
                  "stage2": 0,
                  "stage3": 12504,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "068e546b-197a-4175-9cde-e662a2cc042d"
            }
          ],
          [
            {
              "role": "char",
              "data": "<Thoughts>\n*   User's first prompt: (Implicitly something that led to \"a2\")\n    *   Assistant's first response: \"a2\"\n    *   User's second prompt: \"Good, write that down again.\"\n    *   Assistant's second response: \"a4\"\n    *   User's third prompt: \"No, again.\"\n\n    *   The user said \"write that down again\" after \"a2\", but the assistant wrote \"a4\".\n    *   \"Write that down again\" usually means \"repeat exactly what you just wrote.\"\n    *   The assistant failed by changing \"a2\" to \"a4\".\n    *   The user is now saying \"No, again,\" implying \"Do it correctly this time\" (i.e., repeat \"a2\").\n\n    *   The goal is to repeat the first successful output (\"a2\").\n</Thoughts>\na2",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777565960033,
              "generationInfo": {
                "model": "custom-gemma-4-31b-it-ud",
                "generationId": "a9c49de6-f6ad-4e9c-b14f-957a27411c94",
                "inputTokens": 45,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 6,
                  "stage2": 0,
                  "stage3": 5575,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "a9c49de6-f6ad-4e9c-b14f-957a27411c94"
            }
          ],
          [
            {
              "role": "char",
              "data": "a2",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777608948156,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "19f881dd-0c97-4053-aec7-ef1ad1741b7b",
                "inputTokens": 45,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 986,
                  "stage2": 0,
                  "stage3": 659,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "19f881dd-0c97-4053-aec7-ef1ad1741b7b"
            }
          ],
          [
            {
              "role": "char",
              "data": "a8",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777609111878,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "3f574dba-5e9a-48fd-b49f-2c066bf2b872",
                "inputTokens": 45,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 4,
                  "stage2": 0,
                  "stage3": 764,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "3f574dba-5e9a-48fd-b49f-2c066bf2b872"
            }
          ],
          [
            {
              "role": "char",
              "data": "a7",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777609114868,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "ac6db9da-2f6b-458c-b964-659f8c2956e6",
                "inputTokens": 45,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 4,
                  "stage2": 0,
                  "stage3": 626,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "ac6db9da-2f6b-458c-b964-659f8c2956e6"
            }
          ],
          [
            {
              "role": "char",
              "data": "a5",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777609116173,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "21559aa2-4cb5-4fe4-ac3a-cf4ed1df3f7f",
                "inputTokens": 45,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 4,
                  "stage2": 0,
                  "stage3": 617,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "21559aa2-4cb5-4fe4-ac3a-cf4ed1df3f7f"
            }
          ]
        ]
      },
      {
        "role": "user",
        "data": "Really? Do it again.",
        "time": 1777609126986,
        "name": null,
        "chatId": "e6184405-3f8f-42b3-88a8-eb314bb19b8f"
      },
      {
        "role": "char",
        "data": "a2",
        "saying": "34e1b808-4020-49f0-9506-e082916afad2",
        "time": 1777609151639,
        "generationInfo": {
          "model": "deepseek-chat",
          "generationId": "eaf4b2d8-d064-4e2b-8f8c-e467825527ff",
          "inputTokens": 59,
          "outputTokens": 5000,
          "maxContext": 80000,
          "stageTiming": {
            "stage1": 3,
            "stage2": 0,
            "stage3": 844,
            "stage4": 0
          }
        },
        "promptInfo": {},
        "chatId": "eaf4b2d8-d064-4e2b-8f8c-e467825527ff",
        "swipeId": 3,
        "swipes": [
          [
            {
              "role": "char",
              "data": "a2",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777609127605,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "ee2db2f4-c3b8-4ffd-9214-78c4f687d9e6",
                "inputTokens": 59,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 5,
                  "stage2": 0,
                  "stage3": 606,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "ee2db2f4-c3b8-4ffd-9214-78c4f687d9e6"
            }
          ],
          [
            {
              "role": "char",
              "data": "a6",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777609135912,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "7e7afb91-8fb8-46ae-a7ae-027c20981a5e",
                "inputTokens": 59,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 4,
                  "stage2": 0,
                  "stage3": 720,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "7e7afb91-8fb8-46ae-a7ae-027c20981a5e"
            }
          ],
          [
            {
              "role": "char",
              "data": "a7",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777609141775,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "5da58786-ce6f-4222-8993-dc03f4b4818d",
                "inputTokens": 59,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 4,
                  "stage2": 0,
                  "stage3": 539,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "5da58786-ce6f-4222-8993-dc03f4b4818d"
            }
          ],
          [
            {
              "role": "char",
              "data": "a2",
              "saying": "34e1b808-4020-49f0-9506-e082916afad2",
              "time": 1777609151639,
              "generationInfo": {
                "model": "deepseek-chat",
                "generationId": "eaf4b2d8-d064-4e2b-8f8c-e467825527ff",
                "inputTokens": 59,
                "outputTokens": 5000,
                "maxContext": 80000,
                "stageTiming": {
                  "stage1": 3,
                  "stage2": 0,
                  "stage3": 844,
                  "stage4": 0
                }
              },
              "promptInfo": {},
              "chatId": "eaf4b2d8-d064-4e2b-8f8c-e467825527ff"
            }
          ]
        ]
      }
    ],
    "note": "",
    "name": "Chat 1",
    "localLore": [],
    "fmIndex": 5,
    "id": "a295fff9-c438-4345-bc32-16c2035ceae4",
    "lastMemory": "NewChat",
    "isStreaming": false
  },
  "folders": []
}
```

</details>