### PR TITLE
feat: add GPT-5.5 model support and reasoning / verbosity enhancement

### DIFF
--- a/src/lib/Others/AllSeperateParameters.svelte
+++ b/src/lib/Others/AllSeperateParameters.svelte
@@ -3,6 +3,7 @@
     import Help from "./Help.svelte";
     import { language } from "src/lang";
     import SliderInput from "../UI/GUI/SliderInput.svelte";
+    import SegmentedControl from "../UI/GUI/SegmentedControl.svelte";
     import ClaudeThinkingSeparateParams from "../Setting/Pages/ClaudeThinkingSeparateParams.svelte";
     import type { SeparateParameters } from "src/ts/storage/database.svelte";
     import { downloadFile } from "src/ts/globalApi.svelte";
@@ -35,6 +36,31 @@
     })
     let modelInfo = $derived(getModelInfo(effectiveModel))
     let hasTemperature = $derived(modelInfo.parameters.includes('temperature'))
+    let hasReasoningEffort = $derived(
+        modelInfo.parameters.includes('reasoning_effort') ||
+        modelInfo.parameters.includes('reasoning_effort_min_medium') ||
+        modelInfo.parameters.includes('reasoning_effort_none') ||
+        modelInfo.parameters.includes('reasoning_effort_xhigh')
+    )
+    let reasoningEffortOptions = $derived([
+        ...(!modelInfo.parameters.includes('reasoning_effort_min_medium') ? [{
+            value: -1,
+            label: modelInfo.parameters.includes('reasoning_effort_none') ? 'None' : 'Minimal',
+        }] : []),
+        ...(!modelInfo.parameters.includes('reasoning_effort_min_medium') ? [{ value: 0, label: 'Low' }] : []),
+        { value: 1, label: 'Medium' },
+        { value: 2, label: 'High' },
+        ...(modelInfo.parameters.includes('reasoning_effort_xhigh') ? [{ value: 3, label: 'XHigh' }] : []),
+    ])
+
+    $effect(() => {
+        if (!modelInfo.parameters.includes('reasoning_effort_xhigh') && value.reasoning_effort === 3) {
+            value.reasoning_effort = 2
+        }
+        if (modelInfo.parameters.includes('reasoning_effort_min_medium') && value.reasoning_effort < 1) {
+            value.reasoning_effort = 1
+        }
+    })
 </script>
 
 {#if hasTemperature}
@@ -56,6 +82,10 @@
 <span class="text-textcolor">{language.presensePenalty}</span>
 <SliderInput min={0} max={200} marginBottom step={0.01} fixed={2} bind:value={value.presence_penalty} disableable/>
 <ClaudeThinkingSeparateParams bind:value={value} {paramKey} />
+{#if hasReasoningEffort}
+<span class="text-textcolor">Reasoning Effort</span>
+<SegmentedControl bind:value={value.reasoning_effort} options={reasoningEffortOptions} />
+{/if}
 <span class="text-textcolor">{'Verbosity'}</span>
 <SliderInput min={0} max={2} marginBottom step={1} fixed={0} bind:value={value.verbosity} disableable/>
 

--- a/src/lib/Others/AllSeperateParameters.svelte
+++ b/src/lib/Others/AllSeperateParameters.svelte
@@ -42,6 +42,12 @@
         modelInfo.parameters.includes('reasoning_effort_none') ||
         modelInfo.parameters.includes('reasoning_effort_xhigh')
     )
+    let hasVerbosity = $derived(modelInfo.parameters.includes('verbosity'))
+    const verbosityOptions = [
+        { value: 0, label: 'Low' },
+        { value: 1, label: 'Medium' },
+        { value: 2, label: 'High' },
+    ]
     let reasoningEffortOptions = $derived([
         ...(!modelInfo.parameters.includes('reasoning_effort_min_medium') ? [{
             value: -1,
@@ -54,6 +60,12 @@
     ])
 
     $effect(() => {
+        if (hasVerbosity && value.verbosity === undefined) {
+            value.verbosity = 1
+        }
+        if (hasReasoningEffort && value.reasoning_effort === undefined) {
+            value.reasoning_effort = modelInfo.parameters.includes('reasoning_effort_min_medium') ? 1 : 0
+        }
         if (!modelInfo.parameters.includes('reasoning_effort_xhigh') && value.reasoning_effort === 3) {
             value.reasoning_effort = 2
         }
@@ -86,8 +98,10 @@
 <span class="text-textcolor">Reasoning Effort</span>
 <SegmentedControl bind:value={value.reasoning_effort} options={reasoningEffortOptions} />
 {/if}
+{#if hasVerbosity}
 <span class="text-textcolor">{'Verbosity'}</span>
-<SliderInput min={0} max={2} marginBottom step={1} fixed={0} bind:value={value.verbosity} disableable/>
+<SegmentedControl bind:value={value.verbosity} options={verbosityOptions} />
+{/if}
 
 {#if withImportExport}
     <div class="flex">

--- a/src/lib/Others/AllSeperateParameters.svelte
+++ b/src/lib/Others/AllSeperateParameters.svelte
@@ -60,12 +60,6 @@
     ])
 
     $effect(() => {
-        if (hasVerbosity && value.verbosity === undefined) {
-            value.verbosity = 1
-        }
-        if (hasReasoningEffort && value.reasoning_effort === undefined) {
-            value.reasoning_effort = modelInfo.parameters.includes('reasoning_effort_min_medium') ? 1 : 0
-        }
         if (!modelInfo.parameters.includes('reasoning_effort_xhigh') && value.reasoning_effort === 3) {
             value.reasoning_effort = 2
         }

--- a/src/lib/Setting/Wrappers/SettingSegmented.svelte
+++ b/src/lib/Setting/Wrappers/SettingSegmented.svelte
@@ -25,7 +25,11 @@
     $effect(() => {
         const currentVal = getSettingValue(item, ctx);
         if (processedOptions.length > 0 && currentVal !== undefined && !processedOptions.some(o => o.value === currentVal)) {
-            setSettingValue(item, processedOptions[processedOptions.length - 1].value, ctx);
+            const numericOptions = processedOptions.filter((o): o is { value: number; label: string } => typeof o.value === 'number');
+            const fallback = typeof currentVal === 'number' && numericOptions.length > 0
+                ? numericOptions.reduce((closest, option) => Math.abs(option.value - currentVal) < Math.abs(closest.value - currentVal) ? option : closest).value
+                : processedOptions[processedOptions.length - 1].value;
+            setSettingValue(item, fallback, ctx);
         }
     });
 </script>

--- a/src/ts/model/providers/openai.ts
+++ b/src/ts/model/providers/openai.ts
@@ -1,6 +1,40 @@
-import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, GPT5Parameters, type LLMModel } from '../types'
+import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, GPT5Parameters, GPT5NoneParameters, GPT5XHighParameters, type LLMModel } from '../types'
 
 export const OpenAIModels: LLMModel[] = [
+    // GPT-5.5 (April 2026)
+    {
+        id: 'gpt-5.5',
+        internalID: 'gpt-5.5',
+        name: 'GPT 5.5',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5XHighParameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base,
+        recommended: true
+    },
+    {
+        id: 'gpt-5.5-2026-04-23',
+        internalID: 'gpt-5.5-2026-04-23',
+        name: 'GPT 5.5 (2026-04-23)',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5XHighParameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base
+    },
     // GPT-5.4 (March 2026)
     {
         id: 'gpt-5.4',
@@ -15,7 +49,7 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.hasImageInput,
             LLMFlags.DeveloperRole
         ],
-        parameters: GPT5Parameters,
+        parameters: GPT5XHighParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base,
         recommended: true
     },
@@ -32,7 +66,7 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.hasImageInput,
             LLMFlags.DeveloperRole
         ],
-        parameters: GPT5Parameters,
+        parameters: GPT5XHighParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base
     },
     {
@@ -46,9 +80,10 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.OAICompletionTokens,
             LLMFlags.hasFullSystemPrompt,
             LLMFlags.hasImageInput,
-            LLMFlags.DeveloperRole
+            LLMFlags.DeveloperRole,
+            LLMFlags.noStructuredOutput
         ],
-        parameters: GPT5Parameters,
+        parameters: GPT5XHighParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base
     },
     {
@@ -62,9 +97,10 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.OAICompletionTokens,
             LLMFlags.hasFullSystemPrompt,
             LLMFlags.hasImageInput,
-            LLMFlags.DeveloperRole
+            LLMFlags.DeveloperRole,
+            LLMFlags.noStructuredOutput
         ],
-        parameters: GPT5Parameters,
+        parameters: GPT5XHighParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base
     },
     // GPT-5.2 (December 2025)
@@ -81,7 +117,7 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.hasImageInput,
             LLMFlags.DeveloperRole
         ],
-        parameters: GPT5Parameters,
+        parameters: GPT5XHighParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base,
         recommended: true
     },
