### PR TITLE
fix: improve slider input accessibility

### DIFF
--- a/src/lib/UI/GUI/SliderInput.svelte
+++ b/src/lib/UI/GUI/SliderInput.svelte
@@ -24,10 +24,16 @@
     </div>
   {/if}
   <div 
+    role="slider"
+    tabindex="0"
+    aria-valuemin={min}
+    aria-valuemax={max}
+    aria-valuenow={sliderValue}
+    aria-valuetext={displayText}
     class="relative w-full h-8 border-darkborderc border rounded-full cursor-pointer"
     class:rounded-l-none={disableable}
     style:background={
-      `linear-gradient(to right, var(--risu-theme-darkbutton) 0%, var(--risu-theme-darkbutton) ${(value - min) / (max - min) * 100}%, var(--risu-theme-darkbg) ${(value - min) / (max - min) * 100}%, var(--risu-theme-darkbg) 100%)`
+      `linear-gradient(to right, var(--risu-theme-darkbutton) 0%, var(--risu-theme-darkbutton) ${sliderPercent}%, var(--risu-theme-darkbg) ${sliderPercent}%, var(--risu-theme-darkbg) 100%)`
     }
     onpointerdown={(event) => {
       mouseDown = true;
@@ -48,6 +54,7 @@
     onpointerleave={() => {
       mouseDown = false;
     }}
+    onkeydown={handleKeydown}
     bind:this={slider}
   >
     <!-- <div 
@@ -58,7 +65,7 @@
     <span 
       class="absolute top-0 left-4 h-8 rounded-full items-center justify-center flex text-textcolor text-sm"
     >
-      {customText === undefined ? ((value === -1000 || value === undefined) ? language.disabled : (value * multiple).toFixed(fixed)) : customText}
+      {displayText}
     </span>
   </div>
 </div>
@@ -96,12 +103,43 @@
     onchange
   }: Props = $props();
 
-    function changeValue(event) {
+  let isDisabledValue = $derived(value === -1000 || value === undefined);
+  let sliderValue = $derived(isDisabledValue ? min : value);
+  let sliderPercent = $derived((sliderValue - min) / (max - min) * 100);
+  let displayText = $derived(customText === undefined ? (isDisabledValue ? language.disabled : (value * multiple).toFixed(fixed)) : customText);
+
+    function changeValue(event: PointerEvent) {
         const rect = slider.getBoundingClientRect();
         const x = event.clientX - rect.left;
         console.log(x, rect.width);
         let newValue = ((x / rect.width) * (max - min)) + min;
         newValue = Math.round(newValue / step) * step;
+        value = Math.min(Math.max(newValue, min), max);
+    }
+
+    function handleKeydown(event: KeyboardEvent) {
+        let newValue = isDisabledValue ? min : value;
+
+        switch (event.key) {
+            case 'ArrowLeft':
+            case 'ArrowDown':
+                newValue -= step;
+                break;
+            case 'ArrowRight':
+            case 'ArrowUp':
+                newValue += step;
+                break;
+            case 'Home':
+                newValue = min;
+                break;
+            case 'End':
+                newValue = max;
+                break;
+            default:
+                return;
+        }
+
+        event.preventDefault();
         value = Math.min(Math.max(newValue, min), max);
     }
 </script>

--- a/src/ts/setting/types.ts
+++ b/src/ts/setting/types.ts
@@ -68,7 +68,7 @@ export interface SettingOptions {
     max?: number;
     step?: number;
     fixed?: number;         // Decimal places for slider
-    disableable?: boolean;  // Allow -1 to disable
+    disableable?: boolean;  // Allow -1000 to disable
     customText?: string | ((value: number) => string); // Custom display text for slider
     multiple?: number;      // Multiplier for display value
     nullable?: boolean;     // Allow null for color inputs


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? (N/A: no new public types)
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes the `svelte-check` accessibility warning for `SliderInput` by giving the custom slider proper slider semantics and keyboard support.

## Related Issues

None.

## Changes

- Adds `role="slider"`, value ARIA attributes, and accessible value text to `SliderInput`.
- Adds keyboard support for arrow keys, Home, and End while preserving the existing pointer-based behavior.
- Keeps the current `-1000` disabled sentinel behavior and custom display text handling.
- Updates the stale `disableable` comment to document the actual `-1000` sentinel.

## Impact

Existing slider call sites continue using the same props and bound values.
The change does not cause changing the stored setting values or visual layout.
Now user can use arrow keys to control selected slider's values.