### PR TITLE
build: enable sourcemaps for Tauri frontend build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build --sourcemap",
-    "tauribuild": "vite build",
+    "tauribuild": "vite build --sourcemap",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "test": "vitest run",


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Enable sourcemap generation for the Tauri frontend build by adding `--sourcemap` to the `tauribuild` script.

## Related Issues

None

## Changes

- Updated `pnpm tauribuild` to run `vite build --sourcemap`.
- Kept the existing release minification behavior unchanged, so sourcemaps are generated without relying on `TAURI_ENV_DEBUG` or disabling minification.

## Impact

Tauri release builds will now include frontend sourcemap files in the generated `dist` output. This supports runtime stack trace translation that relies on sourcemaps while preserving the existing optimized production JavaScript output.

## Additional Notes

Validation:

- `pnpm check` was run and failed due to pre-existing diagnostics unrelated to this change: `src/lang/zh-Hant.ts` translation type mismatches and a duplicate `betas` declaration in `src/ts/process/request/anthropic.ts`.
