### PR TITLE
Add Risuai.readInlay(id) to plugin API v3

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -897,6 +897,29 @@ const imageData = await Risuai.readImage('asset-id');
 const savedPath = await Risuai.saveAsset(assetData);
 ```
 
+#### Inlay Assets (user-attached images / audio / video)
+
+Inlay assets are files the **user attaches** to a chat message (e.g. drag-and-dropped images). Raw message text contains a placeholder of the form `{{inlayed::<uuid>}}` referencing the asset.
+
+```javascript
+// In a custom provider handler, recover the user-attached image:
+const charIdx = await Risuai.getCurrentCharacterIndex();
+const chatIdx = await Risuai.getCurrentChatIndex();
+const chat = await Risuai.getChatFromIndex(charIdx, chatIdx);
+const lastMsg = chat.message[chat.message.length - 1];
+
+const m = lastMsg.data.match(/\{\{inlayed::([a-f0-9-]+)\}\}/i);
+if (m) {
+  const inlay = await Risuai.readInlay(m[1]);
+  // inlay.data === "data:image/png;base64,iVBORw0..."
+  // inlay.ext  === "png"
+  // inlay.type === "image"
+  // ... forward to external multi-modal API (Anthropic / OpenAI / etc.)
+}
+```
+
+`readInlay(id)` returns `null` if no asset exists for the given UUID. Supported `type` values: `'image' | 'video' | 'audio' | 'signature'`.
+
 ### Theming
 
 #### Color Scheme

--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -100,6 +100,25 @@
 // ============================================================================
 
 /**
+ * Inlay asset shape returned by `risuai.readInlay`.
+ * `data` is a base64 data-URI string (e.g. `"data:image/png;base64,iVBORw0..."`).
+ */
+interface InlayAssetForPlugin {
+    /** Base64 data-URI string (`data:<mime>;base64,...`) */
+    data: string;
+    /** File extension without leading dot (e.g. `"png"`, `"webp"`, `"mp3"`) */
+    ext: string;
+    /** Original asset filename */
+    name: string;
+    /** Asset category */
+    type: 'image' | 'video' | 'audio' | 'signature';
+    /** Pixel height (for images/videos) */
+    height?: number;
+    /** Pixel width (for images/videos) */
+    width?: number;
+}
+
+/**
  * MCP tool definition
  */
 interface MCPToolDef {
@@ -1831,6 +1850,30 @@ interface RisuaiPluginAPI {
      * @returns Image data
      */
     readImage(path?: string): Promise<any>;
+
+    /**
+     * Reads an inlay asset (image / audio / video / signature) attached by the
+     * user in chat, by its UUID. The UUID can be extracted from raw message
+     * text via the `{{inlayed::<uuid>}}` placeholder
+     * (`getChatFromIndex(...).message[i].data`).
+     *
+     * Returns `null` if no asset exists for that UUID.
+     *
+     * @param id - Inlay UUID
+     * @returns Asset with `data` as a base64 data-URI string, or `null`
+     *
+     * @example
+     * ```typescript
+     * const m = rawMessageData.match(/\{\{inlayed::([a-f0-9-]+)\}\}/i);
+     * if (m) {
+     *     const inlay = await risuai.readInlay(m[1]);
+     *     // inlay.data === "data:image/png;base64,iVBORw0..."
+     *     // inlay.ext  === "png"
+     *     // inlay.type === "image"
+     * }
+     * ```
+     */
+    readInlay(id: string): Promise<InlayAssetForPlugin | null>;
 
     /**
      * Saves an asset

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -13,6 +13,7 @@ import { changeColorScheme, updateColorScheme, updateTextThemeAndCSS, type Color
 import { isNodeServer, isTauri } from "src/ts/platform";
 import { get } from "svelte/store";
 import { registerMCPModule, unregisterMCPModule } from "src/ts/process/mcp/pluginmcp";
+import { getInlayAsset } from "src/ts/process/files/inlays";
 import { getLLMCache, searchLLMCache } from "src/ts/translator/translator";
 import { hasher } from "src/ts/parser/parser.svelte";
 import localforage from "localforage";
@@ -705,6 +706,9 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
         setDatabase: oldApis.setDatabase,
         loadPlugins: oldApis.loadPlugins,
         readImage: oldApis.readImage,
+        readInlay: async (id: string) => {
+            return await getInlayAsset(id);
+        },
         saveAsset: oldApis.saveAsset,
         //Same functionality, but new implementation
         getDatabase: async (includeOnly:string[]|'all' = 'all') => {


### PR DESCRIPTION
Exposes the existing host-side getInlayAsset(id) (from src/ts/process/files/inlays.ts) to plugin sandboxes. Plugins can now read user-attached inlay images/audio/video by the UUID found in {{inlayed::<uuid>}} placeholders inside raw message text.

Use case: custom-provider plugins that proxy chats to external endpoints need access to attached images to forward them in multi-modal API calls. The current plugin API exposes only sanitized text prompt_chat, leaving inlay binaries unreachable.

## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Please provide a brief summary of the changes made in this pull request.

## Related Issues

Please list any related issues or pull requests that this PR addresses.
If there are none, please write "None".

## Changes

Please describe the changes made in this pull request in detail.

## Impact

Please describe any potential impacts this PR may have on existing functionality or users.

## Additional Notes
