### PR TITLE
chore: pin pnpm to latest v10

### DIFF
--- a/.github/workflows/github-actions-builder.yml
+++ b/.github/workflows/github-actions-builder.yml
@@ -41,7 +41,7 @@ jobs:
       - name: install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: latest-10
       - name: install dependencies (ubuntu only)
         if: matrix.settings.platform == 'ubuntu-latest'
         run: |

--- a/.github/workflows/github-actions-builder.yml
+++ b/.github/workflows/github-actions-builder.yml
@@ -41,7 +41,7 @@ jobs:
       - name: install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest-10
+          version: 10.34.1
       - name: install dependencies (ubuntu only)
         if: matrix.settings.platform == 'ubuntu-latest'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json .
 COPY pnpm-lock.yaml .
 
 RUN corepack enable
-RUN corepack install --global pnpm@latest-10
+RUN corepack install --global pnpm@10.34.1
 
 # ------------------------------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json .
 COPY pnpm-lock.yaml .
 
 RUN corepack enable
-RUN corepack install --global pnpm@latest
+RUN corepack install --global pnpm@latest-10
 
 # ------------------------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "risuai",
   "private": true,
   "version": "1.0.0",
-  "packageManager": "pnpm@latest-10",
+  "packageManager": "pnpm@10.34.1",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "risuai",
   "private": true,
   "version": "1.0.0",
+  "packageManager": "pnpm@latest-10",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/server.bat
+++ b/server.bat
@@ -23,7 +23,7 @@ REM if not defined VITE_AD_CLIENT_MOBILE set "VITE_AD_CLIENT_MOBILE="
 REM if not defined VITE_AD_SLOT set "VITE_AD_SLOT="
 REM if not defined VITE_AD_SLOT_MOBILE set "VITE_AD_SLOT_MOBILE="
 
-call npm install -g pnpm@latest-10
+call npm install -g pnpm@10.34.1
 call pnpm install
 call pnpm run build
 

--- a/server.sh
+++ b/server.sh
@@ -23,7 +23,7 @@ set -eu
 # export VITE_AD_SLOT="${VITE_AD_SLOT:-}"
 # export VITE_AD_SLOT_MOBILE="${VITE_AD_SLOT_MOBILE:-}"
 
-npm install -g pnpm@latest-10
+npm install -g pnpm@10.34.1
 pnpm install
 pnpm run build
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Pins package-manager resolution to pnpm 10.34.1 so CI, Docker, and server bootstrap scripts do not unintentionally move to pnpm v11.

## Related Issues

Fixes #1439

## Changes

- Added `packageManager: "pnpm@10.34.1"` to `package.json`.
- Changed GitHub Actions pnpm setup from `latest` to `10.34.1`.
- Changed Docker Corepack installation from `pnpm@latest` to `pnpm@10.34.1`.
- Changed Unix and Windows server bootstrap scripts to install `pnpm@10.34.1`.

## Impact

This keeps installs on pnpm 10.34.1 while avoiding an accidental pnpm v11 upgrade. That preserves compatibility with the project's current Node.js 20 support until a dedicated pnpm v11 migration is ready.

## Additional Notes

Validation performed:

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `git diff --check upstream/main..HEAD`
- `rg -n "pnpm@latest-10|latest-10" .github Dockerfile server.sh server.bat package.json`
