### PR TITLE
fix: sync character grid search with simple list

### DIFF
--- a/src/lib/Mobile/MobileCharacters.svelte
+++ b/src/lib/Mobile/MobileCharacters.svelte
@@ -8,11 +8,18 @@
 
     interface Props {
         endGrid?: () => void;
+        search?: string;
+        hideTrash?: boolean;
     }
 
     const agoFormatter = new Intl.RelativeTimeFormat(navigator.languages, { style: 'short' });
 
-    let {endGrid = () => {}}: Props = $props();
+    let {endGrid = () => {}, search, hideTrash = false}: Props = $props();
+    let normalizedSearch = $derived(normalizeSearch(search ?? $MobileSearch));
+
+    function normalizeSearch(value:string){
+        return value.replace(/ /g,"").toLocaleLowerCase();
+    }
 
     function makeAgoText(time:number){
         if(time === 0){
@@ -44,7 +51,9 @@
     }
 
     function sortChar(char: (character|groupChat)[]) {
-        return char.map((c, i) => {
+        return char.map((c, i) => ({ c, i })).filter(({ c }) => {
+            return !hideTrash || !c.trashTime;
+        }).map(({ c, i }) => {
             return {
                 name: c.name || "Unnamed",
                 image: c.image,
@@ -63,7 +72,7 @@
 </script>
 <div class="flex flex-col items-center w-full overflow-y-auto h-full">
     {#each sortChar(DBState.db.characters) as char, i}
-        {#if char.name.toLocaleLowerCase().includes($MobileSearch.toLocaleLowerCase())}
+        {#if normalizeSearch(char.name).includes(normalizedSearch)}
             <button class="flex p-2 border-t-darkborderc gap-2 w-full" class:border-t={i !== 0} onclick={() => {
                 changeChar(char.i)
                 endGrid()

--- a/src/lib/Others/GridCatalog.svelte
+++ b/src/lib/Others/GridCatalog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { changeChar, characterFormatUpdate, getCharImage, removeChar } from "../../ts/characters";
+    import { changeChar, getCharImage, removeChar } from "../../ts/characters";
     import { type Database } from "../../ts/storage/database.svelte";
     import { DBState } from 'src/ts/stores.svelte';
     import BarIcon from "../SideBars/BarIcon.svelte";
@@ -10,7 +10,7 @@
     import { language } from "src/lang";
     import { parseMultilangString } from "src/ts/util";
     import { checkCharOrder } from "src/ts/globalApi.svelte";
-  import MobileCharacters from "../Mobile/MobileCharacters.svelte";
+    import MobileCharacters from "../Mobile/MobileCharacters.svelte";
     interface Props {
         endGrid?: any;
     }
@@ -151,7 +151,7 @@
                 </div>
             {/each}
         {:else if selected === 3}
-            <MobileCharacters endGrid={endGrid} />
+            <MobileCharacters endGrid={endGrid} search={search} hideTrash={true} />
         {/if}
     </div>
 </div>


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes the character grid catalog's simple list search so it updates with the catalog search input instead of using the mobile-only search store.

## Related Issues

None

## Changes

- Added optional `search` and `hideTrash` props to `MobileCharacters`.
- Kept the existing mobile character screen behavior by falling back to `MobileSearch` when no explicit search prop is provided.
- Passed the grid catalog's local search value into the simple character list view.
- Matched simple list filtering with the catalog count by ignoring spaces, using case-insensitive matching, and hiding trashed characters.

## Impact

Users can now search from the sidebar hamburger character catalog and see the simple list update consistently with the displayed character count and the other catalog views.

Existing mobile character search behavior is preserved.

## Additional Notes

Validation:
- `svelte-check --tsconfig ./tsconfig.json` passed with 0 errors(in this changes).
- Check it manually in dev server.
