### PR TITLE
ci: Add rust build cache and update actions in Tauri release workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,10 +59,10 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,13 +21,13 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/github-actions-builder.yml
+++ b/.github/workflows/github-actions-builder.yml
@@ -29,13 +29,13 @@ jobs:
           
     runs-on: ${{ matrix.settings.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.34.1
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/github-actions-builder.yml
+++ b/.github/workflows/github-actions-builder.yml
@@ -15,21 +15,31 @@ jobs:
         # platform: [ubuntu-latest,macos-latest,windows-latest]
         settings:
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            target: 'aarch64-apple-darwin'
             args: '--target aarch64-apple-darwin'
           - platform: 'macos-latest' # for Intel based macs.
+            target: 'x86_64-apple-darwin'
             args: '--target x86_64-apple-darwin'
           - platform: 'ubuntu-latest' # for Tauri v1 you could replace this with ubuntu-20.04.
+            target: 'x86_64-unknown-linux-gnu'
             args: '--target x86_64-unknown-linux-gnu'
           - platform: 'windows-latest'
+            target: 'x86_64-pc-windows-msvc'
             args: '--target x86_64-pc-windows-msvc'
           
     runs-on: ${{ matrix.settings.platform }}
     steps:
       - uses: actions/checkout@v4
+      - name: install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.1
       - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
       - id: set_var_win
         if: matrix.settings.platform == 'windows-latest'
         run: |
@@ -38,10 +48,6 @@ jobs:
         shell: bash
         run: |
           echo "VERSION_JSON=$(jq -c . < version.json)" >> $GITHUB_ENV
-      - name: install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.34.1
       - name: install dependencies (ubuntu only)
         if: matrix.settings.platform == 'ubuntu-latest'
         run: |
@@ -50,26 +56,14 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable # Set this to dtolnay/rust-toolchain@nightly
         with:
-          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ matrix.settings.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
+          targets: ${{ matrix.settings.target }}
+      - uses: Swatinem/rust-cache@v2
+        name: Setup Rust cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          workspaces: src-tauri -> target
+          key: ${{ matrix.settings.platform }}-${{ matrix.settings.target }}
       - name: install frontend dependencies
-        run: pnpm install --no-frozen-lockfile # change this to npm or pnpm depending on which one you use
-      - if: matrix.settings.platform == 'macos-latest'
-        run: rustup target add x86_64-apple-darwin
-      - if: matrix.settings.platform == 'macos-latest'
-        run: rustup target add aarch64-apple-darwin
+        run: pnpm install --frozen-lockfile
       - uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mod.yml
+++ b/.github/workflows/mod.yml
@@ -16,7 +16,7 @@ jobs:
       models: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: github/ai-moderator@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Optimizes the Tauri release workflow by adding Rust build caching, simplifying pnpm caching, removing redundant macOS target installation, updating GitHub Action versions.

## Related Issues

None.

## Changes

- Adds matrix `target` values and installs only the required Rust target for each Tauri job.
- Replaces the manual pnpm store cache step with the built-in `actions/setup-node` pnpm cache.
- Adds `Swatinem/rust-cache@v2` for `src-tauri` Cargo artifacts.
- Removes duplicate macOS `rustup target add` steps.
- Switches CI dependency installation to `pnpm install --frozen-lockfile`.
- Updates workflow actions where newer major versions are available.

## Impact

This should reduce repeated Tauri release build work in GitHub Actions while keeping release artifact generation unchanged, including updater artifacts. The committed Cargo lockfile also prevents CI from resolving different Rust dependency versions on each run.

For context, I compared the existing upstream workflow usage run:
https://github.com/kwaroran/Risuai/actions/runs/24605548471/usage
| Job | Run time |
| :--- | :--- |
| publish-tauri (macos-latest, --target x86_64-apple-darwin) | 8m 24s |
| publish-tauri (macos-latest, --target aarch64-apple-darwin) | 6m 28s |
| publish-tauri (ubuntu-latest, --target x86_64-unknown-linux-gnu) | 13m 0s |
| publish-tauri (windows-latest, --target x86_64-pc-windows-msvc) | 13m 37s |
| **Total** | **41m 29s** |
---
with the fork test run using the optimized workflow:
https://github.com/SameDesu123/Risuai/actions/runs/25267682504/usage
| Job | Run time |
| :--- | :--- |
| publish-tauri (macos-latest, aarch64-apple-darwin, --target aarch64-apple-darwin --config src-tau... | 4m 51s |
| publish-tauri (macos-latest, x86_64-apple-darwin, --target x86_64-apple-darwin --config src-tauri... | 3m 25s |
| publish-tauri (ubuntu-latest, x86_64-unknown-linux-gnu, --target x86_64-unknown-linux-gnu --confi... | 8m 36s |
| publish-tauri (windows-latest, x86_64-pc-windows-msvc, --target x86_64-pc-windows-msvc --config s... | 6m 37s |
| **Total** | **23m 29s** |


The fork test run showed the streamlined step layout with Rust cache and without the old manual pnpm cache / duplicate macOS target installation steps.

## Additional Notes

Validated locally with:

- `ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].each { |f| YAML.load_file(f) }"`
- `git diff --check`
