### PR TITLE
fix: Backup feature Chunk load error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,11 @@ import { initHotkey } from "./ts/hotkey";
 import { preLoadCheck } from "./preload";
 import { mount } from "svelte";
 
+window.addEventListener('vite:preloadError', (event) => {
+    console.error("Chunk load error detected:", event);
+    alert("The server has been updated or the network connection has been lost. Please refresh the page.");
+});
+
 preLoadCheck()
 let app = mount(App, {
     target: document.getElementById("app"),

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -13,6 +13,7 @@ import { v4 as uuidv4, v4 } from 'uuid';
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { get } from "svelte/store";
 import { open } from '@tauri-apps/plugin-shell'
+import streamSaver from 'streamsaver';
 import { setDatabase, type Database, defaultSdDataFunc, getDatabase, appVer, getCurrentCharacter } from "./storage/database.svelte";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { checkRisuUpdate } from "./update";
@@ -1222,7 +1223,6 @@ export class LocalWriter {
             this.writer = new TauriWriter(filePath)
             return true
         }
-        const streamSaver = await import('streamsaver')
         const writableStream = streamSaver.createWriteStream(name + '.' + ext[0])
         this.writer = writableStream.getWriter()
         return true


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary
<img width="949" height="278" alt="image" src="https://github.com/user-attachments/assets/6adff807-43a1-420a-822e-0700ff6656ce" />

Currently, An error occurs when trying to perform a backup after restart the web risu server.
The dynamic import streamsaver package does not work until reload the page because the address changes.

So I changed streamsaver import in LocalWriter to a static import for reliability (prevents backup failures if server restarts).
And added a global handler in main.ts for Vite’s vite:preloadError event. If a dynamic import fails (e.g., after server update), users are alerted that they needs to refresh the page.
There are other dynamic imports remaining, but I'm leaving them as is since they aren't important enough to convert to static.


