### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/.github/workflows/github-actions-builder.yml
+++ b/.github/workflows/github-actions-builder.yml
@@ -41,7 +41,7 @@ jobs:
       - name: install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 11.0.9
       - name: install dependencies (ubuntu only)
         if: matrix.settings.platform == 'ubuntu-latest'
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-side-effects-cache=false
-ignore-scripts=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ ENV PATH="$PNPM_HOME:$PATH"
 # Copy dependency-related file
 COPY package.json .
 COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
 
 RUN corepack enable
-RUN corepack install --global pnpm@latest
+RUN corepack install --global pnpm@11.0.9
 
 # ------------------------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "packageManager": "pnpm@11.0.9",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
@@ -124,10 +125,5 @@
     "vite": "^8.0.3",
     "vite-plugin-wasm": "3.6.0",
     "vitest": "^4.1.0"
-  },
-  "pnpm": {
-    "neverBuiltDependencies": [
-      "sharp"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+sideEffectsCache: false
+ignoreScripts: false
+
+allowBuilds:
+  '@swc/core': true
+  core-js: false
+  esbuild: true
+  msgpackr-extract: true
+  onnxruntime-node: true
+  protobufjs: true
+  sharp: false

--- a/server.bat
+++ b/server.bat
@@ -1,4 +1,5 @@
-call npm -g install pnpm
+call corepack enable
+call corepack prepare pnpm@11.0.9 --activate
 call pnpm install
 call pnpm run build
 call pnpm run runserver

--- a/server.sh
+++ b/server.sh
@@ -1,4 +1,5 @@
-npm install -g pnpm
+corepack enable
+corepack prepare pnpm@11.0.9 --activate
 pnpm install
 pnpm run build
 pnpm run runserver


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Migrates the repository package manager configuration to pnpm v11.

## Related Issues

None

## Changes

- Adds `packageManager: pnpm@11.0.9`.
- Moves pnpm configuration from `.npmrc` and `package.json#pnpm` into `pnpm-workspace.yaml`.
- Defines pnpm v11 `allowBuilds` entries for install-time build scripts.
- Pins pnpm v11.0.9 in Docker, GitHub Actions, and local server scripts.

## Impact

This should make installs more consistent under pnpm v11 without changing app runtime behavior.

## Additional Notes

Tested with:

- `CI=true pnpm install --frozen-lockfile`
- `pnpm check`
