### PR TITLE
feat: Cancel Account Sync Option

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -926,6 +926,7 @@ export const languageEnglish = {
     logout: "Logout",
     loadDataFromAccount: "Load Data from Account",
     saveCurrentDataToAccount: "Save Current Data to Account",
+    cancelAccountSync: "Cancel Account Sync",
     chatAssumed: "",
     proxyAPIKey: "Key/Password",
     proxyRequestModel: "Request Model",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -794,6 +794,7 @@ export const languageKorean = {
     "logout": "로그아웃",
     "loadDataFromAccount": "계정에서 데이터 불러오기",
     "saveCurrentDataToAccount": "계정에 데이터 현재 덮어쓰기",
+    "cancelAccountSync": "계정 연동 취소하기",
     "chatAssumed": "",
     "proxyAPIKey": "키/패스워드",
     "proxyRequestModel": "요청 모델",

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -52,7 +52,7 @@ export class AutoStorage{
 
             const a = accountStorage.getItem('database/database.bin')
             if(a){
-                const sel = await alertSelect([language.loadDataFromAccount, language.saveCurrentDataToAccount])
+                const sel = await alertSelect([language.loadDataFromAccount, language.saveCurrentDataToAccount, language.cancelAccountSync])
                 if(sel === "0"){
                     this.realStorage = accountStorage
                     alertStore.set({
@@ -63,6 +63,13 @@ export class AutoStorage{
                     localStorage.setItem('fallbackRisuToken',JSON.stringify(db.account))
                     this.isAccount = true
                     return true
+                }
+                else if(sel === "2"){
+                    localStorage.setItem('dosync', 'avoid')
+                    if(db?.account){
+                        db.account.useSync = false
+                    }
+                    return false
                 }
             }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

<img width="364" height="293" alt="image" src="https://github.com/user-attachments/assets/33acd229-0b49-4151-a384-0520f4c86715" />

Add third option to checkAccountSync page, **Cancel Account Sync**.

## Description
Actually, users can already cancel account sync by selecting `Save Current Data to Account` and type a random string in the confirm input.
```js
            const confirm = await alertInput(`to overwrite your data, type "RISUAI"`)
            if(confirm !== "RISUAI"){
                localStorage.setItem('dosync', 'avoid')
                return false
            }
```
However, this is a very unfriendly way of doing things. Who would risk overwriting their own data just to cancel account sync?

So, I'd really like to see this PR merged. It would be much more intuitive to have a cancel button rather than telling people who don't want the sync to just overwrite and cancel the data.