### PR TITLE
fix: Redesign request log in response metadata menu

### DIFF
--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -500,15 +500,21 @@
                 {#if generationInfoMenuIndex === 2}
                     {#await getFetchData($alertStore.msg) then data} 
                         {#if !data}
-                            <span class="text-gray-300 text-lg mt-2">{language.errors.requestLogRemoved}</span>
-                            <span class="text-gray-500">{language.errors.requestLogRemovedDesc}</span>
+                            <span class="text-textcolor text-lg mt-2">{language.errors.requestLogRemoved}</span>
+                            <span class="text-textcolor2">{language.errors.requestLogRemovedDesc}</span>
                         {:else}
-                            <h1 class="text-2xl font-bold my-4">URL</h1>
-                            <code class="text-gray-300 border border-darkborderc p-2 rounded-md whitespace-pre-wrap">{data.url}</code>
-                            <h1 class="text-2xl font-bold my-4">Request Body</h1>
-                            <code class="text-gray-300 border border-darkborderc p-2 rounded-md whitespace-pre-wrap">{beautifyJSON(data.body)}</code>
-                            <h1 class="text-2xl font-bold my-4">Response</h1>
-                            <code class="text-gray-300 border border-darkborderc p-2 rounded-md whitespace-pre-wrap">{beautifyJSON(data.response)}</code>
+                            <h1 class="text-2xl font-bold my-4 text-textcolor">URL</h1>
+                            <code class="text-textcolor border border-darkborderc p-2 rounded-md whitespace-pre-wrap">{data.url}</code>
+                            
+                            <details class="my-4">
+                                <summary class="text-2xl font-bold text-textcolor cursor-pointer select-none">Request Body</summary>
+                                <code class="text-textcolor border border-darkborderc p-2 rounded-md whitespace-pre-wrap mt-2 block w-full">{beautifyJSON(data.body)}</code>
+                            </details>
+                            
+                            <details class="my-4">
+                                <summary class="text-2xl font-bold text-textcolor cursor-pointer select-none">Response</summary>
+                                <code class="text-textcolor border border-darkborderc p-2 rounded-md whitespace-pre-wrap mt-2 block w-full">{beautifyJSON(data.response)}</code>
+                            </details>
                         {/if}
                     {/await}
                 {/if}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

It's currently very inconvenient to view request responses in the request logs within the metadata window.
This is because the response is located below the body, requiring a lot of scrolling to see it.

I solved this issue with a very simple fix using details and summary tags, allowing users to open only the parts they want to see without increasing complexity.

Additionally, since this window was using hardcoded text colors, I modified it to use textcolor instead.

<img width="832" height="901" alt="image" src="https://github.com/user-attachments/assets/116a1866-5350-4579-a92a-d6f338335be3" />