### PR TITLE
feat: add Claude Opus 4.8 model

### DIFF
--- a/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
+++ b/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
@@ -163,6 +163,7 @@
                 {@render CustomFlagButton(index,'noCivilIntegrity', 20)}
                 {@render CustomFlagButton(index,'claudeThinking', 21)}
                 {@render CustomFlagButton(index,'claudeAdaptiveThinking', 22)}
+                {@render CustomFlagButton(index,'claudeXHighEffort', 23)}
                 {@render CustomFlagButton(index,'deepSeekThinkingToggle', 24)}
             </Accordion>
                 </div>

--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -767,6 +767,7 @@
             {@render CustomFlagButton('noCivilIntegrity', 20)}
             {@render CustomFlagButton('claudeThinking', 21)}
             {@render CustomFlagButton('claudeAdaptiveThinking', 22)}
+            {@render CustomFlagButton('claudeXHighEffort', 23)}
             {@render CustomFlagButton('deepSeekThinkingToggle', 24)}
 
         {/if}

--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -45,19 +45,6 @@ export const LLMModels: LLMModel[] = [
     ...AnthropicModels,
     // AWS Bedrock Claude models
     {
-        name: "Claude 4.7 Opus",
-        id: 'anthropic.claude-opus-4-7',
-        provider: LLMProvider.AWS,
-        format: LLMFormat.AWSBedrockClaude,
-        flags: [
-            LLMFlags.hasImageInput,
-            LLMFlags.hasFirstSystemPrompt,
-            LLMFlags.claudeAdaptiveThinking
-        ],
-        parameters: [],
-        tokenizer: LLMTokenizer.Claude,
-    },
-    {
         name: "Claude 4.6 Opus v1",
         id: 'anthropic.claude-opus-4-6-v1',
         provider: LLMProvider.AWS,

--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -45,6 +45,19 @@ export const LLMModels: LLMModel[] = [
     ...AnthropicModels,
     // AWS Bedrock Claude models
     {
+        name: "Claude 4.7 Opus",
+        id: 'anthropic.claude-opus-4-7',
+        provider: LLMProvider.AWS,
+        format: LLMFormat.AWSBedrockClaude,
+        flags: [
+            LLMFlags.hasImageInput,
+            LLMFlags.hasFirstSystemPrompt,
+            LLMFlags.claudeAdaptiveThinking
+        ],
+        parameters: [],
+        tokenizer: LLMTokenizer.Claude,
+    },
+    {
         name: "Claude 4.6 Opus v1",
         id: 'anthropic.claude-opus-4-6-v1',
         provider: LLMProvider.AWS,

--- a/src/ts/model/providers/anthropic.ts
+++ b/src/ts/model/providers/anthropic.ts
@@ -2,6 +2,25 @@ import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, ClaudeParameters, type 
 
 export const AnthropicModels: LLMModel[] = [
 
+    // Claude 4.8 (No Date)
+    {
+        name: "Claude 4.8 Opus",
+        id: 'claude-opus-4-8',
+        shortName: "4.8 Opus",
+        provider: LLMProvider.Anthropic,
+        format: LLMFormat.Anthropic,
+        flags: [
+            LLMFlags.hasImageInput,
+            LLMFlags.hasFirstSystemPrompt,
+            LLMFlags.hasStreaming,
+            LLMFlags.claudeAdaptiveThinking,
+            LLMFlags.claudeXHighEffort
+        ],
+        parameters: [],
+        tokenizer: LLMTokenizer.Claude,
+        recommended: true
+    },
+
     // Claude 4.7 (No Date)
     {
         name: "Claude 4.7 Opus",


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add Claude Opus 4.8 to the Anthropic model list and add the current AWS Bedrock Claude Opus 4.7 model ID.

## Related Issues

None.

## Changes

- Add `claude-opus-4-8` as a recommended Anthropic model.
- Configure Opus 4.8 with adaptive thinking and `xhigh` effort support.
- Omit unsupported sampling parameters for Opus 4.8.
- Expose the `claudeXHighEffort` custom flag in model settings.

## Impact

Users can select Claude Opus 4.8 through the RisuAI Official Anthropic API implementation. Existing models are unchanged.

## Additional notes

Manually tested with streaming on / off and various thinking settings.