### PR TITLE
fix: resolve V3 plugin providers always showing as Plugin Legacy

### DIFF
--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -329,7 +329,8 @@ export async function requestChatData(arg:requestDataArgument, model:ModelModeEx
             
             trys += 1
             if(trys > db.requestRetrys){
-                if(fallbackIndex === fallBackModels.length-1 || da.model === 'custom'){
+                const isPluginModel = da.model === 'custom' || da.model?.startsWith('pluginmodel:::')
+                if(fallbackIndex === fallBackModels.length-1 || isPluginModel){
                     return da
                 }
                 break
@@ -861,11 +862,13 @@ async function requestOoba(arg:RequestDataArgumentExtended):Promise<requestDataR
 
 async function requestPlugin(arg:RequestDataArgumentExtended):Promise<requestDataResponse> {
     const db = getDatabase()
+    const isV3Model = arg.aiModel.startsWith('pluginmodel:::')
+    const responseModel = isV3Model ? arg.aiModel : 'custom'
     try {
         const formated = arg.formated
         const maxTokens = arg.maxTokens
         const bias = arg.biasString
-        const model = arg.aiModel.startsWith('pluginmodel:::') ? arg.aiModel.replace('pluginmodel:::', '') : db.currentPluginProvider
+        const model = isV3Model ? arg.aiModel.replace('pluginmodel:::', '') : db.currentPluginProvider
         const v2Function = pluginV2.providers.get(model)
 
         if(arg.previewBody){
@@ -899,14 +902,14 @@ async function requestPlugin(arg:RequestDataArgumentExtended):Promise<requestDat
             return {
                 type: 'fail',
                 result: (language.errors.unknownModel),
-                model: 'custom'
+                model: responseModel
             }
         }
         else if(!d.success){
             return {
                 type: 'fail',
                 result: d.content instanceof ReadableStream ? await (new Response(d.content)).text() : d.content,
-                model: 'custom'
+                model: responseModel
             }
         }
         else if(d.content instanceof ReadableStream){
@@ -924,14 +927,14 @@ async function requestPlugin(arg:RequestDataArgumentExtended):Promise<requestDat
             return {
                 type: 'streaming',
                 result: d.content.pipeThrough(piper),
-                model: 'custom'
+                model: responseModel
             }
         }
         else{
             return {
                 type: 'success',
                 result: d.content ?? '',
-                model: 'custom'
+                model: responseModel
             }
         }   
     } catch (error) {
@@ -939,7 +942,7 @@ async function requestPlugin(arg:RequestDataArgumentExtended):Promise<requestDat
         return {
             type: 'fail',
             result: `Plugin Error from ${db.currentPluginProvider}: ` + JSON.stringify(error),
-            model: 'custom'
+            model: responseModel
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fix V3 plugin providers registered with `addProvider` always appearing as `Plugin Legacy`.

## Related Issues

None

## Changes

- Return the actual V3 plugin model ID from `requestPlugin` instead of always returning `custom`.
- Update `requestChatData` fallback handling to treat both `pluginmodel:::` and `custom` as plugin responses.

## Impact

Generation metadata uses the returned `model` value from `requestChatData`, then the chat UI resolves it through `getModelInfo(...).shortName`. When the value is `custom`, it resolves to the built-in `Plugin Legacy` model. With this change, V3 plugin providers keep their `pluginmodel:::` ID and display their registered model name, while legacy V2 providers still appear as `Plugin Legacy`.

## Additional Notes

This issue surfaced after commit https://github.com/kwaroran/Risuai/commit/a40dbe4 fixed a bug where returned `model` values could be overwritten with an empty string. After that fix, plugin responses returning `custom` were preserved, causing all plugin generations to resolve as `Plugin Legacy`.

This patch keeps the model value consistent through the request flow. No known side effects are expected outside generation metadata display and plugin fallback handling.
