### PR TITLE
fix: restore cold storage entries from local backups

### DIFF
--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -24,6 +24,10 @@ function getColdStorageBackupKey(name: string): string | null {
 }
 
 function isColdStorageBackupData(data: unknown): boolean {
+    if (Array.isArray(data)) {
+        return true
+    }
+
     return !!data
         && typeof data === 'object'
         && ('character' in data || 'message' in data)

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -18,6 +18,17 @@ function getBasename(data:string){
     return lasts
 }
 
+function getColdStorageBackupKey(name: string): string | null {
+    const match = name.match(/^(?:coldstorage[/_])?([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.json$/)
+    return match?.[1] ?? null
+}
+
+function isColdStorageBackupData(data: unknown): boolean {
+    return !!data
+        && typeof data === 'object'
+        && ('character' in data || 'message' in data)
+}
+
 export async function SaveLocalBackup(){
     alertWait("Saving local backup...")
     const writer = new LocalWriter()
@@ -150,9 +161,9 @@ export async function SaveLocalBackup(){
             const data = await getColdStorageItem(key)
             if(data){
                 const encoded = new TextEncoder().encode(JSON.stringify(data))
-                await writer.writeBackup(`coldstorage/${key}.json`, encoded)
+                await writer.writeBackup(`coldstorage_${key}.json`, encoded)
             } else {
-                missingAssets.push(`coldstorage/${key}.json`)
+                missingAssets.push(`coldstorage_${key}.json`)
             }
         }
     }
@@ -356,6 +367,23 @@ export async function SavePartialLocalBackup(){
         }
     }
 
+    if(!forageStorage.isAccount){
+        //save coldstorages
+        const coldKeys = await listColdDataKeys()
+        for(let i=0;i<coldKeys.length;i++){
+            const key = coldKeys[i]
+            let message = `Saving partial local Backup Cold data... (${i + 1} / ${coldKeys.length})`
+            alertWait(message)
+            const data = await getColdStorageItem(key)
+            if(data){
+                const encoded = new TextEncoder().encode(JSON.stringify(data))
+                await writer.writeBackup(`coldstorage_${key}.json`, encoded)
+            } else {
+                missingAssets.push(`coldstorage_${key}.json`)
+            }
+        }
+    }
+
     const dbWithoutAccount = { ...db, account: undefined }
     const dbData = encodeRisuSaveLegacy(dbWithoutAccount, 'compression')
 
@@ -454,22 +482,36 @@ export function LoadLocalBackup(){
                             });
                         }
                     }
