### PR TITLE
feat: add Voyage Context 4 embedding model

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -1299,6 +1299,7 @@
             <OptionInput value="openai3large">OpenAI text-embedding-3-large</OptionInput>
             <OptionInput value="ada">OpenAI Ada</OptionInput>
             <OptionInput value="voyageContext3">Voyage Context 3</OptionInput>
+            <OptionInput value="voyageContext4">Voyage Context 4</OptionInput>
             <OptionInput value="custom">Custom (OpenAI-compatible)</OptionInput>
         </SelectInput>
 
@@ -1316,7 +1317,7 @@
             <TextInput size="sm" marginBottom bind:value={DBState.db.hypaCustomSettings.model}/>
         {/if}
 
-        {#if DBState.db.hypaModel === 'voyageContext3'}
+        {#if DBState.db.hypaModel === 'voyageContext3' || DBState.db.hypaModel === 'voyageContext4'}
             <span class="text-textcolor">Voyage API Key</span>
             <TextInput size="sm" marginBottom hideText={DBState.db.hideApiKey} bind:value={DBState.db.voyageApiKey}/>
         {/if}

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -1297,6 +1297,7 @@
             <OptionInput value="openai3large">OpenAI text-embedding-3-large</OptionInput>
             <OptionInput value="ada">OpenAI Ada</OptionInput>
             <OptionInput value="voyageContext3">Voyage Context 3</OptionInput>
+            <OptionInput value="voyageContext4">Voyage Context 4</OptionInput>
             <OptionInput value="custom">Custom (OpenAI-compatible)</OptionInput>
         </SelectInput>
 
@@ -1314,7 +1315,7 @@
             <TextInput size="sm" marginBottom bind:value={DBState.db.hypaCustomSettings.model}/>
         {/if}
 
-        {#if DBState.db.hypaModel === 'voyageContext3'}
+        {#if DBState.db.hypaModel === 'voyageContext3' || DBState.db.hypaModel === 'voyageContext4'}
             <span class="text-textcolor">Voyage API Key</span>
             <TextInput size="sm" marginBottom hideText={DBState.db.hideApiKey} bind:value={DBState.db.voyageApiKey}/>
         {/if}

--- a/src/ts/process/memory/contextualEmbedding.ts
+++ b/src/ts/process/memory/contextualEmbedding.ts
@@ -9,32 +9,59 @@ export interface ContextualEmbeddingProvider {
   getCacheKeySuffix(contextTexts?: string[]): string;
 }
 
+type VoyageContextModel = 'voyageContext3' | 'voyageContext4';
+
+interface VoyageContextModelConfig {
+  readonly apiModelId: string;
+  readonly displayName: string;
+  readonly cacheKeySuffix: string;
+  readonly outputDimension?: number;
+  readonly outputDtype?: 'float';
+}
+
+const VOYAGE_CONTEXT_MODELS: Record<VoyageContextModel, VoyageContextModelConfig> = {
+  voyageContext3: {
+    apiModelId: 'voyage-context-3',
+    displayName: 'Voyage Context 3',
+    cacheKeySuffix: 'voyageContext3'
+  },
+  voyageContext4: {
+    apiModelId: 'voyage-context-4',
+    displayName: 'Voyage Context 4',
+    cacheKeySuffix: 'voyageContext4|dim:2048',
+    outputDimension: 2048,
+    outputDtype: 'float'
+  }
+};
+
 export function isContextModel(model: string): boolean {
-  return model === 'voyageContext3';
+  return Object.prototype.hasOwnProperty.call(VOYAGE_CONTEXT_MODELS, model);
 }
 
 export function getContextProvider(model: string): ContextualEmbeddingProvider | null {
-  switch (model) {
-    case 'voyageContext3':
-      return new VoyageContext3Provider();
-    default:
-      return null;
+  if (!isContextModel(model)) {
+    return null;
   }
+
+  return new VoyageContextProvider(VOYAGE_CONTEXT_MODELS[model as VoyageContextModel]);
 }
 
 const VOYAGE_API_URL = "https://api.voyageai.com/v1/contextualizedembeddings";
-const VOYAGE_MODEL = "voyage-context-3";
 const MAX_CHUNKS_PER_REQUEST = 16000;
 const MAX_INPUTS_PER_REQUEST = 1000;
 
-class VoyageContext3Provider implements ContextualEmbeddingProvider {
-  readonly modelId = VOYAGE_MODEL;
+class VoyageContextProvider implements ContextualEmbeddingProvider {
+  readonly modelId: string;
+
+  constructor(private readonly config: VoyageContextModelConfig) {
+    this.modelId = config.apiModelId;
+  }
 
   private getApiKey(): string {
     const db = getDatabase();
     const apiKey = db.voyageApiKey?.trim();
     if (!apiKey) {
-      throw new Error('Voyage Context 3 requires a Voyage API Key');
+      throw new Error(`${this.config.displayName} requires a Voyage API Key`);
     }
     return apiKey;
   }
@@ -52,9 +79,10 @@ class VoyageContext3Provider implements ContextualEmbeddingProvider {
           "Content-Type": "application/json"
         },
         body: {
-          "model": VOYAGE_MODEL,
+          "model": this.config.apiModelId,
           "inputs": batch,
-          "input_type": "document"
+          "input_type": "document",
+          ...this.getOutputOptions()
         }
       });
 
@@ -84,8 +112,9 @@ class VoyageContext3Provider implements ContextualEmbeddingProvider {
       },
       body: {
         "inputs": queries.map(s => [s]),
-        "model": VOYAGE_MODEL,
-        "input_type": "query"
+        "model": this.config.apiModelId,
+        "input_type": "query",
+        ...this.getOutputOptions()
       }
     });
 
@@ -102,7 +131,14 @@ class VoyageContext3Provider implements ContextualEmbeddingProvider {
     const ctxPart = contextTexts && contextTexts.length > 1
       ? `|ctx:${contextHash(contextTexts)}`
       : '';
-    return `|voyageContext3${ctxPart}`;
+    return `|${this.config.cacheKeySuffix}${ctxPart}`;
+  }
+
+  private getOutputOptions(): { output_dimension?: number; output_dtype?: 'float' } {
+    return {
+      ...(this.config.outputDimension ? { output_dimension: this.config.outputDimension } : {}),
+      ...(this.config.outputDtype ? { output_dtype: this.config.outputDtype } : {})
+    };
   }
 
   private batchGroups(groups: string[][]): string[][][] {

--- a/src/ts/process/memory/hypamemory.ts
+++ b/src/ts/process/memory/hypamemory.ts
@@ -5,7 +5,7 @@ import { appendLastPath } from "src/ts/util";
 import { getDatabase } from "src/ts/storage/database.svelte";
 import { isContextModel, getContextProvider } from "./contextualEmbedding";
 
-export type HypaModel = 'custom'|'ada'|'openai3small'|'openai3large'|'MiniLM'|'MiniLMGPU'|'nomic'|'nomicGPU'|'bgeSmallEn'|'bgeSmallEnGPU'|'bgem3'|'bgem3GPU'|'multiMiniLM'|'multiMiniLMGPU'|'bgeM3Ko'|'bgeM3KoGPU'|'voyageContext3'
+export type HypaModel = 'custom'|'ada'|'openai3small'|'openai3large'|'MiniLM'|'MiniLMGPU'|'nomic'|'nomicGPU'|'bgeSmallEn'|'bgeSmallEnGPU'|'bgem3'|'bgem3GPU'|'multiMiniLM'|'multiMiniLMGPU'|'bgeM3Ko'|'bgeM3KoGPU'|'voyageContext3'|'voyageContext4'
 
 // In a typical environment, bge-m3 is a heavy model.
 // If your GPU can't handle this model, you'll see errror below.


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds Voyage Context 4 as a selectable embedding model.

The new option uses Voyage's contextualized embeddings endpoint with `voyage-context-4`, requests 2048-dimensional float embeddings for maximum retrieval quality, and keeps Voyage Context 3 behavior unchanged.

## Related Issues

None.

## Changes

**`src/ts/process/memory/contextualEmbedding.ts`**
- Refactored the Voyage contextual embedding provider to use per-model config
- Added `voyageContext4` mapped to `voyage-context-4`
- Set Voyage Context 4 request options to `output_dimension: 2048` and `output_dtype: "float"`
- Kept Voyage Context 3 request behavior unchanged
- Added a separate cache suffix for Voyage Context 4 so it does not reuse Voyage Context 3 vectors

**`src/ts/process/memory/hypamemory.ts`**
- Added `voyageContext4` to the `HypaModel` type

**`src/lib/Setting/Pages/OtherBotSettings.svelte`**
- Added `Voyage Context 4` to the embedding model selector
- Reused the existing Voyage API key field for both Voyage Context 3 and 4

## Impact

- Existing users are unaffected. The default embedding model remains `MiniLM`, and existing Voyage Context 3 behavior is preserved.
- Users can select `Voyage Context 4` and enter a Voyage API key to use the new provider anywhere RisuAI uses the global embedding model setting.
- Voyage Context 4 embeddings are cached separately from Voyage Context 3 embeddings.
- Because Voyage Context 4 uses 2048-dimensional float vectors, stored embedding size, network payload, and similarity calculation work are higher than the 1024-dimensional default.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- Browser console runtime check against the dev app:
  - `isContextModel("voyageContext4") === true`
  - provider model id is `voyage-context-4`
  - document embeddings returned 2048 dimensions
  - query embeddings returned 2048 dimensions
