### PR TITLE
fix: Add Additional params settings for all models

### DIFF
--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -672,7 +672,6 @@
         </div>
     </Accordion>
 
-    {#if DBState.db.aiModel === 'reverse_proxy'}
     <Accordion styled name="{language.additionalParams} " help="additionalParams">
         <table class="contain w-full max-w-full tabler">
             <tbody>
@@ -687,7 +686,7 @@
                     }}><PlusIcon /></button>
                 </th>
             </tr>
-            {#if DBState.db.bias.length === 0}
+            {#if DBState.db.additionalParams.length === 0}
                 <tr class="text-textcolor2">
                     <td colspan="3">{language.noData}</td>
                 </tr>
@@ -712,7 +711,6 @@
             </tbody>
         </table>
     </Accordion>
-    {/if}
 
 
     <Accordion styled name={language.promptTemplate}>

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -578,9 +578,7 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
         body.tools = undefined
     }
 
-    if(arg.aiModel === 'reverse_proxy' || arg.aiModel?.startsWith('xcustom:::')){
-        body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
-    }
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
 
     if(arg.previewBody){
         return {

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -574,9 +574,8 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         }
         body.n = db.genTime
     }
-    if(aiModel === 'reverse_proxy' || aiModel.startsWith('xcustom:::')){
-        body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
-    }
+    
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
 
     // Some aux flows are intentionally non-streaming (e.g. memory/translate).
     // If custom Additional Parameters contains stream=true, force non-stream mode back.
@@ -933,21 +932,27 @@ export async function requestOpenAILegacyInstruct(arg:RequestDataArgumentExtende
         }
     }
 
+    let body:any = {
+        model: "gpt-3.5-turbo-instruct",
+        prompt: prompt,
+        max_tokens: maxTokens,
+        temperature: temperature,
+        top_p: 1,
+        stop:["User:"," User:", "user:", " user:"],
+        presence_penalty: arg.PresensePenalty || (db.PresensePenalty / 100),
+        frequency_penalty: arg.frequencyPenalty || (db.frequencyPenalty / 100),
+    }
+
+    let headers:any = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + (arg.key ?? db.openAIKey)
+    }
+
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(db.aiModel))
+
     const response = await globalFetch(arg.customURL ?? "https://api.openai.com/v1/completions", {
-        body: {
-            model: "gpt-3.5-turbo-instruct",
-            prompt: prompt,
-            max_tokens: maxTokens,
-            temperature: temperature,
-            top_p: 1,
-            stop:["User:"," User:", "user:", " user:"],
-            presence_penalty: arg.PresensePenalty || (db.PresensePenalty / 100),
-            frequency_penalty: arg.frequencyPenalty || (db.frequencyPenalty / 100),
-        },
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + (arg.key ?? db.openAIKey)
-        },
+        body: body,
+        headers: headers,
         chatId: arg.chatId,
         abortSignal: arg.abortSignal
     });
@@ -1036,7 +1041,7 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         (items[items.length-1] as ResponseOutputItem).status = 'incomplete'
     }
     
-    const body = applyParameters({
+    let body = applyParameters({
         model: arg.modelInfo.internalID ?? aiModel,
         input: items,
         max_output_tokens: maxTokens,
@@ -1106,7 +1111,7 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         }
     }
 
-    const headers = {
+    let headers: Record<string, string> = {
         "Authorization": "Bearer " + (arg.key ?? db.openAIKey),
         "Content-Type": "application/json"
     }
@@ -1114,6 +1119,12 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
     if(risuIdentify){
         headers["X-Proxy-Risu"] = 'RisuAI'
     }
+
+    if(db.modelTools.includes('search')){
+        body.tools.push('web_search_preview')
+    }
+
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
 
     if(arg.previewBody){
         return {
@@ -1124,10 +1135,6 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
                 headers: headers
             })
         }
-    }
-
-    if(db.modelTools.includes('search')){
-        body.tools.push('web_search_preview')
     }
 
     const localNetworkOptions = getLocalNetworkRequestOptions(requestURL, db, false)

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -948,7 +948,7 @@ export async function requestOpenAILegacyInstruct(arg:RequestDataArgumentExtende
         "Authorization": "Bearer " + (arg.key ?? db.openAIKey)
     }
 
-    body = applyAdditionalParameters(body, headers, getAdditionalParameters(db.aiModel))
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
 
     const response = await globalFetch(arg.customURL ?? "https://api.openai.com/v1/completions", {
         body: body,
@@ -1120,10 +1120,6 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         headers["X-Proxy-Risu"] = 'RisuAI'
     }
 
-    if(db.modelTools.includes('search')){
-        body.tools.push('web_search_preview')
-    }
-
     body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
 
     if(arg.previewBody){
@@ -1135,6 +1131,10 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
                 headers: headers
             })
         }
