### PR TITLE
feat(ui): redesign sidebar welcome screen and add missing translations

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -172,6 +172,8 @@ export const languageChinese = {
         "themeDescClassic": "适用于所有设备",
         "texttheme": "设置文字颜色",
         "inputName": "最后，请输入你的昵称。",
+        "welcomeToRisuai": "欢迎来到 Risuai！",
+        "selectBotToStartChatting": "选择一个机器人开始聊天",
         "welcome": "欢迎使用 Risu（叡苏）！我将引导你进行设置。请问我该如何称呼你？",
         "welcome2": "你好，{username}！在开始之前，我会问你一些问题，稍后可在设置中进行修改。\n\n首先，请选择 AI 提供者。",
         "openRouterProvider": "OpenRouter 提供许多模型，部分免费且未经内容过滤，但质量不如 OpenAI。",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -172,6 +172,8 @@ export const languageGerman = {
         "themeDescClassic": "Geeignet für alle Geräte",
         "texttheme": "Wählen Sie Ihre Textfarbe",
         "inputName": "Geben Sie abschließend Ihren Spitznamen ein",
+        "welcomeToRisuai": "Willkommen bei Risuai!",
+        "selectBotToStartChatting": "Wähle einen Bot aus, um zu chatten",
         "welcome": "Willkommen bei Risuai! Ich bin Airisu und werde Sie durch die Einrichtung von Risuai führen. Zuerst, wie darf ich Sie nennen?",
         "welcome2": "Hallo {username}! Bevor wir beginnen, werde ich Ihnen einige Fragen stellen. Sie können diese Einstellungen später in den Einstellungen ändern.\n\nWählen Sie zunächst den KI-Anbieter aus.",
         "openRouterProvider": "OpenRouter hat viele Modelle, einige davon ungefiltert und einige davon kostenlos, aber es ist nicht so gut wie OpenAI.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -319,6 +319,8 @@ export const languageEnglish = {
         themeDescClassic: "Suitable for All devices",
         texttheme: "Select your text color",
         inputName: "Lastly, input your Nickname.",
+        welcomeToRisuai: "Welcome to Risuai!",
+        selectBotToStartChatting: "Select a bot to start chatting",
         welcome: "Welcome to Risuai! I am Airisu, I am here to guide you through the Risuai setup. First, what may I call you?",
         welcome2: "Hello {username}! Before we start, I will ask you some questions. You can change these settings later in settings.\n\nFirst select the AI provider.",
         openRouterProvider: "OpenRouter has a lot of models, some of them unfiltered and some of them free, but it is not as good as OpenAI.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -172,6 +172,8 @@ export const languageSpanish = {
         "themeDescClassic": "Apto para todos los dispositivos",
         "texttheme": "Selecciona el color del texto",
         "inputName": "Por último, ingresa tu apodo.",
+        "welcomeToRisuai": "¡Bienvenido a Risuai!",
+        "selectBotToStartChatting": "Selecciona un bot para empezar a chatear",
         "welcome": "¡Bienvenido a Risuai! Aquí te guiaré para configurarlo. Primero, ¿cómo puedo llamarte?",
         "welcome2": "Hola {username}! Antes de empezar, te haré algunas preguntas. Puedes cambiar estas configuraciones más tarde en la configuración.\n\nPrimero selecciona el proveedor de IA.",
         "openRouterProvider": "OpenRouter tiene muchos modelos, algunos de ellos sin filtro y algunos gratuitos, pero no es tan bueno como OpenAI.",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -191,6 +191,8 @@ export const languageKorean = {
         "themeDescClassic": "모든 기기에 적합합니다",
         "texttheme": "텍스트 색상을 선택해주세요",
         "inputName": "마지막으로, 닉네임을 입력해 주세요",
+        "welcomeToRisuai": "Risuai에 오신 것을 환영해요!",
+        "selectBotToStartChatting": "채팅을 시작할 봇을 선택해 주세요",
         "welcome": "Risuai에 오신 것을 환영해요! 저는 Risuai 셋업을 도와줄 아이리스라고 해요. 먼저 닉네임을 입력해 주세요!",
         "welcome2": "{username}님 안녕하세요! Risuai를 시작하려면 몇 가지 설정만 하시면 되요. Ai 제공자를 선택해 주세요!",
         "openRouterProvider": "OpenRouter는 여러 무료/유료 모델이 있습니다. 기본적으로 무료로 설정됩니다.",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -172,6 +172,8 @@ export const languageVietnamese = {
         "themeDescClassic": "Thích hợp cho mọi thiết bị",
         "texttheme": "Chọn màu văn bản của bạn",
         "inputName": "Cuối cùng, nhập Biệt hiệu của bạn.",
+        "welcomeToRisuai": "Chào mừng đến với Risuai!",
+        "selectBotToStartChatting": "Chọn một bot để bắt đầu trò chuyện",
         "welcome": "Chào mừng đến với Risuai! Tôi là Airisu, tôi ở đây để hướng dẫn bạn cài đặt Risuai. Trước tiên, tôi có thể gọi bạn là gì?",
         "welcome2": "Xin chào {username}! Trước khi bắt đầu, tôi sẽ hỏi bạn một số câu hỏi. Bạn có thể thay đổi các cài đặt này sau trong phần cài đặt.\n\nĐầu tiên hãy chọn nhà cung cấp AI.",
         "openRouterProvider": "OpenRouter có rất nhiều mô hình, một số không được lọc và một số miễn phí, nhưng nó không tốt bằng OpenAI.",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -192,6 +192,8 @@ export const languageChineseTraditional = {
         "themeDescClassic": "適用於所有裝置",
         "texttheme": "設定文字顏色",
         "inputName": "最後，請輸入您的暱稱。",
+        "welcomeToRisuai": "歡迎來到 Risuai！",
+        "selectBotToStartChatting": "選擇一個機器人開始聊天",
         "welcome": "歡迎使用 Risuai！我將引導您進行設定。請問我該如何稱呼您？",
         "welcome2": "您好，{username}！在開始之前，我會問您一些問題，稍後可在設定中進行修改。\n\n首先，請選擇 AI 提供商。",
         "openRouterProvider": "OpenRouter 提供許多模型，部分免費且未經內容過濾。",

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -30,6 +30,7 @@
     HomeIcon,
     WrenchIcon,
     User2Icon,
+    Sparkles,
   } from "@lucide/svelte";
     import {
   addCharacter,
@@ -855,9 +856,13 @@
   </button>
   {#if sideBarMode === 0}
     {#if $selectedCharID < 0 || $settingsOpen}
-      <div>
-        <h1 class="text-xl">Welcome to RisuAI!</h1>
-        <span class="text-xs text-textcolor2">Select a bot to start chatting</span>
+      <div class="flex flex-col flex-1 items-center justify-center w-full min-h-[50vh] opacity-80 select-none text-center px-4">
+        <div class="relative flex items-center justify-center w-40 h-40 mb-8">
+          <div class="absolute inset-0 bg-gradient-to-br from-cyan-400/40 to-blue-600/40 rounded-full blur-3xl"></div>
+          <Sparkles size={100} strokeWidth={1.2} class="relative z-10 text-textcolor" />
+        </div>
+        <h1 class="text-2xl font-bold text-textcolor mb-2">{language.setup.welcomeToRisuai}</h1>
+        <span class="text-sm text-textcolor2">{language.setup.selectBotToStartChatting}</span>
       </div>
     {:else if DBState.db.characters[$selectedCharID]?.chaId === '§playground'}
       <SideChatList bind:chara={ DBState.db.characters[$selectedCharID]} />


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

This PR modernizes the empty state "Welcome" screen in the sidebar and ensures all localization files are fully synchronized with the newly added text keys.

## Related Issues

None

## Changes

- UI Redesign: Replaced the static grayscale logo in `Sidebar.svelte` with a glowing `Sparkles` Lucide icon.
- Aura Effect: Added a beautifully smooth, blurred cyan-to-blue gradient backdrop (`blur-3xl`) behind the icon to match the Risu theme without sharp boundaries.
- Localization Sync: Added the missing `welcomeToRisuai` and `selectBotToStartChatting` translation keys to `cn.ts`, `zh-Hant.ts`, `de.ts`, `es.ts`, and `vi.ts`.

## Impact

- No impact on existing functionality or chat behavior.

## Additional Notes

The glowing effect uses heavily blurred Tailwind CSS utilities and seamlessly assimilates into the dark background, ensuring a premium aesthetic without clashing with dynamic themes.

## Preview

| In dark mode | In white mode |
|-----|-----|
| <img width="801" height="1180" alt="haeRrsTEiWARhrse" src="https://github.com/user-attachments/assets/371affe1-7d04-4758-bc8e-caaa447b58b8" /> | <img width="801" height="1180" alt="vdhskthasierEAre" src="https://github.com/user-attachments/assets/8295ec30-d42a-42c8-b2d3-d30429c7cde0" /> |