@@ -117,7 +153,7 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.hasImageInput,
             LLMFlags.DeveloperRole
         ],
-        parameters: GPT5Parameters,
+        parameters: GPT5NoneParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base,
         recommended: true
     },

--- a/src/ts/model/providers/openai.ts
+++ b/src/ts/model/providers/openai.ts
@@ -1,4 +1,4 @@
-import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, GPT5Parameters, GPT5NoneParameters, GPT5XHighParameters, type LLMModel } from '../types'
+import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, GPT5Parameters, GPT5NoneParameters, GPT5XHighParameters, GPT5ProParameters, type LLMModel } from '../types'
 
 export const OpenAIModels: LLMModel[] = [
     // GPT-5.5 (April 2026)
@@ -83,7 +83,7 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.DeveloperRole,
             LLMFlags.noStructuredOutput
         ],
-        parameters: GPT5XHighParameters,
+        parameters: GPT5ProParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base
     },
     {
@@ -100,7 +100,7 @@ export const OpenAIModels: LLMModel[] = [
             LLMFlags.DeveloperRole,
             LLMFlags.noStructuredOutput
         ],
-        parameters: GPT5XHighParameters,
+        parameters: GPT5ProParameters,
         tokenizer: LLMTokenizer.tiktokenO200Base
     },
     // GPT-5.2 (December 2025)

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -25,7 +25,8 @@ export const LLMFlags = {
     claudeThinking: 21,
     claudeAdaptiveThinking: 22,
     claudeXHighEffort: 23,
-    deepSeekThinkingToggle: 24
+    deepSeekThinkingToggle: 24,
+    noStructuredOutput: 25
 } as const;
 export type LLMFlags = (typeof LLMFlags)[keyof typeof LLMFlags];
 