+    }
+
+    if(db.modelTools.includes('search')){
+        body.tools.push('web_search_preview')
     }
 
     const localNetworkOptions = getLocalNetworkRequestOptions(requestURL, db, false)

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -1171,16 +1171,19 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
             type: 'success',
             result: JSON.stringify({
                 url: isCloud ? 'https://ollama.com/api/chat' : `${db.ollamaURL}/api/chat`,
-                body: requestBody,
+                model: ollamaModel,
                 source: db.ollamaModelSource,
-                headers: customHeaders
+                stream: arg.useStreaming,
+                think: ollamaThinkMode,
+                headers: Object.keys(customHeaders).length > 0 ? customHeaders : undefined,
+                body: requestBody
             })
         }
     }
 
     const ollama = new Ollama({
         host: isCloud ? 'https://ollama.com' : db.ollamaURL,
-        headers: customHeaders,
+        headers: Object.keys(customHeaders).length > 0 ? customHeaders : undefined,
         fetch: isCloud ? ollamaCloudFetch : undefined
     })
 

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -19,7 +19,7 @@ import { runTrigger } from "../triggers";
 import { requestClaude } from './anthropic';
 import { requestGoogleCloudVertex } from './google';
 import { requestOpenAI, requestOpenAILegacyInstruct, requestOpenAIResponseAPI } from "./openAI/requests";
