### PR TITLE
fix: Check VITE_RISU_LEGAL_CONFIGURED in process runtime

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -615,7 +615,8 @@ app.get('/', async (req, res, next) => {
         const mainIndex = await fs.readFile(path.join(process.cwd(), 'dist', 'index.html'))
         const root = htmlparser.parse(mainIndex)
         const head = root.querySelector('head')
-        head.innerHTML = `<script>globalThis.__NODE__ = true</script>` + head.innerHTML
+        const legalConfigured = process.env.VITE_RISU_LEGAL_CONFIGURED?.trim().toUpperCase() === 'TRUE';
+        head.innerHTML = `<script>globalThis.__NODE__ = true;globalThis.__RISU_LEGAL_CONFIGURED__ = ${legalConfigured}</script>` + head.innerHTML
         
         res.send(root.toString())
     } catch (error) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -100,7 +100,7 @@
     }
 
 }}>
-    {#if !import.meta.env.VITE_RISU_LEGAL_CONFIGURED}
+    {#if !(import.meta.env.VITE_RISU_LEGAL_CONFIGURED || globalThis.__RISU_LEGAL_CONFIGURED__)}
         <Legal />
     {:else if aprilFools}
 

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -310,7 +310,7 @@
                         })
                     }}>NO</Button>
                 </div>
-            {:else if $alertStore.type === 'tos' && import.meta.env.VITE_RISU_LEGAL_CONFIGURED}
+            {:else if $alertStore.type === 'tos' && (import.meta.env.VITE_RISU_LEGAL_CONFIGURED || globalThis.__RISU_LEGAL_CONFIGURED__)}
                 <div class="flex gap-2 w-full">
                     <Button className="mt-4 grow" onclick={() => {
                         alertStore.set({


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

### Error Reproduction Method

Run `pnpm build` without `VITE_RISU_LEGAL_CONFIGURED` set. Then, set `VITE_RISU_LEGAL_CONFIGURED` to TRUE, run the server with `pnpm runserver`, and when you enter the server, a popup appears.

### Solution

When `server.cjs` is executed, inject `process.env.VITE_RISU_LEGAL_CONFIGURED` into the HTML so that the environment variable value can be retrieved even after the build is complete.

Also, previously, the popup would not appear as long as the value existed, even if `VITE_RISU_LEGAL_CONFIGURED` was not TRUE; however, the newly added code strictly checks for TRUE.

## Related Issues

#1466 

# Result
<img width="1436" height="596" alt="image" src="https://github.com/user-attachments/assets/a3a7a051-aa16-4493-88ca-1a7720dad7d8" />
<img width="1323" height="525" alt="image" src="https://github.com/user-attachments/assets/588aabce-53ba-4c68-abf4-cdb3d157114f" />

