### PR TITLE
fix: handle Tauri cold storage path and remote persistence

### DIFF
--- a/src/ts/process/coldstorage.svelte.ts
+++ b/src/ts/process/coldstorage.svelte.ts
@@ -2,12 +2,11 @@ import {
     writeFile,
     BaseDirectory,
     readFile,
-    exists,
     mkdir,
     remove,
     readDir
 } from "@tauri-apps/plugin-fs"
-import { forageStorage } from "../globalApi.svelte"
+import { forageStorage, requiresFullEncoderReload } from "../globalApi.svelte"
 import { isTauri, isNodeServer } from "src/ts/platform"
 import { DBState } from "../stores.svelte"
 import type { NodeStorage } from "../storage/nodeStorage"
@@ -145,9 +144,7 @@ export async function setColdStorageItem(key:string, value:any):Promise<boolean>
 
     else if(isTauri){
         try {
-            if(!(await exists('./coldstorage'))){
-                await mkdir('./coldstorage', { recursive: true, baseDir: BaseDirectory.AppData })
-            }
+            await mkdir('./coldstorage', { recursive: true, baseDir: BaseDirectory.AppData })
             await writeFile('./coldstorage/'+key+'.json', compressed, { baseDir: BaseDirectory.AppData })
             return true
         } catch (error) {
@@ -267,7 +264,7 @@ async function removeColdStorageItems(keys:string[]) {
     else if(isTauri){
         try {
             for(let i=0;i<keys.length;i++){
-                await remove('./coldstorage/'+keys[i]+'.json')
+                await remove('./coldstorage/'+keys[i]+'.json', { baseDir: BaseDirectory.AppData })
             }
         } catch (error) {
             console.error(error)
@@ -305,7 +302,7 @@ export async function listColdDataKeys(): Promise<string[]> {
     return keys
 }
 
-async function makeColdDataForCharacter(i:number, coldTime:number){
+async function makeColdDataForCharacter(i:number, coldTime:number): Promise<boolean>{
     const lastInteraction = DBState.db.characters[i].lastInteraction ?? Date.now()
     if(lastInteraction < coldTime && !DBState.db.characters[i].coldstorage){
         console.log(`Character ${DBState.db.characters[i].name ?? i} has not been interacted with since ${new Date(lastInteraction).toLocaleDateString()}, moving to cold storage`)
@@ -316,13 +313,13 @@ async function makeColdDataForCharacter(i:number, coldTime:number){
 
         if(!writeSuccess){
             console.error(`Cold storage write failed for character ${i}, keeping original data`)
-            return
+            return false
         }
 
         const verifyData = await getColdStorageItem(id)
         if(!verifyData || (!Array.isArray(verifyData) && !verifyData.character)){
             console.error(`Cold storage verification failed for character ${DBState.db.characters[i].chaId ?? i}, keeping original data`, verifyData)
-            return
+            return false
         }
 
         //get cold storaged chats in this character
@@ -359,27 +356,30 @@ async function makeColdDataForCharacter(i:number, coldTime:number){
         } as any
 
         DBState.db.characters[i] = coldCharacter
+        return true
     }
+
+    return false
 }
 
-async function makeColdDataForChat(i:number, j:number, coldTime:number){
+async function makeColdDataForChat(i:number, j:number, coldTime:number): Promise<boolean>{
     
     const chat = DBState.db.characters[i].chats[j]
     let greatestTime = chat.lastDate ?? 0
 
     if(chat.message.length < 4){
         //it is inefficient to store small data
-        return
+        return false
     }
 
     if(chat.message?.[0]?.data?.startsWith(coldStorageHeader)){
         //already cold storage
-        return
+        return false
     }
 
     if(DBState.db.characters[i].coldstorage){
         //character is in cold storage, no need to cold storage individual chats
-        return
+        return false
     }
 
 
@@ -408,7 +408,7 @@ async function makeColdDataForChat(i:number, j:number, coldTime:number){
         if(!writeSuccess){
             console.error(`Cold storage write failed for chat ${chat.id ?? j} in character ${i}, keeping original data`)
             alertError(language.errors.coldStorageWriteFailed)
-            return
+            return false
         }
 
         // Verify the data can be read back before replacing
@@ -416,7 +416,7 @@ async function makeColdDataForChat(i:number, j:number, coldTime:number){
         if(!verifyData || (!Array.isArray(verifyData) && !verifyData.message)){
             console.error(`Cold storage verification failed for chat ${chat.id ?? j}, keeping original data`)
             alertError(language.errors.coldStorageVerifyFailed)
-            return
+            return false
         }
 
         chat.message = [{
@@ -434,9 +434,11 @@ async function makeColdDataForChat(i:number, j:number, coldTime:number){
         }
         chat.scriptstate = {}
         chat.localLore = []
-
+        
+        return true
     }
 
+    return false
 }
 
 export async function makeColdData(){
@@ -447,7 +449,8 @@ export async function makeColdData(){
 
     const currentTime = Date.now()
     const coldTime = currentTime - 1000 * 60 * 60 * 24 * 10 //10 days before now
-    const queue:Function[] = []
+    const queue:(() => Promise<boolean>)[] = []
+    let didChange = false
     for(let i=0;i<DBState.db.characters.length;i++){
         queue.push(() => makeColdDataForCharacter(i, coldTime))
     }
@@ -455,7 +458,11 @@ export async function makeColdData(){
     while(queue.length > 0){
         const batch = queue.splice(0, 5) //process 5 at a time to avoid blocking
         alertWait(`Creating character cold storage data... ${queue.length} items left`)
-        await Promise.all(batch.map(fn => fn()))
+        const results = await Promise.all(batch.map(fn => fn()))
+
+        if(results.some(Boolean)){
+            didChange = true
+        }
     }
 
     for(let i=0;i<DBState.db.characters.length;i++){
@@ -467,7 +474,15 @@ export async function makeColdData(){
     while(queue.length > 0){
         const batch = queue.splice(0, 5) //process 5 at a time to avoid blocking
         alertWait(`Creating chat cold storage data... ${queue.length} items left`)
-        await Promise.all(batch.map(fn => fn()))
+        const results = await Promise.all(batch.map(fn => fn()))
+
+        if(results.some(Boolean)){
+            didChange = true
+        }
+    }
+
+    if(didChange){
+        requiresFullEncoderReload.state = true
     }
     
     alertClear()


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - Updated internal helper return types to `Promise<boolean>`. No new public type definitions were needed.
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Tauri cold storage의 AppData 경로 처리와 local remote character block persistence 문제를 수정합니다.

This PR fixes Tauri cold storage AppData path handling and local remote character block persistence.

## Related Issues

None.

## Changes

### 한국어

* Tauri cold storage 저장 시 `exists('./coldstorage')`에 의존하지 않고, `mkdir('./coldstorage', { recursive: true, baseDir: BaseDirectory.AppData })`를 항상 호출하도록 변경했습니다.
* Tauri cold storage cleanup에서 `remove()` 호출에도 `BaseDirectory.AppData`를 추가했습니다.
* cold storage 변환으로 캐릭터 또는 채팅이 실제로 변경되었는지 추적하기 위해 `makeColdDataForCharacter()`와 `makeColdDataForChat()`이 `Promise<boolean>`을 반환하도록 변경했습니다.
* 실제 cold storage 변환이 발생한 경우 `requiresFullEncoderReload.state = true`를 설정하여 다음 저장 시 local remote character blocks가 다시 기록되도록 했습니다.

### English

* Removed reliance on `exists('./coldstorage')` in the Tauri cold storage writer and always create the directory with `mkdir('./coldstorage', { recursive: true, baseDir: BaseDirectory.AppData })`.
* Added `BaseDirectory.AppData` to the Tauri cold storage cleanup `remove()` call.
* Changed `makeColdDataForCharacter()` and `makeColdDataForChat()` to return `Promise<boolean>` so `makeColdData()` can track whether cold storage actually changed any character/chat data.
* When cold storage conversion actually changes data, set `requiresFullEncoderReload.state = true` so local remote character blocks are rewritten on the next save.

## Impact

### 한국어

이 수정은 Tauri 환경에서 cold storage가 process working directory에 의존해 실패하는 문제를 줄이고, cold storage 변환 후 local remote character block에 cold stub이 저장되지 않아 다음 실행 시 같은 캐릭터가 다시 cold storage 처리되는 문제를 방지하기 위한 것입니다.

웹, account storage, node-hosted storage의 cold storage 저장 경로는 변경하지 않았습니다. 변경된 동작은 주로 Tauri local storage와 local remote character block persistence에 해당합니다.

### English

This change should prevent Tauri cold storage from depending on the process working directory, and should also prevent the same characters from being cold-stored again on the next launch because converted cold stubs were not persisted into local remote character blocks.

Cold storage path handling for web, account storage, and node-hosted storage is not changed. The behavior change mainly affects Tauri local storage and local remote character block persistence.

## Testing

### 한국어

* `pnpm check` 통과:

  * `svelte-check found 0 errors and 0 warnings`
* Windows Tauri 릴리즈 빌드에서 DevTools로 문제를 재현하고 확인했습니다.
* 일반 실행 시 cold storage 저장이 실패하고, WorkingDirectory를 `%APPDATA%\co.aiclient.risu`로 지정하면 저장이 시작되는 것을 확인했습니다.
* cold storage 완료 시점에 full encoder reload 플래그를 강제로 설정했을 때, local remote character block에 cold stub이 반영되고 다음 실행 시 중복 cold storage 생성이 멈추는 것을 확인했습니다.
* 성공 적용 후 JS heap이 약 3GB대에서 약 1,153MB까지 감소하는 것을 확인했습니다.

### English

* `pnpm check` passed:

  * `svelte-check found 0 errors and 0 warnings`
* Reproduced and verified the issue with DevTools on the released Windows Tauri build.
* Confirmed that cold storage fails when launched normally, but starts writing when WorkingDirectory is set to `%APPDATA%\co.aiclient.risu`.
* Confirmed that forcing the full encoder reload flag after cold storage conversion persists cold stubs into local remote character blocks and prevents duplicate cold storage generation on the next launch.
* Confirmed JS heap decreased from around 3GB to about 1,153MB after successful persistence.

## Additional Notes

### 한국어

이 PR은 AI model 요청/응답 처리 로직을 변경하지 않습니다.

수정 범위는 `src/ts/process/coldstorage.svelte.ts`에 한정되어 있으며, cold storage 변환 후 실제 변경이 있었을 때만 full encoder reload를 요청하도록 했습니다.

DevTools로 직접 디버깅하고 검증한 결과를 바탕으로 작성했습니다. 변경 범위는 작고, 제출 전 수정 내용을 확인했습니다.

### English

This PR does not modify AI model prompting, request handling, or response handling.

The change is limited to `src/ts/process/coldstorage.svelte.ts`, and full encoder reload is requested only when cold storage conversion actually changed character/chat data.

Based on manual debugging and verification with DevTools. The code change is small and was reviewed before submission.