-import { applyParameters, type ModelModeExtended } from './shared';
+import { applyAdditionalParameters, applyParameters, getAdditionalParameters, type ModelModeExtended } from './shared';
 
 export type ToolCall = {
     name: string;
@@ -615,17 +615,21 @@ async function requestNovelAI(arg:RequestDataArgumentExtended):Promise<requestDa
     
 
       
-    const body = {
+    let body = {
         "input": prompt,
         "model": aiModel === 'novelai_kayra' ? 'kayra-v1' : 'clio-v1',
         "parameters":payload
     }
 
+    let headers = {
+        "Authorization": "Bearer " + (arg.key ?? db.novelai.token)
+    }
+
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
+
     const da = await globalFetch(aiModel === 'novelai_kayra' ? "https://text.novelai.net/ai/generate" : "https://api.novelai.net/ai/generate", {
         body: body,
-        headers: {
-            "Authorization": "Bearer " + (arg.key ?? db.novelai.token)
-        },
+        headers: headers,
         abortSignal,
         chatId: arg.chatId,
     })
@@ -685,9 +689,11 @@ async function requestOobaLegacy(arg:RequestDataArgumentExtended):Promise<reques
         prompt: prompt
     }
 
-    const headers = (aiModel === 'textgen_webui') ? {} : {
+    let headers: Record<string, string> = (aiModel === 'textgen_webui') ? {} : {
         'X-API-KEY': db.mancerHeader
     }
+
+    bodyTemplate = applyAdditionalParameters(bodyTemplate, headers, getAdditionalParameters(aiModel))
 
     if(arg.previewBody){
         return {
@@ -818,19 +824,23 @@ async function requestOoba(arg:RequestDataArgumentExtended):Promise<requestDataR
         }
     }
 
+    let headers: Record<string, string> = {}
+    bodyTemplate = applyAdditionalParameters(bodyTemplate, headers, getAdditionalParameters(aiModel))
+
     if(arg.previewBody){
         return {
             type: 'success',
             result: JSON.stringify({
                 url: urlStr,
                 body: bodyTemplate,
-                headers: {}
+                headers: headers
             })      
         }
     }
 
     const response = await globalFetch(urlStr, {
         body: bodyTemplate,
+        headers: headers,
         chatId: arg.chatId,
         abortSignal: arg.abortSignal
     })
@@ -961,7 +971,7 @@ async function requestKobold(arg:RequestDataArgumentExtended):Promise<requestDat
         url.pathname = 'api/v1/generate'
     }
 
-    const body = applyParameters({
+    let body = applyParameters({
         "prompt": prompt,
         max_length: maxTokens,
         max_context_length: db.maxContext,
@@ -978,13 +988,19 @@ async function requestKobold(arg:RequestDataArgumentExtended):Promise<requestDat
         modelId: arg.aiModel
     }) as KoboldGenerationInputSchema
 
+    let headers: Record<string, string> = {
+        "content-type": "application/json",
+    }
+
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel)) as KoboldGenerationInputSchema
+
     if(arg.previewBody){
         return {
             type: 'success',
             result: JSON.stringify({
                 url: url.toString(),
                 body: body,
-                headers: {}
+                headers: headers
             })      
         }
     }
@@ -992,9 +1008,7 @@ async function requestKobold(arg:RequestDataArgumentExtended):Promise<requestDat
     const da = await globalFetch(url.toString(), {
         method: "POST",
         body: body,
-        headers: {
-            "content-type": "application/json",
-        },
+        headers: headers,
         abortSignal,
         chatId: arg.chatId
     })
@@ -1032,12 +1046,13 @@ async function requestNovelList(arg:RequestDataArgumentExtended):Promise<request
         logit_bias.push(bia[0])
         logit_bias_values.push(bia[1].toString())
     }
