### PR TITLE
Add visual color palette selector

### DIFF
--- a/src/lib/Setting/Pages/Display/ColorSchemeSelect.svelte
+++ b/src/lib/Setting/Pages/Display/ColorSchemeSelect.svelte
@@ -1,19 +1,88 @@
 <script lang="ts">
     import { language } from 'src/lang';
     import { DBState } from 'src/ts/stores.svelte';
-    import { changeColorScheme, colorSchemeList } from 'src/ts/gui/colorscheme';
-    import SelectInput from 'src/lib/UI/GUI/SelectInput.svelte';
-    import OptionInput from 'src/lib/UI/GUI/OptionInput.svelte';
+    import {
+        changeColorScheme,
+        colorSchemeList,
+        colorSchemePresets,
+        type ColorScheme,
+    } from 'src/ts/gui/colorscheme';
 
-    const onSchemeInputChange = (e: Event) => {
-        changeColorScheme((e.target as HTMLInputElement).value);
+    const formatSchemeName = (name: string) => {
+        if (name === 'custom') {
+            return 'Custom';
+        }
+
+        return name
+            .split('-')
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(' ');
+    };
+
+    const paletteStyle = (scheme: ColorScheme) => {
+        const { bgcolor, darkbg, borderc, selected } = scheme;
+
+        return `background: conic-gradient(from 45deg, ${bgcolor} 0deg 90deg, ${darkbg} 90deg 180deg, ${borderc} 180deg 270deg, ${selected} 270deg 360deg);`;
     };
 </script>
 
 <span class="text-textcolor mt-4">{language.colorScheme}</span>
-<SelectInput className="mt-2" value={DBState.db.colorSchemeName} onchange={onSchemeInputChange}>
+
+<div class="mt-2 grid grid-cols-[repeat(auto-fill,minmax(7.5rem,1fr))] gap-2">
     {#each colorSchemeList as scheme}
-        <OptionInput value={scheme}>{scheme}</OptionInput>
+        <button
+            type="button"
+            class="flex min-h-28 flex-col items-center justify-center gap-2 rounded-md border p-3 text-center transition-colors hover:bg-darkbutton focus:outline-hidden focus:ring-2 focus:ring-borderc"
+            class:border-borderc={DBState.db.colorSchemeName === scheme}
+            class:border-darkborderc={DBState.db.colorSchemeName !== scheme}
+            class:bg-darkbutton={DBState.db.colorSchemeName === scheme}
+            aria-pressed={DBState.db.colorSchemeName === scheme}
+            title={formatSchemeName(scheme)}
+            onclick={() => changeColorScheme(scheme)}
+        >
+            <span
+                class="palette-wheel relative h-14 w-14 overflow-hidden rounded-full shadow-sm"
+                aria-hidden="true"
+            >
+                <span class="palette-wheel-fill" style={paletteStyle(colorSchemePresets[scheme])}></span>
+            </span>
+            <span class="w-full truncate text-sm text-textcolor">{formatSchemeName(scheme)}</span>
+        </button>
     {/each}
-    <OptionInput value="custom">Custom</OptionInput>
-</SelectInput>
+
+    <button
+        type="button"
+        class="flex min-h-28 flex-col items-center justify-center gap-2 rounded-md border p-3 text-center transition-colors hover:bg-darkbutton focus:outline-hidden focus:ring-2 focus:ring-borderc"
+        class:border-borderc={DBState.db.colorSchemeName === 'custom'}
+        class:border-darkborderc={DBState.db.colorSchemeName !== 'custom'}
+        class:bg-darkbutton={DBState.db.colorSchemeName === 'custom'}
+        aria-pressed={DBState.db.colorSchemeName === 'custom'}
+        title="Custom"
+        onclick={() => changeColorScheme('custom')}
+    >
+        <span
+            class="palette-wheel relative h-14 w-14 overflow-hidden rounded-full shadow-sm"
+            aria-hidden="true"
+        >
+            <span class="palette-wheel-fill" style={paletteStyle(DBState.db.customColorScheme)}></span>
+        </span>
+        <span class="w-full truncate text-sm text-textcolor">Custom</span>
+    </button>
+</div>
+
+<style>
+    .palette-wheel {
+        box-shadow:
+            inset 0 0 0 1px rgb(255 255 255 / 0.2),
+            0 1px 2px rgb(0 0 0 / 0.15);
+        box-shadow:
+            inset 0 0 0 1px color-mix(in srgb, var(--risu-theme-textcolor) 20%, transparent),
+            0 1px 2px rgb(0 0 0 / 0.15);
+    }
+
+    .palette-wheel-fill {
+        position: absolute;
+        inset: -1px;
+        border-radius: inherit;
+    }
+</style>

--- a/src/lib/Setting/Pages/Display/CustomColorSchemeEditor.svelte
+++ b/src/lib/Setting/Pages/Display/CustomColorSchemeEditor.svelte
@@ -8,7 +8,6 @@
     } from 'src/ts/gui/colorscheme';
     import SelectInput from 'src/lib/UI/GUI/SelectInput.svelte';
     import OptionInput from 'src/lib/UI/GUI/OptionInput.svelte';
-    import ColorInput from 'src/lib/UI/GUI/ColorInput.svelte';
     import { DownloadIcon, HardDriveUploadIcon } from '@lucide/svelte';
 
     const colors = [
@@ -39,7 +38,13 @@
 
         {#each colors as color}
             <div class="flex items-center mt-2">
-                <ColorInput bind:value={DBState.db.customColorScheme[color[0]]} oninput={updateCustomColorScheme} />
+                <input
+                    type="color"
+                    class="native-color-input"
+                    aria-label={color[1]}
+                    bind:value={DBState.db.customColorScheme[color[0]]}
+                    oninput={updateCustomColorScheme}
+                />
                 <span class="ml-2">{color[1]}</span>
             </div>
         {/each}
@@ -60,3 +65,31 @@
         </div>
     </div>
 {/if}
+
+<style>
+    .native-color-input {
+        width: 1.8rem;
+        height: 1.8rem;
+        padding: 0;
+        border: 0;
+        border-radius: 9999px;
+        background: transparent;
+        cursor: pointer;
+        appearance: none;
+        -webkit-appearance: none;
+    }
+
+    .native-color-input::-webkit-color-swatch-wrapper {
+        padding: 0;
+    }
+
+    .native-color-input::-webkit-color-swatch {
+        border: 1px solid var(--risu-theme-darkborderc);
+        border-radius: 9999px;
+    }
+
+    .native-color-input::-moz-color-swatch {
+        border: 1px solid var(--risu-theme-darkborderc);
+        border-radius: 9999px;
+    }
+</style>

--- a/src/lib/Setting/Pages/Display/CustomColorSchemeEditor.svelte
+++ b/src/lib/Setting/Pages/Display/CustomColorSchemeEditor.svelte
@@ -4,7 +4,7 @@
         changeColorSchemeType,
         exportColorScheme,
         importColorScheme,
-        updateColorScheme,
+        updateCustomColorScheme,
     } from 'src/ts/gui/colorscheme';
     import SelectInput from 'src/lib/UI/GUI/SelectInput.svelte';
     import OptionInput from 'src/lib/UI/GUI/OptionInput.svelte';
@@ -28,7 +28,7 @@
     <div class="border border-darkborderc p-2 m-2 rounded-md">
         <SelectInput
             className="mt-2"
-            value={DBState.db.colorScheme.type}
+            value={DBState.db.customColorScheme.type}
             onchange={(e) => {
                 changeColorSchemeType((e.target as HTMLInputElement).value as 'light' | 'dark');
             }}
@@ -39,7 +39,7 @@
 
         {#each colors as color}
             <div class="flex items-center mt-2">
-                <ColorInput bind:value={DBState.db.colorScheme[color[0]]} oninput={updateColorScheme} />
+                <ColorInput bind:value={DBState.db.customColorScheme[color[0]]} oninput={updateCustomColorScheme} />
                 <span class="ml-2">{color[1]}</span>
             </div>
         {/each}

--- a/src/lib/UI/GUI/ColorInput.svelte
+++ b/src/lib/UI/GUI/ColorInput.svelte
@@ -1,25 +1,34 @@
 <script lang="ts">
     import ColorPicker from 'svelte-awesome-color-picker';
+    import { onMount, tick } from 'svelte';
+
     interface Props {
-        value?: string;
+        value?: string | null;
         nullable?: boolean;
         oninput?: () => void;
     }
 
     let { value = $bindable('#000000'), nullable = false, oninput }: Props = $props();
+    let acceptsInput = false;
 
-    $effect(() => {
-        //this is for updating
-        value
-
-        oninput?.()
+    onMount(() => {
+        tick().then(() => {
+            acceptsInput = true;
+        });
     });
+
+    const handleInput = () => {
+        if (!acceptsInput) return;
+        oninput?.();
+    };
 </script>
 
 <div class="cl rounded-full bg-white">
     <ColorPicker
-        label="" bind:hex={value}
+        label=""
+        bind:hex={value}
         nullable={nullable}
+        onInput={handleInput}
     />
 </div>
 

--- a/src/ts/gui/colorscheme.ts
+++ b/src/ts/gui/colorscheme.ts
@@ -95,6 +95,42 @@ const colorShemes = {
         darkbutton: "#2d6a4f",
         type:'dark'
     },
+    "ocean": {
+        bgcolor: "#0b1f2a",
+        darkbg: "#08202b",
+        borderc: "#38bdf8",
+        selected: "#164e63",
+        draculared: "#fb7185",
+        textcolor: "#e6f6fb",
+        textcolor2: "#8fc7d5",
+        darkBorderc: "#155e75",
+        darkbutton: "#0f3a4a",
+        type:'dark'
+    },
+    "aurora": {
+        bgcolor: "#10201c",
+        darkbg: "#152a24",
+        borderc: "#5eead4",
+        selected: "#315c52",
+        draculared: "#fb7185",
+        textcolor: "#ecfdf5",
+        textcolor2: "#a7f3d0",
+        darkBorderc: "#2f6f63",
+        darkbutton: "#21443c",
+        type:'dark'
+    },
+    "twilight": {
+        bgcolor: "#171324",
+        darkbg: "#201936",
+        borderc: "#c084fc",
+        selected: "#3b2a5a",
+        draculared: "#f43f5e",
+        textcolor: "#f8f5ff",
+        textcolor2: "#c4b5fd",
+        darkBorderc: "#4c3575",
+        darkbutton: "#2e2348",
+        type:'dark'
+    },
     "realblack": {
         bgcolor: "#000000",
         darkbg: "#000000",
@@ -130,6 +166,54 @@ const colorShemes = {
         darkBorderc: "#3e3d32",
         darkbutton: "#3e3d32",
         type:'dark'
+    },
+    "sky-light": {
+        bgcolor: "#f6fbff",
+        darkbg: "#e8f3fb",
+        borderc: "#0284c7",
+        selected: "#d7ecf8",
+        draculared: "#e11d48",
+        textcolor: "#0f172a",
+        textcolor2: "#516174",
+        darkBorderc: "#b7d7ea",
+        darkbutton: "#dbeafe",
+        type:'light'
+    },
+    "sage-light": {
+        bgcolor: "#f7faf5",
+        darkbg: "#e8f0e6",
+        borderc: "#3f6212",
+        selected: "#d9e8d3",
+        draculared: "#dc2626",
+        textcolor: "#1f2933",
+        textcolor2: "#586a52",
+        darkBorderc: "#b7c9ad",
+        darkbutton: "#dce8d6",
+        type:'light'
+    },
+    "lavender-light": {
+        bgcolor: "#f8f7ff",
+        darkbg: "#ede9fe",
+        borderc: "#6d28d9",
+        selected: "#ddd6fe",
+        draculared: "#e11d48",
+        textcolor: "#1e1b4b",
+        textcolor2: "#5b5680",
+        darkBorderc: "#c4b5fd",
+        darkbutton: "#e0e7ff",
+        type:'light'
+    },
+    "slate-light": {
+        bgcolor: "#f8fafc",
+        darkbg: "#e2e8f0",
+        borderc: "#334155",
+        selected: "#cbd5e1",
+        draculared: "#dc2626",
+        textcolor: "#020617",
+        textcolor2: "#475569",
+        darkBorderc: "#94a3b8",
+        darkbutton: "#cbd5e1",
+        type:'light'
     },
     "lite": {
         bgcolor: "#1f2937",

--- a/src/ts/gui/colorscheme.ts
+++ b/src/ts/gui/colorscheme.ts
@@ -232,15 +232,28 @@ const colorShemes = {
 
 export const ColorSchemeTypeStore = writable('dark' as 'dark'|'light')
 
+export const colorSchemePresets = colorShemes
+
 export const colorSchemeList = Object.keys(colorShemes) as (keyof typeof colorShemes)[]
 
 export function changeColorScheme(colorScheme: string){
     try {
-        if(colorScheme !== 'custom'){
+        if(colorScheme === 'custom'){
+            DBState.db.colorScheme = safeStructuredClone(DBState.db.customColorScheme ?? defaultColorScheme)
+        }
+        else{
             DBState.db.colorScheme = safeStructuredClone(colorShemes[colorScheme])
         }
         DBState.db.colorSchemeName = colorScheme
         updateColorScheme()   
+    } catch (error) {}
+}
+
+export function updateCustomColorScheme(){
+    try {
+        DBState.db.colorScheme = safeStructuredClone(DBState.db.customColorScheme ?? defaultColorScheme)
+        DBState.db.colorSchemeName = 'custom'
+        updateColorScheme()
     } catch (error) {}
 }
 
@@ -274,14 +287,14 @@ export function updateColorScheme(){
 
 export function changeColorSchemeType(type: 'light'|'dark'){
     try {
-        DBState.db.colorScheme.type = type
-        updateColorScheme()
+        DBState.db.customColorScheme.type = type
+        updateCustomColorScheme()
         updateTextThemeAndCSS()
     } catch (error) {}
 }
 
 export function exportColorScheme(){
-    let json = JSON.stringify(DBState.db.colorScheme)
+    let json = JSON.stringify(DBState.db.customColorScheme)
     downloadFile('colorScheme.json', json)
 }
 
@@ -309,9 +322,8 @@ export async function importColorScheme(){
             alertError('Invalid color scheme')
             return
         }
-        changeColorScheme('custom')
-        DBState.db.colorScheme = colorScheme
-        updateColorScheme()
+        DBState.db.customColorScheme = colorScheme
+        updateCustomColorScheme()
     }
     catch(e){
         alertError('Invalid color scheme')

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -757,6 +757,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             }
             const db = DBState.db
             db.colorSchemeName = 'custom'
+            db.customColorScheme = scheme
             db.colorScheme = scheme
             updateColorScheme()
         },

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -382,6 +382,7 @@ export function setDatabase(data:Database){
     data.animationSpeed ??= 0.4
     data.colorScheme ??= safeStructuredClone(defaultColorScheme)
     data.colorSchemeName ??= 'default'
+    data.customColorScheme ??= safeStructuredClone(data.colorSchemeName === 'custom' ? data.colorScheme : defaultColorScheme)
     data.NAIsettings.starter ??= ""
     data.hypaModel ??= 'MiniLM'
     data.mancerHeader ??= ''
@@ -945,6 +946,7 @@ export interface Database{
     hideRealm:boolean
     colorScheme:ColorScheme
     colorSchemeName:string
+    customColorScheme:ColorScheme
     promptTemplate?:PromptItem[]
     forceProxyAsOpenAI?:boolean
     hypaModel:HypaModel


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Replace the color scheme dropdown in Display settings with visual palette cards and improve how custom color schemes are stored and edited.

The PR also adds several built-in themes and separates the user's custom palette from the currently active preset, allowing it to remain intact while switching between themes.

## Related Issues

None

## Changes

- Replaces the color scheme dropdown with a responsive card-based palette selector.
- Shows a four-color preview for each built-in theme and the user's Custom theme.
- Adds additional built-in dark and light color schemes.
- Separates customColorScheme from the currently active colorScheme.
- Preserves existing custom color schemes when loading older databases.
- Keeps Plugin API V3 color scheme updates synchronized with the stored custom scheme.
- Uses lightweight native color inputs in the Custom scheme editor instead of mounting full color picker components for every field.
- Prevents ColorInput from firing its input callback during initial component setup.
- Keeps the existing color scheme import/export and theme application behavior.

## Impact

Color schemes can now be compared visually instead of through a text-only dropdown.

Custom palettes are stored independently from built-in presets, so selecting another theme no longer replaces the palette shown under Custom. Existing databases are migrated to the new representation when loaded.

The Plugin API continues to support applying custom color schemes, with the stored Custom palette kept in sync.

The Custom editor also avoids mounting multiple heavy color picker widgets, reducing unnecessary work when opening Display settings.

No model request or prompting behavior is changed.

## Additional Notes

Validation performed:

- `pnpm check`
- `git diff --check`
- Browser rendering checks for the palette grid, selection state, responsive layout, and Custom preview stability when switching presets
- Browser interaction checks for Custom mode display-tab entry, display sub-tab navigation, Light-to-Custom selection, and custom color edit propagation

## Preview

| Fancy | 
|-------|
| <img width="1302" height="637" alt="ahuwtsblarewanrnlbes" src="https://github.com/user-attachments/assets/8552c126-1c3a-4a72-a2f7-2515258d2644" /> |
