### PR TITLE
fix: cbs reverse, setdefaultvar

### DIFF
--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -2121,7 +2121,7 @@ export function registerCBS(arg:CBSRegisterArg) {
     registerFunction({
         name: 'reverse',
         callback: (str, matcherArg, args, vars) => {
-            return [...str].reverse().join('')
+            return [...(args[0] ?? '')].reverse().join('')
         },
         alias: [],
         description: 'Reverses the input string.\n\nUsage:: {{reverse::some_value}}',

--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -846,7 +846,8 @@ export function registerCBS(arg:CBSRegisterArg) {
                 return ''
             }
             if(matcherArg.runVar){
-                if(!getChatVar(args[0])){
+                const currentValue = getChatVar(args[0])
+                if(!currentValue || currentValue === 'null'){
                     setChatVar(args[0], args[1])
                 }
                 return ''

--- a/src/ts/parser/tests/cbs/strings.test.ts
+++ b/src/ts/parser/tests/cbs/strings.test.ts
@@ -147,8 +147,7 @@ test('capitalize, lower, upper', () => {
   )
 })
 
-// FIXME: {{reverse::ABC}} => CBA::esrever
-test.skip('reverse', () => {
+test('reverse', () => {
   const splitByPoints = (str: string) => [...str].reverse().join('')
 
   expect(quickParse('reverse', 'Hello World')).toBe('dlroW olleH')


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

fix cbs reverse, setdefaultvar

## Related Issues

"None".

## Changes

fix cbs reverse, setdefaultvar

## Impact

## Additional Notes