@@ -137,4 +138,6 @@ export const ProviderNames = new Map<LLMProvider, string>([
 
 export const OpenAIParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty']
 export const GPT5Parameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort','verbosity']
+export const GPT5NoneParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort_none','verbosity']
+export const GPT5XHighParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort_none_xhigh','verbosity']
 export const ClaudeParameters:LLMParameter[] = ['temperature', 'top_k', 'top_p']

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -138,6 +138,7 @@ export const ProviderNames = new Map<LLMProvider, string>([
 
 export const OpenAIParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty']
 export const GPT5Parameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort','verbosity']
-export const GPT5NoneParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort_none','verbosity']
-export const GPT5XHighParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort_none_xhigh','verbosity']
+export const GPT5NoneParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort', 'reasoning_effort_none','verbosity']
+export const GPT5XHighParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort', 'reasoning_effort_none', 'reasoning_effort_xhigh','verbosity']
+export const GPT5ProParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort', 'reasoning_effort_min_medium', 'reasoning_effort_xhigh','verbosity']
 export const ClaudeParameters:LLMParameter[] = ['temperature', 'top_k', 'top_p']

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -137,8 +137,9 @@ export const ProviderNames = new Map<LLMProvider, string>([
 ])
 
 export const OpenAIParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty']
-export const GPT5Parameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort','verbosity']
-export const GPT5NoneParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort', 'reasoning_effort_none','verbosity']
-export const GPT5XHighParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort', 'reasoning_effort_none', 'reasoning_effort_xhigh','verbosity']
-export const GPT5ProParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort', 'reasoning_effort_min_medium', 'reasoning_effort_xhigh','verbosity']
+const GPT5BaseParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'reasoning_effort', 'verbosity']
+export const GPT5Parameters:LLMParameter[] = [...GPT5BaseParameters]
+export const GPT5NoneParameters:LLMParameter[] = [...GPT5BaseParameters, 'reasoning_effort_none']
+export const GPT5XHighParameters:LLMParameter[] = [...GPT5NoneParameters, 'reasoning_effort_xhigh']
+export const GPT5ProParameters:LLMParameter[] = [...GPT5BaseParameters, 'reasoning_effort_min_medium', 'reasoning_effort_xhigh']
 export const ClaudeParameters:LLMParameter[] = ['temperature', 'top_k', 'top_p']

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -408,7 +408,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         body.seed = db.generationSeed
     }
 
-    if(db.jsonSchemaEnabled || arg.schema){
+    if((db.jsonSchemaEnabled || arg.schema) && !arg.modelInfo.flags.includes(LLMFlags.noStructuredOutput)){
         body.response_format = {
             "type": "json_schema",
             "json_schema": getOpenAIJSONSchema(arg.schema)

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -19,6 +19,16 @@ export type LLMParameter =
 
 export type ModelModeExtended = 'model' | 'submodel' | 'memory' | 'emotion' | 'otherAx' | 'translate'
 
+const reasoningCapabilityParameters: LLMParameter[] = [
+    'reasoning_effort_min_medium',
+    'reasoning_effort_none',
+    'reasoning_effort_xhigh',
+]
+
+function isReasoningCapabilityParameter(parameter: LLMParameter): boolean {
+    return reasoningCapabilityParameters.includes(parameter)
+}
+
 export function setObjectValue<T>(obj: T, key: string, value: any): T {
     const splitKey = key.split('.')
     if (splitKey.length > 1) {
@@ -135,6 +145,9 @@ export function applyParameters(
     },
 ): Record<string, any> {
     const db = getDatabase()
+    const reasoningDisabledEffort = parameters.includes('reasoning_effort_none') ? 'none' : 'minimal'
+    const reasoningMinEffort = parameters.includes('reasoning_effort_min_medium') ? 'medium' : 'low'
+    const supportsXHighReasoning = parameters.includes('reasoning_effort_xhigh')
 
     function getEffort(effort: number, disabledEffort: 'minimal' | 'none' = 'minimal', supportsXHigh = false, minEffort: 'low' | 'medium' = 'low') {
         switch (effort) {
@@ -160,20 +173,7 @@ export function applyParameters(
     }
 
     function getVerbosity(verbosity: number) {
-        switch (verbosity) {
-            case 0: {
-                return 'low'
-            }
-            case 1: {
-                return 'medium'
-            }
-            case 2: {
-                return 'high'
-            }
-            default: {
-                return 'medium'
-            }
-        }
+        return ['low', 'medium', 'high'][verbosity] ?? 'medium'
     }
 
     if (db.seperateParametersEnabled && (modelMode !== 'model' || db.seperateParametersByModel)) {
@@ -191,6 +191,9 @@ export function applyParameters(
 
         for (const parameter of parameters) {
             let value: number | string = 0
+            if (isReasoningCapabilityParameter(parameter)) {
+                continue
+            }
             if (parameter === 'top_k' && arg.ignoreTopKIfZero && sepParams[parameter] === 0) {
                 continue
             }
@@ -244,16 +247,12 @@ export function applyParameters(
                 case 'reasoning_effort': {
                     value = getEffort(
                         sepParams.reasoning_effort,
-                        parameters.includes('reasoning_effort_none') ? 'none' : 'minimal',
-                        parameters.includes('reasoning_effort_xhigh'),
-                        parameters.includes('reasoning_effort_min_medium') ? 'medium' : 'low'
+                        reasoningDisabledEffort,
+                        supportsXHighReasoning,
+                        reasoningMinEffort
                     )
                     break
                 }
-                case 'reasoning_effort_none':
-                case 'reasoning_effort_min_medium':
-                case 'reasoning_effort_xhigh':
-                    continue
                 case 'verbosity': {
                     value = getVerbosity(sepParams.verbosity)
                     break
@@ -276,6 +275,9 @@ export function applyParameters(
 
     for (const parameter of parameters) {
         let value: number | string = 0
+        if (isReasoningCapabilityParameter(parameter)) {
+            continue
+        }
         if (parameter === 'top_k' && arg.ignoreTopKIfZero && db.top_k === 0) {
             continue
         }
@@ -307,16 +309,12 @@ export function applyParameters(
             case 'reasoning_effort': {
                 value = getEffort(
                     db.reasoningEffort,
-                    parameters.includes('reasoning_effort_none') ? 'none' : 'minimal',
-                    parameters.includes('reasoning_effort_xhigh'),
-                    parameters.includes('reasoning_effort_min_medium') ? 'medium' : 'low'
+                    reasoningDisabledEffort,
+                    supportsXHighReasoning,
+                    reasoningMinEffort
                 )
                 break
             }
-            case 'reasoning_effort_none':
-            case 'reasoning_effort_min_medium':
-            case 'reasoning_effort_xhigh':
-                continue
             case 'verbosity': {
                 value = getVerbosity(db.verbosity)
                 break

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -11,6 +11,8 @@ export type LLMParameter =
     | 'frequency_penalty'
     | 'presence_penalty'
     | 'reasoning_effort'
+    | 'reasoning_effort_none'
+    | 'reasoning_effort_none_xhigh'
     | 'thinking_tokens'
     | 'verbosity'
 
@@ -133,10 +135,10 @@ export function applyParameters(
 ): Record<string, any> {
     const db = getDatabase()
 
-    function getEffort(effort: number) {
+    function getEffort(effort: number, disabledEffort: 'minimal' | 'none' = 'minimal') {
         switch (effort) {
             case -1: {
-                return 'minimal'
+                return disabledEffort
             }
             case 0: {
                 return 'low'
@@ -146,6 +148,9 @@ export function applyParameters(
             }
             case 2: {
                 return 'high'
+            }
+            case 3: {
+                return 'xhigh'
             }
             default: {
                 return 'medium'
@@ -239,6 +244,11 @@ export function applyParameters(
                     value = getEffort(sepParams.reasoning_effort)
                     break
                 }
+                case 'reasoning_effort_none':
+                case 'reasoning_effort_none_xhigh': {
+                    value = getEffort(sepParams.reasoning_effort, 'none')
+                    break
+                }
                 case 'verbosity': {
                     value = getVerbosity(sepParams.verbosity)
                     break
@@ -254,7 +264,11 @@ export function applyParameters(
                 continue
             }
 
-            data = setObjectValue(data, rename[parameter] ?? parameter, value)
+            const targetParameter = 
+                (parameter === 'reasoning_effort_none' || parameter === 'reasoning_effort_none_xhigh')
+                ? 'reasoning_effort'
+                : parameter
+            data = setObjectValue(data, rename[parameter] ?? targetParameter, value)
         }
         return data
     }
@@ -293,6 +307,11 @@ export function applyParameters(
                 value = getEffort(db.reasoningEffort)
                 break
             }
+            case 'reasoning_effort_none':
+            case 'reasoning_effort_none_xhigh': {
+                value = getEffort(db.reasoningEffort, 'none')
+                break
+            }
             case 'verbosity': {
                 value = getVerbosity(db.verbosity)
                 break
@@ -315,7 +334,11 @@ export function applyParameters(
             continue
         }
 
-        data = setObjectValue(data, rename[parameter] ?? parameter, value)
+        const targetParameter = 
+            (parameter === 'reasoning_effort_none' || parameter === 'reasoning_effort_none_xhigh')
+            ? 'reasoning_effort'
+            : parameter
+        data = setObjectValue(data, rename[parameter] ?? targetParameter, value)
     }
     return data
 }

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -11,8 +11,9 @@ export type LLMParameter =
     | 'frequency_penalty'
     | 'presence_penalty'
     | 'reasoning_effort'
+    | 'reasoning_effort_min_medium'
     | 'reasoning_effort_none'
-    | 'reasoning_effort_none_xhigh'
+    | 'reasoning_effort_xhigh'
     | 'thinking_tokens'
     | 'verbosity'
 
@@ -135,13 +136,13 @@ export function applyParameters(
 ): Record<string, any> {
     const db = getDatabase()
 
-    function getEffort(effort: number, disabledEffort: 'minimal' | 'none' = 'minimal') {
+    function getEffort(effort: number, disabledEffort: 'minimal' | 'none' = 'minimal', supportsXHigh = false, minEffort: 'low' | 'medium' = 'low') {
         switch (effort) {
             case -1: {
                 return disabledEffort
             }
             case 0: {
-                return 'low'
+                return minEffort
             }
             case 1: {
                 return 'medium'
@@ -150,7 +151,7 @@ export function applyParameters(
                 return 'high'
             }
             case 3: {
-                return 'xhigh'
+                return supportsXHigh ? 'xhigh' : 'high'
             }
             default: {
                 return 'medium'
@@ -241,14 +242,18 @@ export function applyParameters(
                     break
                 }
                 case 'reasoning_effort': {
-                    value = getEffort(sepParams.reasoning_effort)
+                    value = getEffort(
+                        sepParams.reasoning_effort,
+                        parameters.includes('reasoning_effort_none') ? 'none' : 'minimal',
+                        parameters.includes('reasoning_effort_xhigh'),
+                        parameters.includes('reasoning_effort_min_medium') ? 'medium' : 'low'
+                    )
                     break
                 }
                 case 'reasoning_effort_none':
-                case 'reasoning_effort_none_xhigh': {
-                    value = getEffort(sepParams.reasoning_effort, 'none')
-                    break
-                }
+                case 'reasoning_effort_min_medium':
+                case 'reasoning_effort_xhigh':
+                    continue
                 case 'verbosity': {
                     value = getVerbosity(sepParams.verbosity)
                     break
@@ -264,11 +269,7 @@ export function applyParameters(
                 continue
             }
 
-            const targetParameter = 
-                (parameter === 'reasoning_effort_none' || parameter === 'reasoning_effort_none_xhigh')
-                ? 'reasoning_effort'
-                : parameter
-            data = setObjectValue(data, rename[parameter] ?? targetParameter, value)
+            data = setObjectValue(data, rename[parameter] ?? parameter, value)
         }
         return data
     }
@@ -304,14 +305,18 @@ export function applyParameters(
                 break
             }
             case 'reasoning_effort': {
-                value = getEffort(db.reasoningEffort)
+                value = getEffort(
+                    db.reasoningEffort,
+                    parameters.includes('reasoning_effort_none') ? 'none' : 'minimal',
+                    parameters.includes('reasoning_effort_xhigh'),
+                    parameters.includes('reasoning_effort_min_medium') ? 'medium' : 'low'
+                )
                 break
             }
             case 'reasoning_effort_none':
-            case 'reasoning_effort_none_xhigh': {
-                value = getEffort(db.reasoningEffort, 'none')
-                break
-            }
+            case 'reasoning_effort_min_medium':
+            case 'reasoning_effort_xhigh':
+                continue
             case 'verbosity': {
                 value = getVerbosity(db.verbosity)
                 break
@@ -334,11 +339,7 @@ export function applyParameters(
             continue
         }
 
-        const targetParameter = 
-            (parameter === 'reasoning_effort_none' || parameter === 'reasoning_effort_none_xhigh')
-            ? 'reasoning_effort'
-            : parameter
-        data = setObjectValue(data, rename[parameter] ?? targetParameter, value)
+        data = setObjectValue(data, rename[parameter] ?? parameter, value)
     }
     return data
 }

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -270,7 +270,9 @@ export const modelSpecificParameterItems: SettingItem[] = [
         type: 'slider',
         fallbackLabel: 'Reasoning Effort',
         bindKey: 'reasoningEffort',
-        condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort'),
+        condition: (ctx) =>
+            ctx.modelInfo.parameters.includes('reasoning_effort') ||
+            ctx.modelInfo.parameters.includes('reasoning_effort_none'),
         options: {
             min: -1,
             max: 2,
@@ -279,6 +281,21 @@ export const modelSpecificParameterItems: SettingItem[] = [
             disableable: true,
         },
         keywords: ['reasoning', 'effort'],
+    },
+    {
+        id: 'params.reasoningEffortXHigh',
+        type: 'slider',
+        fallbackLabel: 'Reasoning Effort',
+        bindKey: 'reasoningEffort',
+        condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_none_xhigh'),
+        options: {
+            min: -1,
+            max: 3,
+            step: 1,
+            fixed: 0,
+            disableable: true,
+        },
+        keywords: ['reasoning', 'effort', 'xhigh'],
     },
     {
         id: 'params.verbosity',
@@ -318,6 +335,7 @@ export const allBasicParameterItems: SettingItem[] = [
     modelSpecificParameterItems.find(i => i.id === 'params.topA')!,
     modelSpecificParameterItems.find(i => i.id === 'params.repetitionPenalty')!,
     modelSpecificParameterItems.find(i => i.id === 'params.reasoningEffort')!,
+    modelSpecificParameterItems.find(i => i.id === 'params.reasoningEffortXHigh')!,
     modelSpecificParameterItems.find(i => i.id === 'params.verbosity')!,
     penaltyParameterItems.find(i => i.id === 'params.topP')!,
     penaltyParameterItems.find(i => i.id === 'params.frequencyPenalty')!,

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -289,16 +289,16 @@ export const modelSpecificParameterItems: SettingItem[] = [
     },
     {
         id: 'params.verbosity',
-        type: 'slider',
+        type: 'segmented',
         fallbackLabel: 'Verbosity',
         bindKey: 'verbosity',
         condition: (ctx) => ctx.modelInfo.parameters.includes('verbosity'),
         options: {
-            min: 0,
-            max: 2,
-            step: 1,
-            fixed: 0,
-            disableable: true,
+            segmentOptions: [
+                { value: 0, label: 'Low' },
+                { value: 1, label: 'Medium' },
+                { value: 2, label: 'High' },
+            ]
         },
         keywords: ['verbosity', 'length'],
     },

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -267,33 +267,23 @@ export const modelSpecificParameterItems: SettingItem[] = [
     },
     {
         id: 'params.reasoningEffort',
-        type: 'slider',
+        type: 'segmented',
         fallbackLabel: 'Reasoning Effort',
         bindKey: 'reasoningEffort',
         condition: (ctx) =>
             ctx.modelInfo.parameters.includes('reasoning_effort') ||
-            ctx.modelInfo.parameters.includes('reasoning_effort_none'),
+            ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') ||
+            ctx.modelInfo.parameters.includes('reasoning_effort_none') ||
+            ctx.modelInfo.parameters.includes('reasoning_effort_xhigh'),
         options: {
-            min: -1,
-            max: 2,
-            step: 1,
-            fixed: 0,
-            disableable: true,
-        },
-        keywords: ['reasoning', 'effort'],
-    },
-    {
-        id: 'params.reasoningEffortXHigh',
-        type: 'slider',
-        fallbackLabel: 'Reasoning Effort',
-        bindKey: 'reasoningEffort',
-        condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_none_xhigh'),
-        options: {
-            min: -1,
-            max: 3,
-            step: 1,
-            fixed: 0,
-            disableable: true,
+            segmentOptions: [
+                { value: -1, label: 'Minimal', condition: (ctx) => !ctx.modelInfo.parameters.includes('reasoning_effort_none') && !ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') },
+                { value: -1, label: 'None', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_none') },
+                { value: 0, label: 'Low', condition: (ctx) => !ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') },
+                { value: 1, label: 'Medium' },
+                { value: 2, label: 'High' },
+                { value: 3, label: 'XHigh', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_xhigh') },
+            ]
         },
         keywords: ['reasoning', 'effort', 'xhigh'],
     },
@@ -335,7 +325,6 @@ export const allBasicParameterItems: SettingItem[] = [
     modelSpecificParameterItems.find(i => i.id === 'params.topA')!,
     modelSpecificParameterItems.find(i => i.id === 'params.repetitionPenalty')!,
     modelSpecificParameterItems.find(i => i.id === 'params.reasoningEffort')!,
-    modelSpecificParameterItems.find(i => i.id === 'params.reasoningEffortXHigh')!,
     modelSpecificParameterItems.find(i => i.id === 'params.verbosity')!,
     penaltyParameterItems.find(i => i.id === 'params.topP')!,
     penaltyParameterItems.find(i => i.id === 'params.frequencyPenalty')!,

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -574,6 +574,7 @@ export function setDatabase(data:Database){
     data.showPromptComparison ??= false
     data.OaiCompAPIKeys ??= {}
     data.reasoningEffort ??= 0
+    data.verbosity ??= 1
     data.hypaV3Presets ??= [
         createHypaV3Preset("Default", {
             summarizationPrompt: data.supaMemoryPrompt ? data.supaMemoryPrompt : "",


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add GPT-5.5 model entries and update GPT-5 reasoning/verbosity parameter handling.

## Related Issues

None.

## Changes

- Added `gpt-5.5` and `gpt-5.5-2026-04-23` to the OpenAI model list.
- Added GPT-5 parameter capability markers for `none`, `xhigh`, and minimum-medium reasoning effort support.
- Updated reasoning effort and verbosity settings from sliders to segmented controls.
- Clamped invalid reasoning effort values when switching between models with different capabilities.
- Added a `noStructuredOutput` model flag and skipped JSON schema response formatting for flagged models.
- Added a default verbosity value during database initialization.

## Impact

This enables selecting GPT-5.5 and exposes model-specific reasoning options more accurately. Existing GPT-5 model settings may be adjusted to the nearest supported value when a selected model does not support the current reasoning effort. (`xhigh` -> `high`, `none` / `low` -> `mid`)

Internally, this feature still uses integer-based value mapping.

## Demo

### GPT-5.2 ~ GPT-5.5
<img width="387" height="244" alt="image" src="https://github.com/user-attachments/assets/c999b6e5-a01e-4171-befb-4584f87b02e2" />

### GPT-5.1
<img width="302" height="173" alt="image" src="https://github.com/user-attachments/assets/e264a313-4258-4564-8b0f-b6b259dbf7e6" />

### GPT-5
<img width="313" height="173" alt="image" src="https://github.com/user-attachments/assets/4e168da1-11c8-4697-9b5b-4d96bb982aa2" />

### GPT-5.4 Pro
<img width="244" height="173" alt="image" src="https://github.com/user-attachments/assets/ecb68c5e-10ec-4485-8f07-e9255a45186f" />