### PR TITLE
perf: optimize Lua state writes and lightweight chat access

### DIFF
--- a/src/ts/parser/chatVar.svelte.ts
+++ b/src/ts/parser/chatVar.svelte.ts
@@ -24,12 +24,18 @@ export function getChatVar(key:string): string {
     return state.toString()
 }
 
-export function setChatVar(key:string, value:string): void {
+export function setChatVar(key:string, value:string): boolean {
     const selectedChar = get(selectedCharID)
-    if(!DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate){
-        DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate = {}
+    const chat = DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage]
+    chat.scriptstate ??= {}
+
+    const stateKey = '$' + key
+    if(chat.scriptstate[stateKey] === value){
+        return false
     }
-    DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].scriptstate['$' + key] = value
+
+    chat.scriptstate[stateKey] = value
+    return true
 }
 
 export function getGlobalChatVar(key:string): string {

--- a/src/ts/process/modules.ts
+++ b/src/ts/process/modules.ts
@@ -31,6 +31,12 @@ export interface RisuModule{
     mcp?:MCPModule
 }
 
+export interface ModuleTriggerRuntime {
+    trigger: triggerscript
+    moduleId: string
+    index: number
+}
+
 export async function exportModule(module:RisuModule, arg:{
     alertEnd?:boolean
     saveData?:boolean
@@ -398,16 +404,24 @@ export function getModuleAssets() {
 
 
 export function getModuleTriggers() {
+    return getModuleTriggerRuntimes().map((v) => v.trigger)
+}
+
+export function getModuleTriggerRuntimes(): ModuleTriggerRuntime[] {
     const modules = getModules()
-    let triggers: triggerscript[] = []
+    let triggers: ModuleTriggerRuntime[] = []
     for (const module of modules) {
         if(!module){
             continue
         }
         if (module.trigger) {
-            triggers = triggers.concat(module.trigger.map((t) => {
+            triggers = triggers.concat(module.trigger.map((t, index) => {
                 t.lowLevelAccess = module.lowLevelAccess
-                return t
+                return {
+                    trigger: t,
+                    moduleId: module.id,
+                    index,
+                }
             }))
         }
     }

--- a/src/ts/process/modules.ts
+++ b/src/ts/process/modules.ts
@@ -31,12 +31,6 @@ export interface RisuModule{
     mcp?:MCPModule
 }
 
-export interface ModuleTriggerRuntime {
-    trigger: triggerscript
-    moduleId: string
-    index: number
-}
-
 export async function exportModule(module:RisuModule, arg:{
     alertEnd?:boolean
     saveData?:boolean
@@ -404,24 +398,16 @@ export function getModuleAssets() {
 
 
 export function getModuleTriggers() {
-    return getModuleTriggerRuntimes().map((v) => v.trigger)
-}
-
-export function getModuleTriggerRuntimes(): ModuleTriggerRuntime[] {
     const modules = getModules()
-    let triggers: ModuleTriggerRuntime[] = []
+    let triggers: triggerscript[] = []
     for (const module of modules) {
         if(!module){
             continue
         }
         if (module.trigger) {
-            triggers = triggers.concat(module.trigger.map((t, index) => {
+            triggers = triggers.concat(module.trigger.map((t) => {
                 t.lowLevelAccess = module.lowLevelAccess
-                return {
-                    trigger: t,
-                    moduleId: module.id,
-                    index,
-                }
+                return t
             }))
         }
     }

--- a/src/ts/process/scriptings.test.ts
+++ b/src/ts/process/scriptings.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { beforeAll, expect, test, vi } from 'vitest'
+
+vi.mock('../parser/parser.svelte', () => ({
+  hasher: vi.fn(),
+  risuChatParser: vi.fn(),
+}))
+
+vi.mock('../alert', () => ({
+  alertConfirm: vi.fn(),
+  alertError: vi.fn(),
+  alertInput: vi.fn(),
+  alertNormal: vi.fn(),
+  alertSelect: vi.fn(),
+}))
+
+vi.mock('../globalApi.svelte', () => ({ fetchNative: vi.fn(), readImage: vi.fn() }))
+vi.mock('../tokenizer', () => ({ tokenize: vi.fn() }))
+vi.mock('../util', () => ({
+  asBuffer: vi.fn(),
+  getPersonaPrompt: vi.fn(),
+  getUserIcon: vi.fn(),
+  getUserName: vi.fn(),
+}))
+
+vi.mock('../storage/database.svelte', () => ({
+  getCurrentCharacter: vi.fn(() => ({})),
+  getCurrentChat: vi.fn(() => ({ message: [] })),
+  getDatabase: vi.fn(() => ({ characters: [] })),
+  setDatabase: vi.fn(),
+}))
+
+vi.mock('../stores.svelte', () => ({
+  DBState: { db: {} },
+  ReloadChatPointer: { update: vi.fn() },
+  ReloadGUIPointer: { update: vi.fn() },
+  selectedCharID: { subscribe: (run: (value: number) => void) => (run(0), () => undefined) },
+}))
+
+vi.mock('./modules', () => ({
+  getModuleLorebooks: vi.fn(() => []),
+  getModuleTriggers: vi.fn(() => []),
+}))
+
+vi.mock('./files/inlays', () => ({ getInlayAsset: vi.fn(), writeInlayImage: vi.fn() }))
+vi.mock('./lorebook.svelte', () => ({ loadLoreBookV3Prompt: vi.fn() }))
+vi.mock('./memory/hypamemory', () => ({ HypaProcesser: vi.fn() }))
+vi.mock('./request/request', () => ({ requestChatData: vi.fn() }))
+vi.mock('./stableDiff', () => ({ generateAIImage: vi.fn() }))
+
+let runScripted: typeof import('./scriptings').runScripted
+
+beforeAll(async () => {
+  const jsonLua = await readFile(resolve(process.cwd(), 'public/lua/json.lua'), 'utf8')
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(jsonLua, { status: 200 })))
+  const scriptings = await import('./scriptings')
+  runScripted = scriptings.runScripted
+})
+
+test('does not stop generation when setStateChanged is a no-op', async () => {
+  const result = await runScripted(
+    `
+      function onStart(id)
+        return setStateChanged(id, "unchanged", "value")
+      end
+    `,
+    {
+      char: {} as never,
+      chat: { message: [] } as never,
+      setVar: () => false,
+      getVar: () => 'null',
+      mode: 'start',
+    }
+  )
+
+  expect(result.stopSending).toBe(false)
+  expect(result.res).toBeNull()
+})
+
+test('keeps explicit false as the generation stop signal', async () => {
+  const result = await runScripted('function onStart() return false end', {
+    char: {} as never,
+    chat: { message: [] } as never,
+    mode: 'start',
+  })
+
+  expect(result.res).toBe(false)
+  expect(result.stopSending).toBe(true)
+})

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -111,7 +111,13 @@ export async function runScripted(code:string, arg:{
                 if(!ScriptingSafeIds.has(id) && !ScriptingEditDisplayIds.has(id)){
                     return
                 }
-                return ScriptingEngineState.setVar(key, value)
+                ScriptingEngineState.setVar(key, value)
+            })
+            declareAPI('setChatVarChanged', (id:string,key:string, value:string) => {
+                if(!ScriptingSafeIds.has(id) && !ScriptingEditDisplayIds.has(id)){
+                    return false
+                }
+                return ScriptingEngineState.setVar(key, value) === true
             })
             declareAPI('getGlobalVar', (id:string, key:string) => {
                 return getGlobalChatVar(key)
@@ -1327,7 +1333,12 @@ end
 
 function setState(id, name, value)
     local escapedName = "__"..name
-    return setChatVar(id, escapedName, json.encode(value))
+    setChatVar(id, escapedName, json.encode(value))
+end
+
+function setStateChanged(id, name, value)
+    local escapedName = "__"..name
+    return setChatVarChanged(id, escapedName, json.encode(value))
 end
 
 function async(callback)

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -12,7 +12,7 @@ import { writeInlayImage, getInlayAsset } from "./files/inlays";
 import type { OpenAIChat, MultiModal } from "./index.svelte";
 import { requestChatData, type StreamResponseChunk } from "./request/request";
 import { v4 } from "uuid";
-import { getModuleLorebooks, getModuleTriggers } from "./modules";
+import { getModuleLorebooks, getModuleTriggerRuntimes } from "./modules";
 import { Mutex } from "../mutex";
 import { tokenize } from "../tokenizer";
 import { fetchNative, readImage } from "../globalApi.svelte";
@@ -29,7 +29,7 @@ interface BasicScriptingEngineState {
     code?: string;
     mutex: Mutex;
     chat?: Chat;
-    setVar?: (key:string, value:string) => void,
+    setVar?: (key:string, value:string) => boolean|void,
     getVar?: (key:string) => string,
 }
 
@@ -49,19 +49,11 @@ let ScriptingEngines = new Map<string, ScriptingEngineState>()
 let luaFactoryPromise: Promise<void> | null = null;
 let pendingEngineCreations = new Map<string, Promise<ScriptingEngineState>>();
 
-function hashScriptCode(code: string) {
-    let hash = 0
-    for(let i = 0; i < code.length; i++){
-        hash = Math.imul(31, hash) + code.charCodeAt(i) | 0
-    }
-    return (hash >>> 0).toString(36)
-}
-
 export async function runScripted(code:string, arg:{
     char?:character|groupChat|simpleCharacterArgument,
     chat?:Chat
     data?: string|OpenAIChat[],
-    setVar?: (key:string, value:string) => void,
+    setVar?: (key:string, value:string) => boolean|void,
     getVar?: (key:string) => string,
     lowLevelAccess?: boolean,
     meta?: object,
@@ -76,7 +68,7 @@ export async function runScripted(code:string, arg:{
     const getVar = arg.getVar ?? getChatVar
     const meta = arg.meta ?? {}
     const mode = arg.mode ?? 'manual'
-    const engineKey = arg.engineKey ?? `${type}:${mode}:${hashScriptCode(code)}`
+    const engineKey = arg.engineKey ?? `${type}:${mode}`
 
     let chat = arg.chat ?? getCurrentChat()
     let stopSending = false
@@ -119,7 +111,7 @@ export async function runScripted(code:string, arg:{
                 if(!ScriptingSafeIds.has(id) && !ScriptingEditDisplayIds.has(id)){
                     return
                 }
-                ScriptingEngineState.setVar(key, value)
+                return ScriptingEngineState.setVar(key, value)
             })
             declareAPI('getGlobalVar', (id:string, key:string) => {
                 return getGlobalChatVar(key)
@@ -1335,7 +1327,7 @@ end
 
 function setState(id, name, value)
     local escapedName = "__"..name
-    setChatVar(id, escapedName, json.encode(value))
+    return setChatVar(id, escapedName, json.encode(value))
 end
 
 function async(callback)
@@ -1403,6 +1395,19 @@ ${code}
 `
 }
 
+function getCharacterEngineKey(char:character|simpleCharacterArgument, triggerIndex:number, mode:string) {
+    return `lua:char:${char.chaId}:trigger:${triggerIndex}:${mode}`
+}
+
+function getModuleEngineKey(moduleId:string, triggerIndex:number, mode:string) {
+    return `lua:module:${moduleId}:trigger:${triggerIndex}:${mode}`
+}
+
+type LuaTriggerRuntime = {
+    trigger: triggerscript
+    engineKey: string
+}
+
 export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:character|groupChat|simpleCharacterArgument, mode:string, content:T, meta?:object):Promise<T>{
     switch(mode){
         case 'editinput':
@@ -1421,17 +1426,25 @@ export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:char
     try {
         let data = content
 
-        const triggers = char.type === 'group' ? (getModuleTriggers()) : (char.triggerscript.map((v) => {
-            v.lowLevelAccess = false
-            return v
-        }).concat(getModuleTriggers()))
+        const characterTriggers: LuaTriggerRuntime[] = char.type === 'group' ? [] : (char.triggerscript ?? []).map((trigger, index) => ({
+            trigger: {
+                ...trigger,
+                lowLevelAccess: false,
+            },
+            engineKey: getCharacterEngineKey(char, index, mode),
+        }))
+        const triggers = characterTriggers.concat(getModuleTriggerRuntimes().map((runtime) => ({
+            trigger: runtime.trigger,
+            engineKey: getModuleEngineKey(runtime.moduleId, runtime.index, mode),
+        })))
     
-        for(let trigger of triggers){
-            if(trigger?.effect?.[0]?.type === 'triggerlua'){
-                const runResult = await runScripted(trigger.effect[0].code, {
+        for(let triggerRuntime of triggers){
+            if(triggerRuntime.trigger?.effect?.[0]?.type === 'triggerlua'){
+                const runResult = await runScripted(triggerRuntime.trigger.effect[0].code, {
                     char: char,
                     lowLevelAccess: false,
                     mode: mode,
+                    engineKey: triggerRuntime.engineKey,
                     data,
                     meta,
                 })
@@ -1449,17 +1462,25 @@ export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:char
 export async function runLuaButtonTrigger(char:character|groupChat|simpleCharacterArgument, data:string):Promise<any>{
     let runResult
     try {
-        const triggers = char.type === 'group' ? getModuleTriggers() : char.triggerscript.map<triggerscript>((v) => ({
-            ...v,
-            lowLevelAccess: char.type !== 'simple' ? char.lowLevelAccess ?? false : false
-        })).concat(getModuleTriggers())
+        const characterTriggers: LuaTriggerRuntime[] = char.type === 'group' ? [] : (char.triggerscript ?? []).map((trigger, index) => ({
+            trigger: {
+                ...trigger,
+                lowLevelAccess: char.type !== 'simple' ? char.lowLevelAccess ?? false : false,
+            },
+            engineKey: getCharacterEngineKey(char, index, 'onButtonClick'),
+        }))
+        const triggers = characterTriggers.concat(getModuleTriggerRuntimes().map((runtime) => ({
+            trigger: runtime.trigger,
+            engineKey: getModuleEngineKey(runtime.moduleId, runtime.index, 'onButtonClick'),
+        })))
 
-        for(let trigger of triggers){
-            if(trigger?.effect?.[0]?.type === 'triggerlua'){
-                runResult = await runScripted(trigger.effect[0].code, {
+        for(let triggerRuntime of triggers){
+            if(triggerRuntime.trigger?.effect?.[0]?.type === 'triggerlua'){
+                runResult = await runScripted(triggerRuntime.trigger.effect[0].code, {
                     char: char,
-                    lowLevelAccess: trigger.lowLevelAccess,
+                    lowLevelAccess: triggerRuntime.trigger.lowLevelAccess,
                     mode: 'onButtonClick',
+                    engineKey: triggerRuntime.engineKey,
                     data: data
                 })
             }

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -113,9 +113,11 @@ export async function runScripted(code:string, arg:{
             })
             declareAPI('setChatVarChanged', (id:string,key:string, value:string) => {
                 if(!ScriptingSafeIds.has(id) && !ScriptingEditDisplayIds.has(id)){
-                    return false
+                    return
                 }
-                return ScriptingEngineState.setVar(key, value) === true
+                if(ScriptingEngineState.setVar(key, value) === true){
+                    return true
+                }
             })
             declareAPI('getGlobalVar', (id:string, key:string) => {
                 return getGlobalChatVar(key)

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -49,6 +49,14 @@ let ScriptingEngines = new Map<string, ScriptingEngineState>()
 let luaFactoryPromise: Promise<void> | null = null;
 let pendingEngineCreations = new Map<string, Promise<ScriptingEngineState>>();
 
+function hashScriptCode(code: string) {
+    let hash = 0
+    for(let i = 0; i < code.length; i++){
+        hash = Math.imul(31, hash) + code.charCodeAt(i) | 0
+    }
+    return (hash >>> 0).toString(36)
+}
+
 export async function runScripted(code:string, arg:{
     char?:character|groupChat|simpleCharacterArgument,
     chat?:Chat
@@ -58,6 +66,7 @@ export async function runScripted(code:string, arg:{
     lowLevelAccess?: boolean,
     meta?: object,
     mode?: string,
+    engineKey?: string,
     type?: 'lua'|'py'
 }){
     const type: 'lua'|'py' = arg.type ?? 'lua'
@@ -67,6 +76,7 @@ export async function runScripted(code:string, arg:{
     const getVar = arg.getVar ?? getChatVar
     const meta = arg.meta ?? {}
     const mode = arg.mode ?? 'manual'
+    const engineKey = arg.engineKey ?? `${type}:${mode}:${hashScriptCode(code)}`
 
     let chat = arg.chat ?? getCurrentChat()
     let stopSending = false
@@ -75,7 +85,7 @@ export async function runScripted(code:string, arg:{
     if(type === 'lua'){
         await ensureLuaFactory()
     }
-    let ScriptingEngineState = await getOrCreateEngineState(mode, type);
+    let ScriptingEngineState = await getOrCreateEngineState(engineKey, type);
     
     return await ScriptingEngineState.mutex.runExclusive(async () => {
         ScriptingEngineState.chat = chat
@@ -85,7 +95,7 @@ export async function runScripted(code:string, arg:{
             let declareAPI:(name: string, func:Function) => void
 
             if(ScriptingEngineState.type === 'lua'){
-                console.log('Creating new Lua engine for mode:', mode)
+                console.log('Creating new Lua engine for:', engineKey)
                 ScriptingEngineState.engine?.global.close()
                 ScriptingEngineState.code = code
                 ScriptingEngineState.engine = await luaFactory.createEngine({injectObjects: true})
@@ -95,7 +105,7 @@ export async function runScripted(code:string, arg:{
                 }
             }
             if(ScriptingEngineState.type === 'py'){
-                console.log('Creating new Pyodide context for mode:', mode)
+                console.log('Creating new Pyodide context for:', engineKey)
                 ScriptingEngineState.pyodide?.close()
                 ScriptingEngineState.pyodide = new PyodideContext()
                 declareAPI = (name:string, func:Function) => {
@@ -162,6 +172,27 @@ export async function runScripted(code:string, arg:{
                     time: chat.time ?? 0
                 }
                 return JSON.stringify(data)
+            })
+
+            declareAPI('getChatData', (id:string, index:number) => {
+                const chat = ScriptingEngineState.chat.message.at(index)
+                return chat?.data ?? ''
+            })
+
+            declareAPI('getChatRole', (id:string, index:number) => {
+                const chat = ScriptingEngineState.chat.message.at(index)
+                return chat?.role ?? ''
+            })
+
+            declareAPI('getRecentChatsMain', (id:string, count:number) => {
+                const chats = ScriptingEngineState.chat.message
+                const safeCount = Math.max(0, Math.floor(count || 0))
+                const start = Math.max(0, chats.length - safeCount)
+                return JSON.stringify(chats.slice(start).map((v) => ({
+                    role: v.role,
+                    data: v.data,
+                    time: v.time ?? 0,
+                })))
             })
 
             declareAPI('setChat', (id:string, index:number, value:string) => {
@@ -1225,6 +1256,10 @@ end
 
 function getFullChat(id)
     return json.decode(getFullChatMain(id))
+end
+
+function getRecentChats(id, count)
+    return json.decode(getRecentChatsMain(id, count))
 end
 
 function setFullChat(id, value)

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -12,7 +12,7 @@ import { writeInlayImage, getInlayAsset } from "./files/inlays";
 import type { OpenAIChat, MultiModal } from "./index.svelte";
 import { requestChatData, type StreamResponseChunk } from "./request/request";
 import { v4 } from "uuid";
-import { getModuleLorebooks, getModuleTriggerRuntimes } from "./modules";
+import { getModuleLorebooks, getModuleTriggers } from "./modules";
 import { Mutex } from "../mutex";
 import { tokenize } from "../tokenizer";
 import { fetchNative, readImage } from "../globalApi.svelte";
@@ -58,7 +58,6 @@ export async function runScripted(code:string, arg:{
     lowLevelAccess?: boolean,
     meta?: object,
     mode?: string,
-    engineKey?: string,
     type?: 'lua'|'py'
 }){
     const type: 'lua'|'py' = arg.type ?? 'lua'
@@ -68,7 +67,6 @@ export async function runScripted(code:string, arg:{
     const getVar = arg.getVar ?? getChatVar
     const meta = arg.meta ?? {}
     const mode = arg.mode ?? 'manual'
-    const engineKey = arg.engineKey ?? `${type}:${mode}`
 
     let chat = arg.chat ?? getCurrentChat()
     let stopSending = false
@@ -77,7 +75,7 @@ export async function runScripted(code:string, arg:{
     if(type === 'lua'){
         await ensureLuaFactory()
     }
-    let ScriptingEngineState = await getOrCreateEngineState(engineKey, type);
+    let ScriptingEngineState = await getOrCreateEngineState(mode, type);
     
     return await ScriptingEngineState.mutex.runExclusive(async () => {
         ScriptingEngineState.chat = chat
@@ -87,7 +85,7 @@ export async function runScripted(code:string, arg:{
             let declareAPI:(name: string, func:Function) => void
 
             if(ScriptingEngineState.type === 'lua'){
-                console.log('Creating new Lua engine for:', engineKey)
+                console.log('Creating new Lua engine for mode:', mode)
                 ScriptingEngineState.engine?.global.close()
                 ScriptingEngineState.code = code
                 ScriptingEngineState.engine = await luaFactory.createEngine({injectObjects: true})
@@ -97,7 +95,7 @@ export async function runScripted(code:string, arg:{
                 }
             }
             if(ScriptingEngineState.type === 'py'){
-                console.log('Creating new Pyodide context for:', engineKey)
+                console.log('Creating new Pyodide context for mode:', mode)
                 ScriptingEngineState.pyodide?.close()
                 ScriptingEngineState.pyodide = new PyodideContext()
                 declareAPI = (name:string, func:Function) => {
@@ -1406,19 +1404,6 @@ ${code}
 `
 }
 
-function getCharacterEngineKey(char:character|simpleCharacterArgument, triggerIndex:number, mode:string) {
-    return `lua:char:${char.chaId}:trigger:${triggerIndex}:${mode}`
-}
-
-function getModuleEngineKey(moduleId:string, triggerIndex:number, mode:string) {
-    return `lua:module:${moduleId}:trigger:${triggerIndex}:${mode}`
-}
-
-type LuaTriggerRuntime = {
-    trigger: triggerscript
-    engineKey: string
-}
-
 export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:character|groupChat|simpleCharacterArgument, mode:string, content:T, meta?:object):Promise<T>{
     switch(mode){
         case 'editinput':
@@ -1437,25 +1422,17 @@ export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:char
     try {
         let data = content
 
-        const characterTriggers: LuaTriggerRuntime[] = char.type === 'group' ? [] : (char.triggerscript ?? []).map((trigger, index) => ({
-            trigger: {
-                ...trigger,
-                lowLevelAccess: false,
-            },
-            engineKey: getCharacterEngineKey(char, index, mode),
-        }))
-        const triggers = characterTriggers.concat(getModuleTriggerRuntimes().map((runtime) => ({
-            trigger: runtime.trigger,
-            engineKey: getModuleEngineKey(runtime.moduleId, runtime.index, mode),
-        })))
+        const triggers = char.type === 'group' ? (getModuleTriggers()) : (char.triggerscript.map((v) => {
+            v.lowLevelAccess = false
+            return v
+        }).concat(getModuleTriggers()))
     
-        for(let triggerRuntime of triggers){
-            if(triggerRuntime.trigger?.effect?.[0]?.type === 'triggerlua'){
-                const runResult = await runScripted(triggerRuntime.trigger.effect[0].code, {
+        for(let trigger of triggers){
+            if(trigger?.effect?.[0]?.type === 'triggerlua'){
+                const runResult = await runScripted(trigger.effect[0].code, {
                     char: char,
                     lowLevelAccess: false,
                     mode: mode,
-                    engineKey: triggerRuntime.engineKey,
                     data,
                     meta,
                 })
@@ -1473,25 +1450,17 @@ export async function runLuaEditTrigger<T extends string|OpenAIChat[]>(char:char
 export async function runLuaButtonTrigger(char:character|groupChat|simpleCharacterArgument, data:string):Promise<any>{
     let runResult
     try {
-        const characterTriggers: LuaTriggerRuntime[] = char.type === 'group' ? [] : (char.triggerscript ?? []).map((trigger, index) => ({
-            trigger: {
-                ...trigger,
-                lowLevelAccess: char.type !== 'simple' ? char.lowLevelAccess ?? false : false,
-            },
-            engineKey: getCharacterEngineKey(char, index, 'onButtonClick'),
-        }))
-        const triggers = characterTriggers.concat(getModuleTriggerRuntimes().map((runtime) => ({
-            trigger: runtime.trigger,
-            engineKey: getModuleEngineKey(runtime.moduleId, runtime.index, 'onButtonClick'),
-        })))
+        const triggers = char.type === 'group' ? getModuleTriggers() : char.triggerscript.map<triggerscript>((v) => ({
+            ...v,
+            lowLevelAccess: char.type !== 'simple' ? char.lowLevelAccess ?? false : false
+        })).concat(getModuleTriggers())
 
-        for(let triggerRuntime of triggers){
-            if(triggerRuntime.trigger?.effect?.[0]?.type === 'triggerlua'){
-                runResult = await runScripted(triggerRuntime.trigger.effect[0].code, {
+        for(let trigger of triggers){
+            if(trigger?.effect?.[0]?.type === 'triggerlua'){
+                runResult = await runScripted(trigger.effect[0].code, {
                     char: char,
-                    lowLevelAccess: triggerRuntime.trigger.lowLevelAccess,
+                    lowLevelAccess: trigger.lowLevelAccess,
                     mode: 'onButtonClick',
-                    engineKey: triggerRuntime.engineKey,
                     data: data
                 })
             }

--- a/src/ts/process/triggers.ts
+++ b/src/ts/process/triggers.ts
@@ -1122,13 +1122,13 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
         return null
     }
     
-    function setLocalVar(key: string, value: string, indent: number) {
+    function setLocalVar(key: string, value: string, indent: number): boolean {
         if (!localVarScopes || localVarScopes.length === 0) {
             localVarScopes = [{}]
         }
         const currentScope = localVarScopes[localVarScopes.length - 1]
         if (!currentScope) {
-            return
+            return false
         }
         
         const finalValue = (value === null || value === undefined) ? 'null' : value
@@ -1146,8 +1146,13 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
         if (!currentScope[targetIndent]) {
             currentScope[targetIndent] = {}
         }
+
+        if(currentScope[targetIndent][key] === finalValue){
+            return false
+        }
         
         currentScope[targetIndent][key] = finalValue
+        return true
     }
     
     function declareLocalVar(key: string, value: string, indent: number) {
@@ -1195,27 +1200,35 @@ export async function runTrigger(char:character,mode:triggerMode, arg:{
         return state.toString()
     }
 
-    function setVar(key:string, value:string){
+    function setVar(key:string, value:string): boolean {
         if(arg.displayMode){
+            if(tempVars[key] === value){
+                return false
+            }
             tempVars[key] = value
-            return
+            return true
         }
         
         const localVar = getLocalVar(key)
         if(localVar !== null){
-            setLocalVar(key, value, currentIndent)
-            return
+            return setLocalVar(key, value, currentIndent)
         }
         
         const selectedCharId = get(selectedCharID)
         const currentCharacter = getCurrentCharacter()
         const db = getDatabase()
-        varChanged = true
         chat.scriptstate ??= {}
-        chat.scriptstate['$' + key] = value
+        const stateKey = '$' + key
+        if(chat.scriptstate[stateKey] === value){
+            return false
+        }
+
+        varChanged = true
+        chat.scriptstate[stateKey] = value
         currentChat.scriptstate = chat.scriptstate
         currentCharacter.chats[currentCharacter.chatPage].scriptstate = chat.scriptstate
         db.characters[selectedCharId].chats[currentCharacter.chatPage].scriptstate = chat.scriptstate
+        return true
     }
     
     


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Reduce avoidable Lua scripting work by skipping redundant chat-state writes and adding lightweight chat access APIs. Existing Lua-facing setters keep their no-return behavior for compatibility, while new opt-in APIs expose whether a write changed state.

## Related Issues

None.

## Changes

- Skip `setChatVar` writes when the stored value is already identical.
- Keep the existing Lua-facing `setChatVar` and `setState` APIs no-return for backward compatibility.
- Add `setChatVarChanged` and `setStateChanged` for scripts that explicitly need a changed/skipped result.
- Apply the same changed/skipped behavior to trigger-local, display-mode, and persistent chat state writes.
- Add lightweight `getChatData`, `getChatRole`, and `getRecentChats` APIs as cheaper alternatives to `getFullChat`.

## Impact

This is intended to be backward compatible. Existing Lua APIs remain available with their previous return behavior, and the new APIs are additive. Lua engine caching and lifecycle behavior are unchanged; that work is deferred to #1557.

No model request or response behavior is changed.

## Additional Notes

Validated with `pnpm check`, `git diff --check`, and `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/ts/parser/tests/chatVar.svelte.test.ts`.