### PR TITLE
fix: fallback missing realm card image

### DIFF
--- a/src/ts/characterCards.ts
+++ b/src/ts/characterCards.ts
@@ -712,6 +712,28 @@ export async function exportChar(charaID:number):Promise<string> {
     return ''
 }
 
+async function readCardExportImage(image?: string) {
+    if(image){
+        try{
+            const img = await readImage(image)
+            if(img?.length){
+                return img
+            }
+        } catch {
+        }
+    }
+
+    const res = await fetch('/none.webp')
+    if(!res.ok){
+        throw new Error(`Failed to load fallback character image: ${res.status} ${res.statusText}`)
+    }
+    const fallbackImage = new Uint8Array(await res.arrayBuffer())
+    if(!fallbackImage.length){
+        throw new Error('Failed to load fallback character image: empty response')
+    }
+    return fallbackImage
+}
+
 
 async function importCharacterCardSpec(card:CharacterCardV2Risu|CharacterCardV3, img?:Uint8Array, mode:'hub'|'normal' = 'normal', assetDict:{[key:string]:string} = {}, overrideLorebook: loreBook[] = null):Promise<boolean>{
     if(!card ||(card.spec !== 'chara_card_v2' && card.spec !== 'chara_card_v3' )){
@@ -1236,7 +1258,7 @@ export async function exportCharacterCard(char:character, type:'png'|'json'|'cha
     writer?:LocalWriter|VirtualWriter,
     spec?:'v2'|'v3'
 } = {}) {
-    let img = await readImage(char.image)
+    let img = await readCardExportImage(char.image)
     const spec:'v2'|'v3' = arg.spec ?? 'v2' //backward compatibility
     try{
         char.image = ''

--- a/src/ts/characterCards.ts
+++ b/src/ts/characterCards.ts
@@ -719,7 +719,8 @@ async function readCardExportImage(image?: string) {
             if(img?.length){
                 return img
             }
-        } catch {
+        } catch (e) {
+            console.warn('readCardExportImage: failed to read character image, falling back to none.webp', e)
         }
     }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds a fallback image for character card exports when the character has no readable avatar image.

## Related Issues

None

## Changes

- Added a character card export image resolver that first tries the character image.
- Falls back to `/none.webp` when the character image is missing, empty, or unreadable.
- Keeps the fallback limited to export/upload output without mutating the character or database image field.

## Impact

Realm uploads and character card exports no longer fail solely because a bot card has no profile image. Existing characters with valid images continue to export with their original image.

## Additional Notes

Validated with `pnpm check`.
Test it manually in dev server.