-                    else if (name.startsWith('coldstorage/')) {
-                        const key = name.replace('coldstorage/', '').replace('.json', '')
-                        const text = new TextDecoder().decode(data)
-                        if(!forageStorage.isAccount){
+                    
+                    else {
+                        const coldStorageKey = getColdStorageBackupKey(name)
+                        let handledAsColdStorage = false
+
+                        if (coldStorageKey && forageStorage.isAccount) {
+                            handledAsColdStorage = true
+                        }
+                        else if (coldStorageKey) {
                             try {
+                                const text = new TextDecoder().decode(data)
                                 const jsonData = JSON.parse(text)
-                                await setColdStorageItem(key, jsonData)
+
+                                if (isColdStorageBackupData(jsonData)) {
+                                    await setColdStorageItem(coldStorageKey, jsonData)
+                                    handledAsColdStorage = true
+                                } else {
+                                    console.warn(`Skipping invalid cold storage backup item ${name}`)
+                                }
                             } catch (e) {
-                                console.error(`Failed to parse cold storage item ${key}:`, e)
+                                console.error(`Failed to parse cold storage item ${coldStorageKey}:`, e)
                             }
                         }
-                    } else {
-                        if (isTauri) {
-                            await writeFile(`assets/` + name, data, { baseDir: BaseDirectory.AppData });
-                        } else {
-                            await forageStorage.setItem('assets/' + name, data);
+
+                        if (!handledAsColdStorage) {
+                            if (isTauri) {
+                                await writeFile(`assets/` + name, data, { baseDir: BaseDirectory.AppData });
+                            } else {
+                                await forageStorage.setItem('assets/' + name, data);
+                            }
                         }
                     }
                     await sleep(10);


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

### 한국어

로컬 백업의 cold storage 가져오기/내보내기 문제를 수정합니다.

기존에는 cold storage 항목을 `writer.writeBackup('coldstorage/<key>.json', ...)` 형태로 저장했지만, `LocalWriter.writeBackup()`는 실제 백업에 basename만 기록합니다. 그래서 기존 로컬 백업에는 cold storage 항목이 `<key>.json` 형태로 들어가지만, `LoadLocalBackup()`은 `coldstorage/`로 시작하는 항목만 복원하고 있었습니다.

이 PR은 로컬 백업 복원 시 다음 형태의 cold storage 항목을 처리하도록 수정합니다.

* `coldstorage/<key>.json`
* `coldstorage_<key>.json`
* `<key>.json`

또한 앞으로 생성되는 로컬 백업에서는 cold storage 항목을 `coldstorage_<key>.json`으로 저장하여, basename만 저장되더라도 cold storage 항목임을 유지하도록 변경합니다.

### English

This PR fixes local backup import/export for cold storage data.

Cold storage entries were written with `writer.writeBackup('coldstorage/<key>.json', ...)`, but `LocalWriter.writeBackup()` stores only the basename. Because of that, existing local backups contain cold storage entries as `<key>.json`, while `LoadLocalBackup()` only restored entries starting with `coldstorage/`.

This PR makes local backup restore handle cold storage entries saved as:

* `coldstorage/<key>.json`
* `coldstorage_<key>.json`
* `<key>.json`

It also updates local backup export to write cold storage entries as `coldstorage_<key>.json`, so the cold storage marker remains in the basename.

## Related Issues

None

## Changes

### 한국어

* 파일명을 기준으로 cold storage 백업 항목을 식별하는 helper를 추가했습니다.
* UUID `.json` 파일은 JSON 내용이 cold storage 데이터 형태일 때만 cold storage로 복원되도록 검증을 추가했습니다.
* `SaveLocalBackup()`에서 cold storage 항목을 `coldstorage_<key>.json` 형식으로 저장하도록 변경했습니다.
* `SavePartialLocalBackup()`에도 cold storage 항목을 포함하도록 변경했습니다. 이를 통해 partial backup 복원 시 cold stub 상태의 캐릭터가 원본 cold storage 데이터 없이 복원되는 문제를 방지합니다.
* `LoadLocalBackup()`에서 기존 basename-only 형식과 새 `coldstorage_` 형식 모두를 복원할 수 있도록 수정했습니다.
* 계정 저장소 모드에서는 인식된 cold storage 항목이 일반 asset으로 import되지 않도록 처리했습니다.

### English

* Added a helper to detect cold storage backup entries by filename.
* Added validation so UUID `.json` files are only restored as cold storage when the parsed JSON looks like cold storage data.
* Updated `SaveLocalBackup()` to write cold storage entries using `coldstorage_<key>.json`.
* Updated `SavePartialLocalBackup()` to include cold storage entries as well, so partial backups do not restore cold-stubbed characters without their cold storage data.
* Updated `LoadLocalBackup()` to restore cold storage entries from both the old basename-only format and the new `coldstorage_` format.
* Prevented recognized cold storage entries from being imported as regular assets in account-storage mode.

## Impact

### 한국어

cold storage 상태의 캐릭터나 채팅이 포함된 데이터베이스를 로컬 백업에서 복원할 때 발생하던 문제를 수정합니다.

이전에는 cold storage 데이터가 백업 파일에 포함되어 있어도 복원 시 cold storage로 인식되지 않아, 백업 import 후 cold-stored 캐릭터를 열 때 로드에 실패할 수 있었습니다.

이 변경은 로컬 백업 가져오기/내보내기에만 영향을 줍니다. 모델 동작, 프롬프트, 응답 처리, 기존 계정 cold storage API 경로는 변경하지 않습니다.

### English

This fixes local backup restore for databases containing cold-stored characters or chats.

Before this change, cold storage data could be included in a local backup but not restored correctly, causing cold-stored characters to fail to load after importing the backup.

The change is limited to local backup import/export. It does not change model behavior, prompting, response handling, or the existing account cold storage API path.

## Additional Notes

### 한국어

1303개의 cold storage 항목과 10개의 PNG asset이 포함된 로컬 백업으로 테스트했습니다.

검증 내용:

* 백업에 포함된 cold storage key 1303개가 모두 OPFS에 복원되는 것을 확인했습니다.
* import 후 백업에 있던 cold storage key 누락이 없는 것을 확인했습니다.
* PNG asset이 asset으로 저장되는 것을 확인했습니다.
* cold storage JSON 항목이 asset으로 잘못 저장되지 않는 것을 확인했습니다.
* import 후 cold-stored 캐릭터 여러 개를 무작위로 열어 보았고, 이전의 null cold storage 오류 없이 정상 로드되는 것을 확인했습니다.

### English

Tested with a local backup containing 1303 cold storage entries and 10 PNG assets.

Validation performed:

* Confirmed all 1303 cold storage keys from the backup were restored to OPFS.
* Confirmed no cold storage keys from the backup were missing after import.
* Confirmed imported PNG assets were stored as assets.
* Confirmed cold storage JSON entries were not incorrectly stored as assets.
* Randomly opened several cold-stored characters after import and confirmed they loaded without the previous null cold storage error.