-    const headers = {
+
+    let headers: Record<string, string> = {
         'Authorization': `Bearer ${auth_key}`,
         'Content-Type': 'application/json'
     };
     
-    const send_body = {
+    let send_body: Record<string, any> = {
         text: stringlizeAINChat(formated, currentChar?.name ?? '', arg.continue),
         length: maxTokens,
         temperature: temperature,
@@ -1055,6 +1070,7 @@ async function requestNovelList(arg:RequestDataArgumentExtended):Promise<request
         logit_bias_values: (logit_bias_values.length > 0) ? logit_bias_values.join("|") : undefined,
     };
 
+    send_body = applyAdditionalParameters(send_body, headers, getAdditionalParameters(arg.aiModel))
 
     if(arg.previewBody){
         return {
@@ -1129,27 +1145,7 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
         return requestClaude(arg)
     }
 
-    if(arg.previewBody){
-        return {
-            type: 'success',
-            result: JSON.stringify({
-                url: isCloud ? 'https://ollama.com/api/chat' : `${db.ollamaURL}/api/chat`,
-                model: ollamaModel,
-                source: db.ollamaModelSource,
-                stream: arg.useStreaming,
-                think: ollamaThinkMode,
-                headers: isCloud ? { Authorization: 'Bearer ' + db.ollamaApiKey } : {}
-            })
-        }
-    }
-
-    const ollama = new Ollama({
-        host: isCloud ? 'https://ollama.com' : db.ollamaURL,
-        headers: isCloud && db.ollamaApiKey ? { Authorization: 'Bearer ' + db.ollamaApiKey } : undefined,
-        fetch: isCloud ? ollamaCloudFetch : undefined
-    })
-
-    const messages = []
+    const messages: any[] = []
     for (const v of formated) {
         if (v.role === 'assistant' || v.role === 'user' || v.role === 'system') {
             messages.push({
@@ -1159,15 +1155,40 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
         }
     }
 
-    if(!arg.useStreaming){
-        const response = await ollama.chat({
-            model: ollamaModel,
-            messages: messages,
-            stream: false,
-            think: ollamaThinkMode
-        })
+    let customHeaders: Record<string, string> = isCloud && db.ollamaApiKey ? { Authorization: 'Bearer ' + db.ollamaApiKey } : {}
 
-        const result = formatThinkingOutput(response.message.thinking ?? '', response.message.content)
+    let requestBody: any = {
+        model: ollamaModel,
+        messages: messages,
+        stream: arg.useStreaming,
+        think: ollamaThinkMode
+    }
+
+    requestBody = applyAdditionalParameters(requestBody, customHeaders, getAdditionalParameters(arg.aiModel))
+
+    if(arg.previewBody){
+        return {
+            type: 'success',
+            result: JSON.stringify({
+                url: isCloud ? 'https://ollama.com/api/chat' : `${db.ollamaURL}/api/chat`,
+                body: requestBody,
+                source: db.ollamaModelSource,
+                headers: customHeaders
+            })
+        }
+    }
+
+    const ollama = new Ollama({
+        host: isCloud ? 'https://ollama.com' : db.ollamaURL,
+        headers: customHeaders,
+        fetch: isCloud ? ollamaCloudFetch : undefined
+    })
+
+    if(!arg.useStreaming){
+        requestBody.stream = false
+        const response: any = await ollama.chat(requestBody)
+
+        const result = formatThinkingOutput(response.message?.thinking ?? '', response.message?.content ?? '')
         return {
             type: 'success',
             result: unstringlizeChat(result, formated, arg.currentChar?.name ?? ''),
@@ -1175,20 +1196,16 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
         }
     }
 
-    const response = await ollama.chat({
-        model: ollamaModel,
-        messages: messages,
-        stream: true,
-        think: ollamaThinkMode
-    })
+    requestBody.stream = true
+    const response: any = await ollama.chat(requestBody)
 
     const readableStream = new ReadableStream<StreamResponseChunk>({
         async start(controller){
             let content = ''
             let thinking = ''
             for await(const chunk of response){
-                thinking += chunk.message.thinking ?? ''
-                content += chunk.message.content ?? ''
+                thinking += chunk.message?.thinking ?? ''
+                content += chunk.message?.content ?? ''
                 controller.enqueue({
                     "0": formatThinkingOutput(thinking, content)
                 })
@@ -1285,6 +1302,12 @@ async function requestCohere(arg:RequestDataArgumentExtended):Promise<requestDat
         }
     }
 
+    let headers: Record<string, string> = {
+        "Authorization": "Bearer " + (arg.key ?? db.cohereAPIKey),
+        "Content-Type": "application/json"
+    }
+
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
     console.log(body)
 
     if(arg.previewBody){
@@ -1293,20 +1316,14 @@ async function requestCohere(arg:RequestDataArgumentExtended):Promise<requestDat
             result: JSON.stringify({
                 url: arg.customURL ?? 'https://api.cohere.com/v1/chat',
                 body: body,
-                headers: {
-                    "Authorization": "Bearer " + (arg.key ?? db.cohereAPIKey),
-                    "Content-Type": "application/json"
-                }
+                headers: headers
             })
         }
     }
 
     const res = await globalFetch(arg.customURL ?? 'https://api.cohere.com/v1/chat', {
         method: "POST",
-        headers: {
-            "Authorization": "Bearer " + (arg.key ?? db.cohereAPIKey),
-            "Content-Type": "application/json"
-        },
+        headers: headers,
         body: body,
         abortSignal: arg.abortSignal
     })
@@ -1381,13 +1398,17 @@ async function requestHorde(arg:RequestDataArgumentExtended):Promise<requestData
         apiKey = db.hordeConfig.apiKey
     }
 
+    let headers: Record<string, string> = {
+        "content-type": "application/json",
+        "apikey": apiKey
+    }
+
+    let finalBody = applyAdditionalParameters(argument, headers, getAdditionalParameters(arg.aiModel))
+
     const da = await fetch("https://stablehorde.net/api/v2/generate/text/async", {
-        body: JSON.stringify(argument),
+        body: JSON.stringify(finalBody),
         method: "POST",
-        headers: {
-            "content-type": "application/json",
-            "apikey": apiKey
-        },
+        headers: headers,
         signal: abortSignal
     })
 
@@ -1457,14 +1478,18 @@ async function requestWebLLM(arg:RequestDataArgumentExtended):Promise<requestDat
             })
         }
     }
-    const v = await runTransformers(prompt, realModel, {
+    const transformersParams = {
         temperature: temperature,
         max_new_tokens: maxTokens,
         top_k: db.ooba.top_k,
         top_p: db.ooba.top_p,
         repetition_penalty: db.ooba.repetition_penalty,
         typical_p: db.ooba.typical_p,
-    } as any)
+    } as any
+
+    const finalParams = applyAdditionalParameters(transformersParams, {}, getAdditionalParameters(arg.aiModel))
+
+    const v = await runTransformers(prompt, realModel, finalParams)
     return {
         type: 'success',
         result: unstringlizeChat((v.generated_text as string) ?? '', formated, currentChar?.name ?? '')

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -34,29 +34,26 @@ export function setObjectValue<T>(obj: T, key: string, value: any): T {
 export function getAdditionalParameters(aiModel?: string): [string, string][] {
     const db = getDatabase()
 
-    if (!aiModel) {
-        return []
-    }
-
-    if (aiModel === 'reverse_proxy') {
-        return [...(db.additionalParams ?? [])]
-    }
-
-    if (!aiModel.startsWith('xcustom:::')) {
-        return []
-    }
-
-    const found = db.customModels.find((model) => model.id === aiModel)
-    const params = found?.params
-    if (!params) {
-        return []
-    }
-
     const additionalParams: [string, string][] = []
-    for (const line of params.split('\n')) {
-        const split = line.split('=')
-        if (split.length >= 2) {
-            additionalParams.push([split[0], split.slice(1).join('=')])
+
+    if (db.additionalParams) {
+        additionalParams.push(...db.additionalParams)
+    }
+
+    if (!aiModel) {
+        return additionalParams
+    }
+
+    if (aiModel.startsWith('xcustom:::')) {
+        const found = db.customModels.find((model) => model.id === aiModel)
+        const params = found?.params
+        if (params) {
+            for (const line of params.split('\n')) {
+                const split = line.split('=')
+                if (split.length >= 2) {
+                    additionalParams.push([split[0], split.slice(1).join('=')])
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Demo
### Setting Additional parameter on Anthropic provider
<img width="651" height="510" alt="image" src="https://github.com/user-attachments/assets/4dbaa389-2c5d-43db-8ff8-f1adc1e74e4e" />
<img width="657" height="416" alt="image" src="https://github.com/user-attachments/assets/938bfc8c-9fd8-4a63-9eab-647f8f34019c" />
<img width="529" height="250" alt="image" src="https://github.com/user-attachments/assets/c4278af8-082c-4f73-9f9b-52b7879e730d" />
<img width="254" height="179" alt="image" src="https://github.com/user-attachments/assets/501f2303-be65-459b-b11d-aea4b6bf0c5e" />


## Summary

Currently, additional parameter settings cannot be used unless it's a custom API.
This PR allows additional parameters to be used regardless of the model.

I applied the `applyAdditionalParameters` function to all request code and updated the frontend so that the additional parameters button appears.

## Changes

Changes made during this process:
- Request code for all providers has been modified.
- The `getAdditionalParameters` function was also updated. Originally, this function was designed to return only `[]` if the `aiModel` did not start with `reverse_proxy` or `xcustom`. I modified it to return `db.additionalParams` for other models while maintaining the existing flow.

The `getAdditionalParameters` function underwent the most significant changes, so please review that part especially closely.
Also, since Ollama had the most extensive code changes, please take a look at that as well.

I've double-checked the modified code myself, but I'd appreciate it if you could verify if there are any issues.

## Impact

In theory, this modification shouldn't make any difference if no additional parameters are set.
But please check if there are any other side effects.