### PR TITLE
style: render checkbox inputs as toggle switches and optimize aesthetics

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -941,8 +941,7 @@
 
 {#if submenu === 1 || submenu === -1}
 <Accordion name="TTS" styled disabled={submenu !== -1}>
-    <span class="text-textcolor mt-2">Auto Speech</span>
-    <CheckInput bind:check={DBState.db.ttsAutoSpeech}/>
+    <CheckInput bind:check={DBState.db.ttsAutoSpeech} name="Auto Speech" className="mt-2"/>
 
     <span class="text-textcolor mt-2">ElevenLabs API key</span>
     <TextInput size="sm" marginBottom bind:value={DBState.db.elevenLabKey}/>

--- a/src/lib/UI/GUI/CheckInput.svelte
+++ b/src/lib/UI/GUI/CheckInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { CheckIcon } from '@lucide/svelte';
 
     interface Props {
         check?: boolean;
@@ -52,9 +53,13 @@
         aria-hidden="true"
     >
         <span
-            class="absolute left-0.5 h-5 w-5 rounded-full shadow-sm transition-all duration-200 {check ? 'translate-x-4 bg-bgcolor' : 'translate-x-0 bg-textcolor'}"
+            class="absolute left-0.5 flex h-5 w-5 items-center justify-center rounded-full shadow-sm transition-all duration-200 {check ? 'translate-x-4 bg-bgcolor text-textcolor' : 'translate-x-0 bg-textcolor text-bgcolor'}"
             aria-hidden="true"
-        ></span>
+        >
+            {#if check}
+                <CheckIcon size={14} strokeWidth={4} />
+            {/if}
+        </span>
     </span>
     {#if !hiddenName && !reverse}
         <span class="min-w-0">{name} {@render children?.()}</span>

--- a/src/lib/UI/GUI/CheckInput.svelte
+++ b/src/lib/UI/GUI/CheckInput.svelte
@@ -24,7 +24,7 @@
         children
     }: Props = $props();
 
-    let stateLabel = $derived(`${name} ${check ? 'abled' : 'disabled'}`);
+    let stateLabel = $derived(name ? `${name} ${check ? 'enabled' : 'disabled'}` : check ? 'enabled' : 'disabled');
 </script>
 
 <label 
@@ -48,11 +48,11 @@
         aria-label={stateLabel}
     />
     <span 
-        class="relative inline-flex h-6 w-[2.625rem] min-w-[2.625rem] shrink-0 items-center rounded-full border border-darkborderc {check ? 'bg-borderc' : 'bg-darkbutton'} transition-colors duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-borderc"
+        class="relative inline-flex h-6 w-[2.625rem] min-w-[2.625rem] shrink-0 items-center rounded-full border {check ? 'border-textcolor bg-textcolor' : 'border-darkborderc bg-darkbutton'} transition-colors duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-borderc"
         aria-hidden="true"
     >
         <span
-            class="absolute left-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 {check ? 'translate-x-4' : 'translate-x-0'}"
+            class="absolute left-0.5 h-5 w-5 rounded-full shadow-sm transition-all duration-200 {check ? 'translate-x-4 bg-bgcolor' : 'translate-x-0 bg-textcolor'}"
             aria-hidden="true"
         ></span>
     </span>

--- a/src/lib/UI/GUI/CheckInput.svelte
+++ b/src/lib/UI/GUI/CheckInput.svelte
@@ -48,7 +48,7 @@
         aria-label={stateLabel}
     />
     <span 
-        class="relative inline-flex h-6 w-10 min-w-10 shrink-0 items-center rounded-full border border-darkborderc {check ? 'bg-borderc' : 'bg-darkbutton'} transition-colors duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-borderc"
+        class="relative inline-flex h-6 w-[2.625rem] min-w-[2.625rem] shrink-0 items-center rounded-full border border-darkborderc {check ? 'bg-borderc' : 'bg-darkbutton'} transition-colors duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-borderc"
         aria-hidden="true"
     >
         <span

--- a/src/lib/UI/GUI/CheckInput.svelte
+++ b/src/lib/UI/GUI/CheckInput.svelte
@@ -2,7 +2,7 @@
 
     interface Props {
         check?: boolean;
-        onChange?: (check:boolean) => any,
+        onChange?: (check:boolean) => any;
         margin?: boolean;
         name?: string;
         hiddenName?: boolean;
@@ -19,45 +19,44 @@
         name = '',
         hiddenName = false,
         reverse = false,
-        className = "",
+        className = '',
         grayText = false,
         children
     }: Props = $props();
+
+    let stateLabel = $derived(`${name} ${check ? 'abled' : 'disabled'}`);
 </script>
 
 <label 
-    class={"flex items-center gap-2 cursor-pointer" + (className ? " " + className : "") + (grayText ? " text-textcolor2" : " text-textcolor")}
+    class={"flex items-center gap-2 cursor-pointer select-none" + (className ? " " + className : "") + (grayText ? " text-textcolor2" : " text-textcolor")}
     class:mr-2={margin}
-    aria-describedby="{name} {check ? 'abled' : 'disabled'}"
-    aria-labelledby="{name} {check ? 'abled' : 'disabled'}"
+    aria-label={hiddenName ? stateLabel : undefined}
 >
     {#if reverse}
-        <span>{name} {@render children?.()}</span>
+        <span class="min-w-0">{name} {@render children?.()}</span>
     {/if}
     <input 
-        class="hidden" 
+        class="peer sr-only" 
         type="checkbox" 
         alt={name}
         bind:checked={check}
         onchange={() => {
             onChange(check)
         }}
-        aria-describedby="{name} {check ? 'abled' : 'disabled'}"
-        aria-labelledby="{name} {check ? 'abled' : 'disabled'}"
+        role="switch"
+        aria-checked={check}
+        aria-label={stateLabel}
     />
     <span 
-        class="w-5 h-5 min-w-5 min-h-5 rounded-md border-2 border-darkborderc flex justify-center items-center {check ? 'bg-darkborderc' : 'bg-darkbutton'} transition-colors duration-200"
+        class="relative inline-flex h-6 w-10 min-w-10 shrink-0 items-center rounded-full border border-darkborderc {check ? 'bg-borderc' : 'bg-darkbutton'} transition-colors duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-borderc"
         aria-hidden="true"
-        aria-describedby="{name} {check ? 'abled' : 'disabled'}"
-        aria-labelledby="{name} {check ? 'abled' : 'disabled'}"
     >
-        {#if check}
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="white" class="w-3 h-3" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-            </svg>
-        {/if}
+        <span
+            class="absolute left-0.5 h-5 w-5 rounded-full bg-textcolor shadow-sm transition-transform duration-200 {check ? 'translate-x-4' : 'translate-x-0'}"
+            aria-hidden="true"
+        ></span>
     </span>
     {#if !hiddenName && !reverse}
-        <span>{name} {@render children?.()}</span>
+        <span class="min-w-0">{name} {@render children?.()}</span>
     {/if}
 </label>

--- a/src/lib/UI/GUI/CheckInput.svelte
+++ b/src/lib/UI/GUI/CheckInput.svelte
@@ -52,7 +52,7 @@
         aria-hidden="true"
     >
         <span
-            class="absolute left-0.5 h-5 w-5 rounded-full bg-textcolor shadow-sm transition-transform duration-200 {check ? 'translate-x-4' : 'translate-x-0'}"
+            class="absolute left-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 {check ? 'translate-x-4' : 'translate-x-0'}"
             aria-hidden="true"
         ></span>
     </span>


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Redesigns the `CheckInput` component to render as a modern toggle switch (switch pill) instead of a standard checkbox, improving visual aesthetics, contrast, and alignment.

## Related Issues

None

## Changes

### `src/lib/UI/GUI/CheckInput.svelte`
- Replaced the checkbox box and SVG checkmark structure with a toggle switch track (`rounded-full`) and a sliding circle knob (`bg-white`).
- Set the switch track width to `w-[2.625rem]` (42px) and the knob transition to `translate-x-4` (16px) to achieve a symmetric 2px inner padding on both checked and unchecked states.
- Improved light mode contrast of the knob by utilizing a solid white background instead of `bg-textcolor`.
- Enhanced accessibility by adding `role="switch"`, `aria-checked`, and configuring `aria-label` for screen readers.

## Impact

- All checkboxes utilizing `CheckInput` are now rendered as modern toggle switches.
- Better visual balance and accessibility across both light and dark themes.

## Additional Notes

None

## Preview

| White theme | Dark theme |
|-----|-----|
| <img width="581" height="444" alt="zdskewtoerstdrert0" src="https://github.com/user-attachments/assets/39382b95-08f3-4552-9cc9-a4f861179ab5" /> | <img width="581" height="444" alt="zdskewtoerstdrert1" src="https://github.com/user-attachments/assets/c6f7e911-652e-4459-9c78-a70ca646bd2b" /> |

