### PR TITLE
feat: add DeepSeek V4 tokenizer

### DIFF
--- a/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
+++ b/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
@@ -107,6 +107,7 @@
                 <OptionInput value="10">GoogleCloud</OptionInput>
                 <OptionInput value="11">Cohere</OptionInput>
                 <OptionInput value="13">DeepSeek</OptionInput>
+                <OptionInput value="14">DeepSeek V4</OptionInput>
             </SelectInput>
             <span class="text-textcolor">{language.format}</span>
             <SelectInput size={"sm"} value={DBState.db.customModels[index].format.toString()} onchange={(e) => {

--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -463,7 +463,7 @@ export const LLMModels: LLMModel[] = [
         format: LLMFormat.OpenAICompatible,
         flags: [LLMFlags.hasFirstSystemPrompt, LLMFlags.requiresAlternateRole, LLMFlags.mustStartWithUserInput, LLMFlags.hasPrefill, LLMFlags.deepSeekPrefix, LLMFlags.deepSeekThinkingInput, LLMFlags.deepSeekThinkingOutput, LLMFlags.deepSeekThinkingToggle, LLMFlags.hasStreaming],
         parameters: ['frequency_penalty', 'presence_penalty', 'temperature', 'top_p'],
-        tokenizer: LLMTokenizer.DeepSeek,
+        tokenizer: LLMTokenizer.DeepSeekV4,
         endpoint: 'https://api.deepseek.com/beta/chat/completions',
         keyIdentifier: 'deepseek',
         recommended: true
@@ -475,7 +475,7 @@ export const LLMModels: LLMModel[] = [
         format: LLMFormat.OpenAICompatible,
         flags: [LLMFlags.hasFirstSystemPrompt, LLMFlags.requiresAlternateRole, LLMFlags.mustStartWithUserInput, LLMFlags.hasPrefill, LLMFlags.deepSeekPrefix, LLMFlags.deepSeekThinkingInput, LLMFlags.deepSeekThinkingOutput, LLMFlags.deepSeekThinkingToggle, LLMFlags.hasStreaming],
         parameters: ['frequency_penalty', 'presence_penalty', 'temperature', 'top_p'],
-        tokenizer: LLMTokenizer.DeepSeek,
+        tokenizer: LLMTokenizer.DeepSeekV4,
         endpoint: 'https://api.deepseek.com/beta/chat/completions',
         keyIdentifier: 'deepseek',
         recommended: true

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -92,7 +92,8 @@ export const LLMTokenizer = {
     GoogleCloud: 10,
     Cohere: 11,
     Local: 12,
-    DeepSeek: 13
+    DeepSeek: 13,
+    DeepSeekV4: 14
 } as const;
 export type LLMTokenizer = (typeof LLMTokenizer)[keyof typeof LLMTokenizer];
 

--- a/src/ts/tokenizer.ts
+++ b/src/ts/tokenizer.ts
@@ -40,6 +40,7 @@ export const tokenizerList = [
     ['gemma', 'Gemma'],
     ['cohere', 'Cohere'],
     ['deepseek', 'DeepSeek'],
+    ['deepseek-v4', 'DeepSeek V4'],
 ] as const
 
 export async function encodeWithTokenizer(data: string, tokenizerType: string): Promise<(number[] | Uint32Array | Int32Array)> {
@@ -64,6 +65,8 @@ export async function encodeWithTokenizer(data: string, tokenizerType: string): 
             return await tokenizeWebTokenizers(data, 'cohere');
         case 'deepseek':
             return await tokenizeWebTokenizers(data, 'DeepSeek');
+        case 'deepseek-v4':
+            return await tokenizeWebTokenizers(data, 'DeepSeekV4');
         default:
             return await tikJS(data, 'cl100k_base');
     }
@@ -113,6 +116,8 @@ export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Arr
                 result = await tokenizeWebTokenizers(data, 'cohere'); break;
             case 'deepseek':
                 result = await tokenizeWebTokenizers(data, 'DeepSeek'); break;
+            case 'deepseek-v4':
+                result = await tokenizeWebTokenizers(data, 'DeepSeekV4'); break;
             default:
                 result = await tikJS(data, 'o200k_base'); break;
         }
@@ -167,6 +172,8 @@ export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Arr
             result = await gemmaTokenize(data);
         } else if(modelInfo.tokenizer === LLMTokenizer.DeepSeek){
             result = await tokenizeWebTokenizers(data, 'DeepSeek');
+        } else if(modelInfo.tokenizer === LLMTokenizer.DeepSeekV4){
+            result = await tokenizeWebTokenizers(data, 'DeepSeekV4');
         } else if(modelInfo.tokenizer === LLMTokenizer.Cohere){
             result = await tokenizeWebTokenizers(data, 'cohere');
         } else {
@@ -180,7 +187,7 @@ export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Arr
     return result;
 }
 
-type tokenizerType = 'novellist'|'claude'|'novelai'|'llama'|'mistral'|'llama3'|'gemma'|'cohere'|'googleCloud'|'DeepSeek'
+type tokenizerType = 'novellist'|'claude'|'novelai'|'llama'|'mistral'|'llama3'|'gemma'|'cohere'|'googleCloud'|'DeepSeek'|'DeepSeekV4'
 
 let tikParser:Tiktoken = null
 let tokenizersTokenizer:Tokenizer = null
@@ -336,6 +343,11 @@ async function tokenizeWebTokenizers(text:string, type:tokenizerType) {
             case 'DeepSeek':
                 tokenizersTokenizer = await webTokenizer.Tokenizer.fromJSON(
                     await (await fetch("/token/deepseek/tokenizer.json")
+                ).arrayBuffer())
+                break
+            case 'DeepSeekV4':
+                tokenizersTokenizer = await webTokenizer.Tokenizer.fromJSON(
+                    await (await fetch("/token/deepseek/v4/tokenizer.json")
                 ).arrayBuffer())
                 break
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add a dedicated DeepSeek V4 tokenizer path so DeepSeek V4 Pro and DeepSeek V4 Flash no longer share the older DeepSeek tokenizer asset used by V3/R1-style models.

## Related Issues

Related to #1416.

## Changes

- Added `LLMTokenizer.DeepSeekV4` and wired it through the tokenizer selector and browser tokenizer loader.
- Updated `deepseek-v4-pro` and `deepseek-v4-flash` to use `DeepSeekV4` while keeping existing DeepSeek models on the existing tokenizer.
- Added DeepSeek V4 to the custom model tokenizer selector.
- Vendored the shared DeepSeek V4 Pro/Flash `tokenizer.json` under `public/token/deepseek/v4/tokenizer.json`, minified to avoid a large line-based GitHub diff while keeping the tokenizer local.

## Impact

DeepSeek V4 token counting should better match the V4 tokenizer asset. Existing DeepSeek Chat, Reasoner, DeepInfra R1/V3, and older DeepSeek tokenizer behavior are preserved. This does not implement DeepSeek V4's full `encoding_dsv4` message-format logic.

## Additional Notes

- DeepSeek V4 Pro and Flash tokenizer files were downloaded from Hugging Face and compared before vendoring; both had the same SHA-256: `8f9f37ca37fdc4f5fd36d5cf4d3b0e8392edb4e894fd10cc0d70b4957c8633cf`.
- The vendored tokenizer remains local and is not loaded from an external runtime URL.
- Validation: confirmed the minified tokenizer loads through Vite/browser `fetch('/token/deepseek/v4/tokenizer.json')`, `Tokenizer.fromJSON(...)`, and `encode(...)` successfully (`tokenCount: 16` for a mixed English/Korean sample).
- Earlier validation: `pnpm check` completed with 0 errors and 1 existing Svelte accessibility warning in `src/lib/UI/GUI/SliderInput.svelte`.
