### PR TITLE
fix: use thinkingLevel for Gemini 3.x instead of thinkingBudget

### DIFF
--- a/src/ts/model/providers/google.ts
+++ b/src/ts/model/providers/google.ts
@@ -9,7 +9,7 @@ export const GoogleModels: LLMModel[] = [
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
         flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
-        parameters: ['thinking_tokens', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true
     },
@@ -20,7 +20,7 @@ export const GoogleModels: LLMModel[] = [
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
         flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
-        parameters: ['thinking_tokens', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true
     },
@@ -30,7 +30,7 @@ export const GoogleModels: LLMModel[] = [
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
         flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
-        parameters: ['thinking_tokens', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true
     },

--- a/src/ts/model/providers/google.ts
+++ b/src/ts/model/providers/google.ts
@@ -8,7 +8,7 @@ export const GoogleModels: LLMModel[] = [
         id: 'gemini-3.1-pro-preview',
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
-        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
+        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.geminiThinkingNoMinimal, LLMFlags.hasFirstSystemPrompt],
         parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -26,7 +26,8 @@ export const LLMFlags = {
     claudeAdaptiveThinking: 22,
     claudeXHighEffort: 23,
     deepSeekThinkingToggle: 24,
-    noStructuredOutput: 25
+    noStructuredOutput: 25,
+    geminiThinkingNoMinimal: 26
 } as const;
 export type LLMFlags = (typeof LLMFlags)[keyof typeof LLMFlags];
 

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -319,6 +319,7 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
 
     if(arg.modelInfo.flags.includes(LLMFlags.geminiThinking)){
         para.push('thinking_tokens')
+        para.push('reasoning_effort')
     }
 
     para = para.filter((v) => {
@@ -334,7 +335,8 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
             'top_k': "topK",
             'presence_penalty': "presencePenalty",
             'frequency_penalty': "frequencyPenalty",
-            'thinking_tokens': "thinkingBudget"
+            'thinking_tokens': "thinkingBudget",
+            'reasoning_effort': "thinkingConfig.thinkingLevel"
         }, arg.mode, {
             ignoreTopKIfZero: true,
             modelId: arg.modelInfo.id
@@ -360,39 +362,19 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     }
 
     if(arg.modelInfo.flags.includes(LLMFlags.geminiThinking)){
-        const internalId = arg.modelInfo.internalID
-        const thinkingBudget = body.generation_config.thinkingBudget
+        const generationConfig = body.generation_config
 
-        // Gemini 3 models use `thinking_level` (via thinkingConfig.thinkingLevel) instead of `thinking_budget`.
-        // Keep UI/param name 'thinking_tokens' but translate it here for compatibility.
-        if (internalId && /^gemini-3-/.test(internalId)) {
-            const budgetNum = typeof thinkingBudget === 'number' ? thinkingBudget : Number(thinkingBudget)
-
-            // Conservative mapping: keep levels coarse to avoid model-specific strict validation.
-            // - gemini-3-flash-preview: LOW/MEDIUM/HIGH
-            // - gemini-3-pro* (incl. image): LOW/HIGH
-            let thinkingLevel: 'LOW' | 'MEDIUM' | 'HIGH' = 'HIGH'
-            if (internalId === 'gemini-3-flash-preview') {
-                if (!Number.isFinite(budgetNum) || budgetNum >= 16384) thinkingLevel = 'HIGH'
-                else if (budgetNum >= 4096) thinkingLevel = 'MEDIUM'
-                else thinkingLevel = 'LOW'
-            } else {
-                if (!Number.isFinite(budgetNum) || budgetNum >= 8192) thinkingLevel = 'HIGH'
-                else thinkingLevel = 'LOW'
-            }
-
-            body.generation_config.thinkingConfig = {
-                "thinkingLevel": thinkingLevel,
+        // 2.5's flat thinkingBudget is wrapped into thinkingConfig here.
+        // 3.x's thinkingConfig.thinkingLevel was already set by the rename above.
+        if (generationConfig.thinkingBudget !== undefined) {
+            generationConfig.thinkingConfig = {
+                "thinkingBudget": generationConfig.thinkingBudget,
                 "includeThoughts": true,
             }
-        } else {
-            body.generation_config.thinkingConfig = {
-                "thinkingBudget": thinkingBudget,
-                "includeThoughts": true,
-            }
+            delete generationConfig.thinkingBudget
+        } else if (generationConfig.thinkingConfig) {
+            generationConfig.thinkingConfig.includeThoughts = true
         }
-
-        delete body.generation_config.thinkingBudget
     }
 
     if(systemPrompt === ''){

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -373,6 +373,11 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
             }
             delete generationConfig.thinkingBudget
         } else if (generationConfig.thinkingConfig) {
+            // Models without a `minimal` level (e.g. Gemini 3.1 Pro) — map it to `low`, as Google does.
+            if (generationConfig.thinkingConfig.thinkingLevel === 'minimal'
+                && arg.modelInfo.flags.includes(LLMFlags.geminiThinkingNoMinimal)) {
+                generationConfig.thinkingConfig.thinkingLevel = 'low'
+            }
             generationConfig.thinkingConfig.includeThoughts = true
         }
     }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Two fixes:
1. Fix the model match. The old regex `/^gemini-3-/` missed `gemini-3.1` and `gemini-3.5`.
2. Set Gemini 3.x models to use `reasoning_effort` (Minimal / Low / Medium / High), and send it as `thinkingLevel`.

Gemini 3.x models use `thinkingLevel` (a text value: `minimal`, `low`, `medium`, or `high`), not a token number (`thinkingBudget`).

The old code used the regex `/^gemini-3-/` to find Gemini 3 models. This only matches IDs that start with `gemini-3-` (like `gemini-3-pro-preview`). It does not match `gemini-3.1-...` or `gemini-3.5-...`, because of the dot after `3`. So those models fell through and sent the wrong field (`thinkingBudget` instead of `thinkingLevel`).

This PR fixes it. Gemini 2.5 still uses `thinkingBudget` (no change).

## Related Issues

#1469 (draft) also works on Gemini thinking level, as part of a larger Gemini API update. This PR is a smaller, focused take that only fixes the thinking-level handling and reuses the existing `reasoning_effort` control. I'm happy to defer to #1469 or close this if that PR already covers it.

## Changes

`src/ts/model/types.ts`
- Add a new `geminiThinkingNoMinimal` model flag.

`src/ts/model/providers/google.ts`
- For `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, and `gemini-3-flash-preview`: change the parameter from `thinking_tokens` to `reasoning_effort`.
- Now these models show the Minimal / Low / Medium / High buttons (same UI as GPT-5).
- Add the `geminiThinkingNoMinimal` flag to `gemini-3.1-pro-preview`, because it does not support the `minimal` level.

`src/ts/process/request/google.ts`
- Send `reasoning_effort` as `thinkingConfig.thinkingLevel` (lowercase).
- Remove the old `/^gemini-3-/` code. It did not match `gemini-3.1`, it used uppercase values, and it guessed the level from the token slider.
- For models with the `geminiThinkingNoMinimal` flag, map `minimal` to `low` (this matches what Google's own API does for Gemini 3.1 Pro).
- Gemini 2.5 still puts its token number inside `thinkingConfig`.

## Impact

- Gemini 3.x now sends the correct `thinkingLevel`. Before, `gemini-3.1` sent the wrong field.
- `gemini-3.1-pro-preview` maps `minimal` to `low`, because it does not support `minimal`.
- Gemini 2.5 does not change.
- The Gemini 3.x setting UI is now the same as GPT-5 (level buttons, not a token slider).
- No new setting and no new database field.

<img width="842" height="583" alt="image" src="https://github.com/user-attachments/assets/f959263a-581f-4e74-bed6-d4e8c6b2cb02" />


## Additional Notes

- Small change (3 files). No new settings or database fields, only a model flag.
- The code is AI-assisted, but I read it and understand it.
- I checked the UI: the level buttons show for Gemini 3.x, and Gemini 2.5 still shows the token slider.
- Tested live in my self-hosted Docker client. Working: `gemini-3.1-pro-preview`, `gemini-3-flash-preview`, and `gemini-2.5-pro`.
- Note: `gemini-3-pro-preview` now returns 404 (Google deprecated it server-side).
