### PR TITLE
fix: preserve cold storage during sync and backup

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -31,6 +31,7 @@ export const languageChinese = {
         "vertexAuthError": "Vertex AI 身份验证详情缺失。",
         "coldStorageWriteFailed": "冷存储写入失败。您的聊天数据已被保留。",
         "coldStorageVerifyFailed": "冷存储验证失败。您的聊天数据已被保留。",
+        "coldStorageRestoreFailed": "无法加载冷存储数据。受影响角色的数据可能已永久丢失。",
         "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
             `${characterNames || "未知角色"}的冷存储数据缺失或无效。${unresolvedCount > 0 ? `有 ${unresolvedCount} 个项目无法关联到角色。` : ""}\n\n如果继续，此备份将缺少 ${unavailableCount} 个冷存储项目，受影响的角色或聊天数据可能无法从该备份恢复。\n\n仍要创建不完整的备份吗？`,
         "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>

--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -30,7 +30,11 @@ export const languageChinese = {
         "requestLogRemovedDesc": "当客户端刷新或加载时，该请求记录会被删除。",
         "vertexAuthError": "Vertex AI 身份验证详情缺失。",
         "coldStorageWriteFailed": "冷存储写入失败。您的聊天数据已被保留。",
-        "coldStorageVerifyFailed": "冷存储验证失败。您的聊天数据已被保留。"
+        "coldStorageVerifyFailed": "冷存储验证失败。您的聊天数据已被保留。",
+        "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `${characterNames || "未知角色"}的冷存储数据缺失或无效。${unresolvedCount > 0 ? `有 ${unresolvedCount} 个项目无法关联到角色。` : ""}\n\n如果继续，此备份将缺少 ${unavailableCount} 个冷存储项目，受影响的角色或聊天数据可能无法从该备份恢复。\n\n仍要创建不完整的备份吗？`,
+        "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `无法恢复 ${characterNames || "未知角色"}的冷存储数据。${unresolvedCount > 0 ? `有 ${unresolvedCount} 个项目无法关联到角色。` : ""}\n\n如果继续，${unavailableCount} 个冷存储项目将不可用，受影响的角色或聊天数据可能会永久丢失。\n\n仍要继续不完整的恢复吗？`
     },
     "showHelp": "显示帮助",
     "help": {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -31,6 +31,7 @@ export const languageGerman = {
         "vertexAuthError": "Vertex AI-Authentifizierungsdetails fehlen.",
         "coldStorageWriteFailed": "Kaltlager-Schreibvorgang fehlgeschlagen. Ihre Chat-Daten wurden beibehalten.",
         "coldStorageVerifyFailed": "Kaltlager-Überprüfung fehlgeschlagen. Ihre Chat-Daten wurden beibehalten.",
+        "coldStorageRestoreFailed": "Kaltlagerdaten konnten nicht geladen werden. Die Daten des betroffenen Charakters können dauerhaft verloren sein.",
         "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
             `Kaltlagerdaten für ${characterNames || "unbekannte Charaktere"} fehlen oder sind ungültig.${unresolvedCount > 0 ? ` ${unresolvedCount} Element(e) konnten keinem Charakter zugeordnet werden.` : ""}\n\nWenn Sie fortfahren, fehlen in dieser Sicherung ${unavailableCount} Kaltlagerelement(e). Die betroffenen Charakter- oder Chatdaten können daraus möglicherweise nicht wiederhergestellt werden.\n\nTrotzdem eine unvollständige Sicherung erstellen?`,
         "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -30,7 +30,11 @@ export const languageGerman = {
         "requestLogRemovedDesc": "Dieses Anfrage-Protokoll wird entfernt, wenn der Client aktualisiert oder neu geladen wird.",
         "vertexAuthError": "Vertex AI-Authentifizierungsdetails fehlen.",
         "coldStorageWriteFailed": "Kaltlager-Schreibvorgang fehlgeschlagen. Ihre Chat-Daten wurden beibehalten.",
-        "coldStorageVerifyFailed": "Kaltlager-Überprüfung fehlgeschlagen. Ihre Chat-Daten wurden beibehalten."
+        "coldStorageVerifyFailed": "Kaltlager-Überprüfung fehlgeschlagen. Ihre Chat-Daten wurden beibehalten.",
+        "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `Kaltlagerdaten für ${characterNames || "unbekannte Charaktere"} fehlen oder sind ungültig.${unresolvedCount > 0 ? ` ${unresolvedCount} Element(e) konnten keinem Charakter zugeordnet werden.` : ""}\n\nWenn Sie fortfahren, fehlen in dieser Sicherung ${unavailableCount} Kaltlagerelement(e). Die betroffenen Charakter- oder Chatdaten können daraus möglicherweise nicht wiederhergestellt werden.\n\nTrotzdem eine unvollständige Sicherung erstellen?`,
+        "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `Kaltlagerdaten für ${characterNames || "unbekannte Charaktere"} konnten nicht wiederhergestellt werden.${unresolvedCount > 0 ? ` ${unresolvedCount} Element(e) konnten keinem Charakter zugeordnet werden.` : ""}\n\nWenn Sie fortfahren, bleiben ${unavailableCount} Kaltlagerelement(e) nicht verfügbar. Die betroffenen Charakter- oder Chatdaten können dauerhaft verloren gehen.\n\nTrotzdem mit der unvollständigen Wiederherstellung fortfahren?`
     },
     "showHelp": "Hilfe anzeigen",
     "help": {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -32,6 +32,10 @@ export const languageEnglish = {
         requestLogRemovedDesc: "This request log removes when client is refreshed or reloaded.",
         coldStorageWriteFailed: "Cold storage write failed. Your chat data has been preserved.",
         coldStorageVerifyFailed: "Cold storage verification failed. Your chat data has been preserved.",
+        coldStorageIncompleteBackupConfirm: (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `Cold storage data for ${characterNames || "unknown characters"} is missing or invalid.${unresolvedCount > 0 ? ` ${unresolvedCount} item(s) could not be linked to a character.` : ""}\n\nIf you continue, this backup will be missing ${unavailableCount} cold storage item(s), and the affected character or chat data may not be recoverable from it.\n\nCreate the incomplete backup anyway?`,
+        coldStorageIncompleteRestoreConfirm: (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `Cold storage data for ${characterNames || "unknown characters"} could not be restored.${unresolvedCount > 0 ? ` ${unresolvedCount} item(s) could not be linked to a character.` : ""}\n\nIf you continue, ${unavailableCount} cold storage item(s) will remain unavailable, and the affected character or chat data may be permanently lost.\n\nContinue with the incomplete restore anyway?`,
     },
     showHelp: "Show Help",
     help: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -32,6 +32,7 @@ export const languageEnglish = {
         requestLogRemovedDesc: "This request log removes when client is refreshed or reloaded.",
         coldStorageWriteFailed: "Cold storage write failed. Your chat data has been preserved.",
         coldStorageVerifyFailed: "Cold storage verification failed. Your chat data has been preserved.",
+        coldStorageRestoreFailed: "Cold storage data could not be loaded. The affected character's data may be permanently lost.",
         coldStorageIncompleteBackupConfirm: (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
             `Cold storage data for ${characterNames || "unknown characters"} is missing or invalid.${unresolvedCount > 0 ? ` ${unresolvedCount} item(s) could not be linked to a character.` : ""}\n\nIf you continue, this backup will be missing ${unavailableCount} cold storage item(s), and the affected character or chat data may not be recoverable from it.\n\nCreate the incomplete backup anyway?`,
         coldStorageIncompleteRestoreConfirm: (characterNames: string, unavailableCount: number, unresolvedCount: number) =>

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -31,6 +31,7 @@ export const languageSpanish = {
         "vertexAuthError": "Faltan los detalles de autenticación de Vertex AI.",
         "coldStorageWriteFailed": "Error al escribir en almacenamiento frío. Sus datos de chat se han conservado.",
         "coldStorageVerifyFailed": "Error en la verificación del almacenamiento frío. Sus datos de chat se han conservado.",
+        "coldStorageRestoreFailed": "No se pudieron cargar los datos del almacenamiento frío. Los datos del personaje afectado pueden haberse perdido permanentemente.",
         "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
             `Faltan datos del almacenamiento frío de ${characterNames || "personajes desconocidos"} o no son válidos.${unresolvedCount > 0 ? ` No se pudieron asociar ${unresolvedCount} elemento(s) con un personaje.` : ""}\n\nSi continúa, a esta copia de seguridad le faltarán ${unavailableCount} elemento(s) del almacenamiento frío y puede que no sea posible recuperar los datos de los personajes o chats afectados.\n\n¿Crear de todos modos la copia de seguridad incompleta?`,
         "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -30,7 +30,11 @@ export const languageSpanish = {
         "requestLogRemovedDesc": "Este registro de solicitud se elimina cuando el cliente se actualiza o recarga.",
         "vertexAuthError": "Faltan los detalles de autenticación de Vertex AI.",
         "coldStorageWriteFailed": "Error al escribir en almacenamiento frío. Sus datos de chat se han conservado.",
-        "coldStorageVerifyFailed": "Error en la verificación del almacenamiento frío. Sus datos de chat se han conservado."
+        "coldStorageVerifyFailed": "Error en la verificación del almacenamiento frío. Sus datos de chat se han conservado.",
+        "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `Faltan datos del almacenamiento frío de ${characterNames || "personajes desconocidos"} o no son válidos.${unresolvedCount > 0 ? ` No se pudieron asociar ${unresolvedCount} elemento(s) con un personaje.` : ""}\n\nSi continúa, a esta copia de seguridad le faltarán ${unavailableCount} elemento(s) del almacenamiento frío y puede que no sea posible recuperar los datos de los personajes o chats afectados.\n\n¿Crear de todos modos la copia de seguridad incompleta?`,
+        "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `No se pudieron restaurar los datos del almacenamiento frío de ${characterNames || "personajes desconocidos"}.${unresolvedCount > 0 ? ` No se pudieron asociar ${unresolvedCount} elemento(s) con un personaje.` : ""}\n\nSi continúa, ${unavailableCount} elemento(s) del almacenamiento frío seguirán sin estar disponibles y los datos de los personajes o chats afectados podrían perderse permanentemente.\n\n¿Continuar de todos modos con la restauración incompleta?`
     },
     "showHelp": "Mostrar Ayuda",
     "help": {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -31,6 +31,7 @@ export const languageKorean = {
         "vertexAuthError": "Vertex AI 인증 정보가 누락되었습니다.",
         "coldStorageWriteFailed": "콜드 스토리지 저장에 실패했습니다. 채팅 데이터는 보존되었습니다.",
         "coldStorageVerifyFailed": "콜드 스토리지 검증에 실패했습니다. 채팅 데이터는 보존되었습니다.",
+        "coldStorageRestoreFailed": "콜드 스토리지 데이터를 불러올 수 없습니다. 해당 캐릭터의 데이터가 영구적으로 손실되었을 수 있습니다.",
         "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
             `${characterNames || "알 수 없는 캐릭터"}의 콜드 스토리지 데이터가 없거나 손상되었습니다.${unresolvedCount > 0 ? ` 캐릭터를 확인할 수 없는 항목이 ${unresolvedCount}개 있습니다.` : ""}\n\n계속하면 이 백업에서 콜드 스토리지 항목 ${unavailableCount}개가 누락되며, 해당 캐릭터 또는 채팅 데이터를 이 백업으로 복구하지 못할 수 있습니다.\n\n그래도 불완전한 백업을 생성하시겠습니까?`,
         "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -30,7 +30,11 @@ export const languageKorean = {
         "requestLogRemovedDesc": "요청 로그는 앱이 재시작되거나 새로고침되면 삭제됩니다.",
         "vertexAuthError": "Vertex AI 인증 정보가 누락되었습니다.",
         "coldStorageWriteFailed": "콜드 스토리지 저장에 실패했습니다. 채팅 데이터는 보존되었습니다.",
-        "coldStorageVerifyFailed": "콜드 스토리지 검증에 실패했습니다. 채팅 데이터는 보존되었습니다."
+        "coldStorageVerifyFailed": "콜드 스토리지 검증에 실패했습니다. 채팅 데이터는 보존되었습니다.",
+        "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `${characterNames || "알 수 없는 캐릭터"}의 콜드 스토리지 데이터가 없거나 손상되었습니다.${unresolvedCount > 0 ? ` 캐릭터를 확인할 수 없는 항목이 ${unresolvedCount}개 있습니다.` : ""}\n\n계속하면 이 백업에서 콜드 스토리지 항목 ${unavailableCount}개가 누락되며, 해당 캐릭터 또는 채팅 데이터를 이 백업으로 복구하지 못할 수 있습니다.\n\n그래도 불완전한 백업을 생성하시겠습니까?`,
+        "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `${characterNames || "알 수 없는 캐릭터"}의 콜드 스토리지 데이터를 복원하지 못했습니다.${unresolvedCount > 0 ? ` 캐릭터를 확인할 수 없는 항목이 ${unresolvedCount}개 있습니다.` : ""}\n\n계속하면 콜드 스토리지 항목 ${unavailableCount}개를 사용할 수 없으며, 해당 캐릭터 또는 채팅 데이터가 영구적으로 손실될 수 있습니다.\n\n그래도 불완전한 복원을 계속하시겠습니까?`
     },
     "showHelp": "도움말 보기",
     "help": {

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -30,7 +30,11 @@ export const languageVietnamese = {
         "requestLogRemovedDesc": "This request log removes when client is refreshed or reloaded.",
         "vertexAuthError": "Thiếu thông tin xác thực Vertex AI.",
         "coldStorageWriteFailed": "Ghi vào bộ nhớ lạnh thất bại. Dữ liệu trò chuyện của bạn đã được bảo toàn.",
-        "coldStorageVerifyFailed": "Xác minh bộ nhớ lạnh thất bại. Dữ liệu trò chuyện của bạn đã được bảo toàn."
+        "coldStorageVerifyFailed": "Xác minh bộ nhớ lạnh thất bại. Dữ liệu trò chuyện của bạn đã được bảo toàn.",
+        "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `Dữ liệu bộ nhớ lạnh của ${characterNames || "nhân vật không xác định"} bị thiếu hoặc không hợp lệ.${unresolvedCount > 0 ? ` Có ${unresolvedCount} mục không thể liên kết với nhân vật.` : ""}\n\nNếu tiếp tục, bản sao lưu này sẽ thiếu ${unavailableCount} mục bộ nhớ lạnh và dữ liệu nhân vật hoặc cuộc trò chuyện bị ảnh hưởng có thể không thể khôi phục từ bản sao lưu.\n\nVẫn tạo bản sao lưu không đầy đủ?`,
+        "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `Không thể khôi phục dữ liệu bộ nhớ lạnh của ${characterNames || "nhân vật không xác định"}.${unresolvedCount > 0 ? ` Có ${unresolvedCount} mục không thể liên kết với nhân vật.` : ""}\n\nNếu tiếp tục, ${unavailableCount} mục bộ nhớ lạnh sẽ vẫn không khả dụng và dữ liệu nhân vật hoặc cuộc trò chuyện bị ảnh hưởng có thể bị mất vĩnh viễn.\n\nVẫn tiếp tục khôi phục không đầy đủ?`
     },
     "showHelp": "Hiển thị trợ giúp",
     "help": {

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -31,6 +31,7 @@ export const languageVietnamese = {
         "vertexAuthError": "Thiếu thông tin xác thực Vertex AI.",
         "coldStorageWriteFailed": "Ghi vào bộ nhớ lạnh thất bại. Dữ liệu trò chuyện của bạn đã được bảo toàn.",
         "coldStorageVerifyFailed": "Xác minh bộ nhớ lạnh thất bại. Dữ liệu trò chuyện của bạn đã được bảo toàn.",
+        "coldStorageRestoreFailed": "Không thể tải dữ liệu bộ nhớ lạnh. Dữ liệu của nhân vật bị ảnh hưởng có thể đã bị mất vĩnh viễn.",
         "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
             `Dữ liệu bộ nhớ lạnh của ${characterNames || "nhân vật không xác định"} bị thiếu hoặc không hợp lệ.${unresolvedCount > 0 ? ` Có ${unresolvedCount} mục không thể liên kết với nhân vật.` : ""}\n\nNếu tiếp tục, bản sao lưu này sẽ thiếu ${unavailableCount} mục bộ nhớ lạnh và dữ liệu nhân vật hoặc cuộc trò chuyện bị ảnh hưởng có thể không thể khôi phục từ bản sao lưu.\n\nVẫn tạo bản sao lưu không đầy đủ?`,
         "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -31,6 +31,7 @@ export const languageChineseTraditional = {
         "vertexAuthError": "缺少 Vertex AI 驗證詳細資料。",
         "coldStorageWriteFailed": "冷儲存寫入失敗。您的對話資料已被保留。",
         "coldStorageVerifyFailed": "冷儲存驗證失敗。您的對話資料已被保留。",
+        "coldStorageRestoreFailed": "無法載入冷儲存資料。受影響角色的資料可能已永久遺失。",
         "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
             `${characterNames || "未知角色"}的冷儲存資料遺失或無效。${unresolvedCount > 0 ? `有 ${unresolvedCount} 個項目無法連結到角色。` : ""}\n\n若繼續，此備份將缺少 ${unavailableCount} 個冷儲存項目，受影響的角色或對話資料可能無法從此備份復原。\n\n仍要建立不完整的備份嗎？`,
         "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -30,7 +30,11 @@ export const languageChineseTraditional = {
         "requestLogRemovedDesc": "當用戶端重新整理或重新載入時，該請求記錄會被刪除。",
         "vertexAuthError": "缺少 Vertex AI 驗證詳細資料。",
         "coldStorageWriteFailed": "冷儲存寫入失敗。您的對話資料已被保留。",
-        "coldStorageVerifyFailed": "冷儲存驗證失敗。您的對話資料已被保留。"
+        "coldStorageVerifyFailed": "冷儲存驗證失敗。您的對話資料已被保留。",
+        "coldStorageIncompleteBackupConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `${characterNames || "未知角色"}的冷儲存資料遺失或無效。${unresolvedCount > 0 ? `有 ${unresolvedCount} 個項目無法連結到角色。` : ""}\n\n若繼續，此備份將缺少 ${unavailableCount} 個冷儲存項目，受影響的角色或對話資料可能無法從此備份復原。\n\n仍要建立不完整的備份嗎？`,
+        "coldStorageIncompleteRestoreConfirm": (characterNames: string, unavailableCount: number, unresolvedCount: number) =>
+            `無法復原 ${characterNames || "未知角色"}的冷儲存資料。${unresolvedCount > 0 ? `有 ${unresolvedCount} 個項目無法連結到角色。` : ""}\n\n若繼續，${unavailableCount} 個冷儲存項目將無法使用，受影響的角色或對話資料可能永久遺失。\n\n仍要繼續不完整的復原嗎？`
     },
     "showHelp": "顯示幫助",
     "help": {

--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -879,7 +879,7 @@ export async function changeChar(index: number, arg:{
             DBState.db.characters[index] = coldData.character
         }
         else{
-            alertError(language.errors.coldStorageVerifyFailed)
+            alertError(language.errors.coldStorageRestoreFailed)
             return
         }
     }

--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -875,7 +875,7 @@ export async function changeChar(index: number, arg:{
     reseter();
     if(DBState.db.characters?.[index]?.coldstorage){
         const coldData = await getColdStorageItem(DBState.db.characters[index].coldstorage!)
-        if(coldData.character && coldData.character.chaId === DBState.db.characters[index].chaId){
+        if(coldData?.character && coldData.character.chaId === DBState.db.characters[index].chaId){
             DBState.db.characters[index] = coldData.character
         }
         else{

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -9,7 +9,7 @@ import { relaunch } from "@tauri-apps/plugin-process";
 import { decryptBuffer, encryptBuffer, sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { language } from "src/lang";
-import { getColdStorageBackupKey, getColdStorageBackupName, getColdStorageItem, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
+import { collectColdStorageBackupPayloads, getColdStorageBackupKey, getColdStorageItem, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
 import { DBState } from "../stores.svelte";
 
 function getBasename(data:string){
@@ -21,6 +21,13 @@ function getBasename(data:string){
 
 export async function SaveLocalBackup(){
     alertWait("Saving local backup...")
+    const db = getDatabase()
+    const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
+    if(coldStoragePayloads.missingKeys.length > 0){
+        alertError(`Backup failed. ${coldStoragePayloads.missingKeys.length} cold storage item(s) are missing.`)
+        return
+    }
+
     const writer = new LocalWriter()
     const r = await writer.init()
     if(!r){
@@ -28,7 +35,6 @@ export async function SaveLocalBackup(){
         return
     }
 
-    const db = getDatabase()
     const assetMap = new Map<string, { charName: string, assetName: string }>()
     if (db.characters) {
         for (const char of db.characters) {
@@ -145,19 +151,11 @@ export async function SaveLocalBackup(){
         }
     }
 
-    const coldKeys = await listColdDataKeys()
-    for(let i=0;i<coldKeys.length;i++){
-        const key = coldKeys[i]
-        const backupName = getColdStorageBackupName(key)
-        let message = `Saving local Backup Cold data... (${i + 1} / ${coldKeys.length})`
+    for(let i=0;i<coldStoragePayloads.payloads.length;i++){
+        const payload = coldStoragePayloads.payloads[i]
+        let message = `Saving local Backup Cold data... (${i + 1} / ${coldStoragePayloads.payloads.length})`
         alertWait(message)
-        const data = await getColdStorageItem(key)
-        if(data){
-            const encoded = new TextEncoder().encode(JSON.stringify(data))
-            await writer.writeBackup(backupName, encoded)
-        } else {
-            missingAssets.push(backupName)
-        }
+        await writer.writeBackup(payload.backupName, payload.encoded)
     }
 
     const dbWithoutAccount = { ...db, account: undefined }
@@ -177,7 +175,7 @@ export async function SaveLocalBackup(){
     await writer.close()
 
     if (missingAssets.length > 0) {
-        let message = 'Backup Successful, but the following assets or cold storage items were missing and skipped:\n\n'
+        let message = 'Backup Successful, but the following assets were missing and skipped:\n\n'
         for (const key of missingAssets) {
             const assetInfo = assetMap.get(key)
             if (assetInfo) {
@@ -218,6 +216,13 @@ export async function SavePartialLocalBackup(){
     }
     
     alertWait("Saving partial local backup...")
+    const db = getDatabase()
+    const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
+    if(coldStoragePayloads.missingKeys.length > 0){
+        alertError(`Partial backup failed. ${coldStoragePayloads.missingKeys.length} cold storage item(s) are missing.`)
+        return
+    }
+
     const writer = new LocalWriter()
     const r = await writer.init()
     if(!r){
@@ -225,7 +230,6 @@ export async function SavePartialLocalBackup(){
         return
     }
 
-    const db = getDatabase()
     const assetMap = new Map<string, { charName: string, assetName: string }>()
     
     // Only collect main profile images for both characters and groups
@@ -367,19 +371,11 @@ export async function SavePartialLocalBackup(){
         }
     }
 
-    const coldKeys = await listColdDataKeys()
-    for(let i=0;i<coldKeys.length;i++){
-        const key = coldKeys[i]
-        const backupName = getColdStorageBackupName(key)
-        let message = `Saving partial local Backup Cold data... (${i + 1} / ${coldKeys.length})`
+    for(let i=0;i<coldStoragePayloads.payloads.length;i++){
+        const payload = coldStoragePayloads.payloads[i]
+        let message = `Saving partial local Backup Cold data... (${i + 1} / ${coldStoragePayloads.payloads.length})`
         alertWait(message)
-        const data = await getColdStorageItem(key)
-        if(data){
-            const encoded = new TextEncoder().encode(JSON.stringify(data))
-            await writer.writeBackup(backupName, encoded)
-        } else {
-            missingAssets.push(backupName)
-        }
+        await writer.writeBackup(payload.backupName, payload.encoded)
     }
 
     const dbWithoutAccount = { ...db, account: undefined }
@@ -391,7 +387,7 @@ export async function SavePartialLocalBackup(){
     await writer.close()
 
     if (missingAssets.length > 0) {
-        let message = 'Partial backup successful, but the following profile images or cold storage items were missing and skipped:\n\n'
+        let message = 'Partial backup successful, but the following profile images were missing and skipped:\n\n'
         for (const key of missingAssets) {
             const assetInfo = assetMap.get(key)
             if (assetInfo) {
@@ -429,6 +425,8 @@ export function LoadLocalBackup(){
             const CHUNK_SIZE = 1024 * 1024; // 1MB chunk size
             let bytesRead = 0;
             let remainingBuffer = new Uint8Array();
+            let pendingDatabase: Uint8Array | null = null;
+            const restoredColdStorageKeys = new Set<string>();
 
             while (true) {
                 const { done, value } = await reader.read();
@@ -481,36 +479,7 @@ export function LoadLocalBackup(){
                     }
 
                     else if (name === 'database.risudat') {
-                        let db = new Uint8Array(data);
-                        if(encryptionMeta.type === 'account' && encryptionMeta.time){
-                            try {
-                                const key = (await (await fetch(`https://sv.risuai.xyz/cryptokey?key=${encryptionMeta.time}`)).json()).key
-                                const decrypted = await decryptBuffer(db, key)
-                                db = new Uint8Array(decrypted)
-                            }
-                            catch (e) {
-                                console.error('Failed to decrypt database backup:', e)
-                                alertError('Failed to decrypt database backup, will attempt to load it without decryption.')
-                            }
-                        }
-                        const dbData = await decodeRisuSave(db);
-                        setDatabaseLite(dbData);
-                        requiresFullEncoderReload.state = true;
-                        if (isTauri) {
-                            await writeFile('database/database.bin', db, { baseDir: BaseDirectory.AppData });
-                            await relaunch();
-                            alertStore.set({
-                                type: "wait",
-                                msg: "Success, Refreshing your app."
-                            });
-                        } else {
-                            await forageStorage.setItem('database/database.bin', db);
-                            location.search = '';
-                            alertStore.set({
-                                type: "wait",
-                                msg: "Success, Refreshing your app."
-                            });
-                        }
+                        pendingDatabase = new Uint8Array(data);
                     }
                     
                     else {
@@ -518,13 +487,17 @@ export function LoadLocalBackup(){
                         let handledAsColdStorage = false
 
                         if (coldStorageKey) {
+                            handledAsColdStorage = true
                             try {
                                 const text = new TextDecoder().decode(data)
                                 const jsonData = JSON.parse(text)
 
                                 if (isColdStorageBackupData(jsonData)) {
-                                    await setColdStorageItem(coldStorageKey, jsonData)
-                                    handledAsColdStorage = true
+                                    if(await setColdStorageItem(coldStorageKey, jsonData)){
+                                        restoredColdStorageKeys.add(coldStorageKey)
+                                    } else {
+                                        console.error(`Failed to restore cold storage item ${coldStorageKey}`)
+                                    }
                                 } else {
                                     console.warn(`Skipping invalid cold storage backup item ${name}`)
                                 }
@@ -549,6 +522,57 @@ export function LoadLocalBackup(){
                     offset += 4 + nameLength + 4 + dataLength;
                 }
                 remainingBuffer = remainingBuffer.slice(offset);
+            }
+
+            if(!pendingDatabase){
+                alertError('Failed, Is file corrupted?')
+                return
+            }
+
+            let db = pendingDatabase;
+            if(encryptionMeta.type === 'account' && encryptionMeta.time){
+                try {
+                    const key = (await (await fetch(`https://sv.risuai.xyz/cryptokey?key=${encryptionMeta.time}`)).json()).key
+                    const decrypted = await decryptBuffer(db, key)
+                    db = new Uint8Array(decrypted)
+                }
+                catch (e) {
+                    console.error('Failed to decrypt database backup:', e)
+                    alertError('Failed to decrypt database backup, will attempt to load it without decryption.')
+                }
+            }
+            const dbData = await decodeRisuSave(db);
+            const missingColdStorageKeys:string[] = []
+            for(const key of await listColdDataKeys(dbData)){
+                if(restoredColdStorageKeys.has(key)){
+                    continue
+                }
+                const existingColdStorage = await getColdStorageItem(key)
+                if(!existingColdStorage){
+                    missingColdStorageKeys.push(key)
+                }
+            }
+            if(missingColdStorageKeys.length > 0){
+                alertError(`Backup restore failed. ${missingColdStorageKeys.length} cold storage item(s) are missing.`)
+                return
+            }
+
+            setDatabaseLite(dbData);
+            requiresFullEncoderReload.state = true;
+            if (isTauri) {
+                await writeFile('database/database.bin', db, { baseDir: BaseDirectory.AppData });
+                await relaunch();
+                alertStore.set({
+                    type: "wait",
+                    msg: "Success, Refreshing your app."
+                });
+            } else {
+                await forageStorage.setItem('database/database.bin', db);
+                location.search = '';
+                alertStore.set({
+                    type: "wait",
+                    msg: "Success, Refreshing your app."
+                });
             }
 
             alertNormal('Success');

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -9,7 +9,7 @@ import { relaunch } from "@tauri-apps/plugin-process";
 import { decryptBuffer, encryptBuffer, sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { language } from "src/lang";
-import { getColdStorageItem, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
+import { getColdStorageBackupKey, getColdStorageBackupName, getColdStorageItem, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
 import { DBState } from "../stores.svelte";
 
 function getBasename(data:string){
@@ -17,21 +17,6 @@ function getBasename(data:string){
     const splited = data.replace(baseNameRegex, '/').split('/')
     const lasts = splited[splited.length-1]
     return lasts
-}
-
-function getColdStorageBackupKey(name: string): string | null {
-    const match = name.match(/^(?:coldstorage[/_])?([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.json$/)
-    return match?.[1] ?? null
-}
-
-function isColdStorageBackupData(data: unknown): boolean {
-    if (Array.isArray(data)) {
-        return true
-    }
-
-    return !!data
-        && typeof data === 'object'
-        && ('character' in data || 'message' in data)
 }
 
 export async function SaveLocalBackup(){
@@ -160,20 +145,18 @@ export async function SaveLocalBackup(){
         }
     }
 
-    if(!forageStorage.isAccount){
-        //save coldstorages
-        const coldKeys = await listColdDataKeys()
-        for(let i=0;i<coldKeys.length;i++){
-            const key = coldKeys[i]
-            let message = `Saving local Backup Cold data... (${i + 1} / ${coldKeys.length})`
-            alertWait(message)
-            const data = await getColdStorageItem(key)
-            if(data){
-                const encoded = new TextEncoder().encode(JSON.stringify(data))
-                await writer.writeBackup(`coldstorage_${key}.json`, encoded)
-            } else {
-                missingAssets.push(`coldstorage_${key}.json`)
-            }
+    const coldKeys = await listColdDataKeys()
+    for(let i=0;i<coldKeys.length;i++){
+        const key = coldKeys[i]
+        const backupName = getColdStorageBackupName(key)
+        let message = `Saving local Backup Cold data... (${i + 1} / ${coldKeys.length})`
+        alertWait(message)
+        const data = await getColdStorageItem(key)
+        if(data){
+            const encoded = new TextEncoder().encode(JSON.stringify(data))
+            await writer.writeBackup(backupName, encoded)
+        } else {
+            missingAssets.push(backupName)
         }
     }
 
@@ -194,7 +177,7 @@ export async function SaveLocalBackup(){
     await writer.close()
 
     if (missingAssets.length > 0) {
-        let message = 'Backup Successful, but the following assets were missing and skipped:\n\n'
+        let message = 'Backup Successful, but the following assets or cold storage items were missing and skipped:\n\n'
         for (const key of missingAssets) {
             const assetInfo = assetMap.get(key)
             if (assetInfo) {
@@ -384,20 +367,18 @@ export async function SavePartialLocalBackup(){
         }
     }
 
-    if(!forageStorage.isAccount){
-        //save coldstorages
-        const coldKeys = await listColdDataKeys()
-        for(let i=0;i<coldKeys.length;i++){
-            const key = coldKeys[i]
-            let message = `Saving partial local Backup Cold data... (${i + 1} / ${coldKeys.length})`
-            alertWait(message)
-            const data = await getColdStorageItem(key)
-            if(data){
-                const encoded = new TextEncoder().encode(JSON.stringify(data))
-                await writer.writeBackup(`coldstorage_${key}.json`, encoded)
-            } else {
-                missingAssets.push(`coldstorage_${key}.json`)
-            }
+    const coldKeys = await listColdDataKeys()
+    for(let i=0;i<coldKeys.length;i++){
+        const key = coldKeys[i]
+        const backupName = getColdStorageBackupName(key)
+        let message = `Saving partial local Backup Cold data... (${i + 1} / ${coldKeys.length})`
+        alertWait(message)
+        const data = await getColdStorageItem(key)
+        if(data){
+            const encoded = new TextEncoder().encode(JSON.stringify(data))
+            await writer.writeBackup(backupName, encoded)
+        } else {
+            missingAssets.push(backupName)
         }
     }
 
@@ -410,7 +391,7 @@ export async function SavePartialLocalBackup(){
     await writer.close()
 
     if (missingAssets.length > 0) {
-        let message = 'Partial backup successful, but the following profile images were missing and skipped:\n\n'
+        let message = 'Partial backup successful, but the following profile images or cold storage items were missing and skipped:\n\n'
         for (const key of missingAssets) {
             const assetInfo = assetMap.get(key)
             if (assetInfo) {
@@ -536,10 +517,7 @@ export function LoadLocalBackup(){
                         const coldStorageKey = getColdStorageBackupKey(name)
                         let handledAsColdStorage = false
 
-                        if (coldStorageKey && forageStorage.isAccount) {
-                            handledAsColdStorage = true
-                        }
-                        else if (coldStorageKey) {
+                        if (coldStorageKey) {
                             try {
                                 const text = new TextDecoder().decode(data)
                                 const jsonData = JSON.parse(text)

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -23,8 +23,9 @@ export async function SaveLocalBackup(){
     alertWait("Saving local backup...")
     const db = getDatabase()
     const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
-    if(coldStoragePayloads.missingKeys.length > 0){
-        alertError(`Backup failed. ${coldStoragePayloads.missingKeys.length} cold storage item(s) are missing.`)
+    const unavailableColdStorageCount = coldStoragePayloads.missingKeys.length + coldStoragePayloads.invalidKeys.length
+    if(unavailableColdStorageCount > 0){
+        alertError(`Backup failed. ${unavailableColdStorageCount} cold storage item(s) are missing or invalid.`)
         return
     }
 
@@ -218,8 +219,9 @@ export async function SavePartialLocalBackup(){
     alertWait("Saving partial local backup...")
     const db = getDatabase()
     const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
-    if(coldStoragePayloads.missingKeys.length > 0){
-        alertError(`Partial backup failed. ${coldStoragePayloads.missingKeys.length} cold storage item(s) are missing.`)
+    const unavailableColdStorageCount = coldStoragePayloads.missingKeys.length + coldStoragePayloads.invalidKeys.length
+    if(unavailableColdStorageCount > 0){
+        alertError(`Partial backup failed. ${unavailableColdStorageCount} cold storage item(s) are missing or invalid.`)
         return
     }
 

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -9,7 +9,7 @@ import { relaunch } from "@tauri-apps/plugin-process";
 import { decryptBuffer, encryptBuffer, sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { language } from "src/lang";
-import { collectColdStorageBackupPayloads, getColdStorageBackupKey, getColdStorageItem, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
+import { collectColdStorageBackupPayloads, confirmIncompleteColdStorageOperation, getColdStorageBackupKey, getColdStorageItem, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
 import { DBState } from "../stores.svelte";
 
 function getBasename(data:string){
@@ -23,9 +23,8 @@ export async function SaveLocalBackup(){
     alertWait("Saving local backup...")
     const db = getDatabase()
     const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
-    const unavailableColdStorageCount = coldStoragePayloads.missingKeys.length + coldStoragePayloads.invalidKeys.length
-    if(unavailableColdStorageCount > 0){
-        alertError(`Backup failed. ${unavailableColdStorageCount} cold storage item(s) are missing or invalid.`)
+    const unavailableColdStorageKeys = [...coldStoragePayloads.missingKeys, ...coldStoragePayloads.invalidKeys]
+    if(!await confirmIncompleteColdStorageOperation(db, unavailableColdStorageKeys, 'backup')){
         return
     }
 
@@ -219,9 +218,8 @@ export async function SavePartialLocalBackup(){
     alertWait("Saving partial local backup...")
     const db = getDatabase()
     const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
-    const unavailableColdStorageCount = coldStoragePayloads.missingKeys.length + coldStoragePayloads.invalidKeys.length
-    if(unavailableColdStorageCount > 0){
-        alertError(`Partial backup failed. ${unavailableColdStorageCount} cold storage item(s) are missing or invalid.`)
+    const unavailableColdStorageKeys = [...coldStoragePayloads.missingKeys, ...coldStoragePayloads.invalidKeys]
+    if(!await confirmIncompleteColdStorageOperation(db, unavailableColdStorageKeys, 'backup')){
         return
     }
 
@@ -550,12 +548,11 @@ export function LoadLocalBackup(){
                     continue
                 }
                 const existingColdStorage = await getColdStorageItem(key)
-                if(!existingColdStorage){
+                if(!isColdStorageBackupData(existingColdStorage)){
                     missingColdStorageKeys.push(key)
                 }
             }
-            if(missingColdStorageKeys.length > 0){
-                alertError(`Backup restore failed. ${missingColdStorageKeys.length} cold storage item(s) are missing.`)
+            if(!await confirmIncompleteColdStorageOperation(dbData, missingColdStorageKeys, 'restore')){
                 return
             }
 

--- a/src/ts/drive/drive.ts
+++ b/src/ts/drive/drive.ts
@@ -128,8 +128,9 @@ async function backupDrive(ACCESS_TOKEN:string) {
     })
 
     const coldStoragePayloads = await collectColdStorageBackupPayloads(getDatabase())
-    if(coldStoragePayloads.missingKeys.length > 0){
-        alertError(`Backup failed. ${coldStoragePayloads.missingKeys.length} cold storage item(s) are missing.`)
+    const unavailableColdStorageCount = coldStoragePayloads.missingKeys.length + coldStoragePayloads.invalidKeys.length
+    if(unavailableColdStorageCount > 0){
+        alertError(`Backup failed. ${unavailableColdStorageCount} cold storage item(s) are missing or invalid.`)
         return
     }
 

--- a/src/ts/drive/drive.ts
+++ b/src/ts/drive/drive.ts
@@ -8,6 +8,7 @@ import { relaunch } from '@tauri-apps/plugin-process';
 import { sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { decodeRisuSave, encodeRisuSaveLegacy } from "../storage/risuSave";
+import { getColdStorageBackupName, getColdStorageItem, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
 
 export async function checkDriver(type:'save'|'load'|'loadtauri'|'savetauri'|'reftoken'){
     const CLIENT_ID = '580075990041-l26k2d3c0nemmqiu3d3aag01npfrkn76.apps.googleusercontent.com';
@@ -164,6 +165,25 @@ async function backupDrive(ACCESS_TOKEN:string) {
         }
     }
 
+    const coldKeys = await listColdDataKeys(getDatabase())
+    for(let i=0;i<coldKeys.length;i++){
+        const key = coldKeys[i]
+        const coldStorageName = getColdStorageBackupName(key)
+        alertStore.set({
+            type: "wait",
+            msg: `Uploading Cold Storage... (${i + 1} / ${coldKeys.length})`
+        })
+        if(fileNames.includes(coldStorageName)){
+            continue
+        }
+        const data = await getColdStorageItem(key)
+        if(!data){
+            console.warn(`Skipping missing cold storage item ${key}`)
+            continue
+        }
+        await createFileInFolder(ACCESS_TOKEN, coldStorageName, new TextEncoder().encode(JSON.stringify(data)))
+    }
+
     const dbData = encodeRisuSaveLegacy(getDatabase(), 'compression')
 
     alertStore.set({
@@ -282,6 +302,7 @@ async function loadDrive(ACCESS_TOKEN:string, mode: 'backup'|'sync'):Promise<voi
         const db:Database = mode === 'backup' ? await getDbFromList() : JSON.parse(Buffer.from(await getFileData(ACCESS_TOKEN, dbs[0][0].id)).toString('utf-8'))
         lastSaved = Date.now()
         localStorage.setItem('risu_lastsaved', `${lastSaved}`)
+        await restoreColdStorageFromDrive(ACCESS_TOKEN, files, db, mode)
         const requiredImages = (await getUncleanables(db))
         let ind = 0;
         let errorLogs:string[] = []
@@ -354,6 +375,43 @@ async function loadDrive(ACCESS_TOKEN:string, mode: 'backup'|'sync'):Promise<voi
     }
     else if(mode === 'backup'){
         location.search = ''
+    }
+}
+
+async function restoreColdStorageFromDrive(
+    ACCESS_TOKEN:string,
+    files:DriveFile[],
+    db:Database,
+    mode:'backup'|'sync'
+) {
+    const coldKeys = await listColdDataKeys(db)
+    for(let i=0;i<coldKeys.length;i++){
+        const key = coldKeys[i]
+        const names = new Set([
+            getColdStorageBackupName(key),
+            `coldstorage/${key}.json`,
+            `${key}.json`
+        ])
+        const file = files.find((driveFile) => names.has(driveFile.name))
+        if(!file){
+            console.warn(`Cold storage data not found in Drive backup: ${key}`)
+            continue
+        }
+        alertStore.set({
+            type: "wait",
+            msg: `${mode === 'sync' ? 'Sync' : 'Loading Backup'} Cold Storage... (${i + 1} / ${coldKeys.length})`
+        })
+        try {
+            const jsonData = JSON.parse(new TextDecoder().decode(await getFileData(ACCESS_TOKEN, file.id)))
+            if(isColdStorageBackupData(jsonData)){
+                await setColdStorageItem(key, jsonData)
+            }
+            else{
+                console.warn(`Skipping invalid cold storage Drive item ${file.name}`)
+            }
+        } catch (error) {
+            console.error(`Failed to restore cold storage item ${key}:`, error)
+        }
     }
 }
 

--- a/src/ts/drive/drive.ts
+++ b/src/ts/drive/drive.ts
@@ -8,7 +8,7 @@ import { relaunch } from '@tauri-apps/plugin-process';
 import { sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { decodeRisuSave, encodeRisuSaveLegacy } from "../storage/risuSave";
-import { collectColdStorageBackupPayloads, getColdStorageBackupName, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
+import { collectColdStorageBackupPayloads, confirmIncompleteColdStorageOperation, getColdStorageBackupName, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
 
 export async function checkDriver(type:'save'|'load'|'loadtauri'|'savetauri'|'reftoken'){
     const CLIENT_ID = '580075990041-l26k2d3c0nemmqiu3d3aag01npfrkn76.apps.googleusercontent.com';
@@ -128,9 +128,8 @@ async function backupDrive(ACCESS_TOKEN:string) {
     })
 
     const coldStoragePayloads = await collectColdStorageBackupPayloads(getDatabase())
-    const unavailableColdStorageCount = coldStoragePayloads.missingKeys.length + coldStoragePayloads.invalidKeys.length
-    if(unavailableColdStorageCount > 0){
-        alertError(`Backup failed. ${unavailableColdStorageCount} cold storage item(s) are missing or invalid.`)
+    const unavailableColdStorageKeys = [...coldStoragePayloads.missingKeys, ...coldStoragePayloads.invalidKeys]
+    if(!await confirmIncompleteColdStorageOperation(getDatabase(), unavailableColdStorageKeys, 'backup')){
         return
     }
 
@@ -302,8 +301,13 @@ async function loadDrive(ACCESS_TOKEN:string, mode: 'backup'|'sync'):Promise<voi
         const db:Database = mode === 'backup' ? await getDbFromList() : JSON.parse(Buffer.from(await getFileData(ACCESS_TOKEN, dbs[0][0].id)).toString('utf-8'))
         const coldStorageRestoreFailures = await restoreColdStorageFromDrive(ACCESS_TOKEN, files, db, mode)
         if(coldStorageRestoreFailures.length > 0){
-            alertError(`${mode === 'sync' ? 'Sync' : 'Backup restore'} failed. ${coldStorageRestoreFailures.length} cold storage item(s) could not be restored.`)
-            return
+            if(mode === 'sync'){
+                alertError(`Sync failed. ${coldStorageRestoreFailures.length} cold storage item(s) could not be restored.`)
+                return
+            }
+            if(!await confirmIncompleteColdStorageOperation(db, coldStorageRestoreFailures, 'restore')){
+                return
+            }
         }
         const requiredImages = (await getUncleanables(db))
         let ind = 0;

--- a/src/ts/drive/drive.ts
+++ b/src/ts/drive/drive.ts
@@ -8,7 +8,7 @@ import { relaunch } from '@tauri-apps/plugin-process';
 import { sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { decodeRisuSave, encodeRisuSaveLegacy } from "../storage/risuSave";
-import { getColdStorageBackupName, getColdStorageItem, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
+import { collectColdStorageBackupPayloads, getColdStorageBackupName, isColdStorageBackupData, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
 
 export async function checkDriver(type:'save'|'load'|'loadtauri'|'savetauri'|'reftoken'){
     const CLIENT_ID = '580075990041-l26k2d3c0nemmqiu3d3aag01npfrkn76.apps.googleusercontent.com';
@@ -127,6 +127,12 @@ async function backupDrive(ACCESS_TOKEN:string) {
         return d.name
     })
 
+    const coldStoragePayloads = await collectColdStorageBackupPayloads(getDatabase())
+    if(coldStoragePayloads.missingKeys.length > 0){
+        alertError(`Backup failed. ${coldStoragePayloads.missingKeys.length} cold storage item(s) are missing.`)
+        return
+    }
+
     if(isTauri){
         const assets = await readDir('assets', {baseDir: BaseDirectory.AppData})
         let i = 0;
@@ -165,23 +171,16 @@ async function backupDrive(ACCESS_TOKEN:string) {
         }
     }
 
-    const coldKeys = await listColdDataKeys(getDatabase())
-    for(let i=0;i<coldKeys.length;i++){
-        const key = coldKeys[i]
-        const coldStorageName = getColdStorageBackupName(key)
+    for(let i=0;i<coldStoragePayloads.payloads.length;i++){
+        const payload = coldStoragePayloads.payloads[i]
         alertStore.set({
             type: "wait",
-            msg: `Uploading Cold Storage... (${i + 1} / ${coldKeys.length})`
+            msg: `Uploading Cold Storage... (${i + 1} / ${coldStoragePayloads.payloads.length})`
         })
-        if(fileNames.includes(coldStorageName)){
+        if(fileNames.includes(payload.backupName)){
             continue
         }
-        const data = await getColdStorageItem(key)
-        if(!data){
-            console.warn(`Skipping missing cold storage item ${key}`)
-            continue
-        }
-        await createFileInFolder(ACCESS_TOKEN, coldStorageName, new TextEncoder().encode(JSON.stringify(data)))
+        await createFileInFolder(ACCESS_TOKEN, payload.backupName, payload.encoded)
     }
 
     const dbData = encodeRisuSaveLegacy(getDatabase(), 'compression')
@@ -302,7 +301,11 @@ async function loadDrive(ACCESS_TOKEN:string, mode: 'backup'|'sync'):Promise<voi
         const db:Database = mode === 'backup' ? await getDbFromList() : JSON.parse(Buffer.from(await getFileData(ACCESS_TOKEN, dbs[0][0].id)).toString('utf-8'))
         lastSaved = Date.now()
         localStorage.setItem('risu_lastsaved', `${lastSaved}`)
-        await restoreColdStorageFromDrive(ACCESS_TOKEN, files, db, mode)
+        const coldStorageRestoreFailures = await restoreColdStorageFromDrive(ACCESS_TOKEN, files, db, mode)
+        if(coldStorageRestoreFailures.length > 0){
+            alertError(`${mode === 'sync' ? 'Sync' : 'Backup restore'} failed. ${coldStorageRestoreFailures.length} cold storage item(s) could not be restored.`)
+            return
+        }
         const requiredImages = (await getUncleanables(db))
         let ind = 0;
         let errorLogs:string[] = []
@@ -385,6 +388,7 @@ async function restoreColdStorageFromDrive(
     mode:'backup'|'sync'
 ) {
     const coldKeys = await listColdDataKeys(db)
+    const failures:string[] = []
     for(let i=0;i<coldKeys.length;i++){
         const key = coldKeys[i]
         const names = new Set([
@@ -395,6 +399,7 @@ async function restoreColdStorageFromDrive(
         const file = files.find((driveFile) => names.has(driveFile.name))
         if(!file){
             console.warn(`Cold storage data not found in Drive backup: ${key}`)
+            failures.push(key)
             continue
         }
         alertStore.set({
@@ -404,15 +409,20 @@ async function restoreColdStorageFromDrive(
         try {
             const jsonData = JSON.parse(new TextDecoder().decode(await getFileData(ACCESS_TOKEN, file.id)))
             if(isColdStorageBackupData(jsonData)){
-                await setColdStorageItem(key, jsonData)
+                if(!await setColdStorageItem(key, jsonData)){
+                    failures.push(key)
+                }
             }
             else{
                 console.warn(`Skipping invalid cold storage Drive item ${file.name}`)
+                failures.push(key)
             }
         } catch (error) {
             console.error(`Failed to restore cold storage item ${key}:`, error)
+            failures.push(key)
         }
     }
+    return failures
 }
 
 function checkImageExist(image:string){

--- a/src/ts/drive/drive.ts
+++ b/src/ts/drive/drive.ts
@@ -299,8 +299,6 @@ async function loadDrive(ACCESS_TOKEN:string, mode: 'backup'|'sync'):Promise<voi
         }
     
         const db:Database = mode === 'backup' ? await getDbFromList() : JSON.parse(Buffer.from(await getFileData(ACCESS_TOKEN, dbs[0][0].id)).toString('utf-8'))
-        lastSaved = Date.now()
-        localStorage.setItem('risu_lastsaved', `${lastSaved}`)
         const coldStorageRestoreFailures = await restoreColdStorageFromDrive(ACCESS_TOKEN, files, db, mode)
         if(coldStorageRestoreFailures.length > 0){
             alertError(`${mode === 'sync' ? 'Sync' : 'Backup restore'} failed. ${coldStorageRestoreFailures.length} cold storage item(s) could not be restored.`)
@@ -361,6 +359,8 @@ async function loadDrive(ACCESS_TOKEN:string, mode: 'backup'|'sync'):Promise<voi
 
         if(isTauri){
             await writeFile('database/database.bin', dbData, {baseDir: BaseDirectory.AppData})
+            lastSaved = Date.now()
+            localStorage.setItem('risu_lastsaved', `${lastSaved}`)
             relaunch()
             alertStore.set({
                 type: "wait",
@@ -369,6 +369,8 @@ async function loadDrive(ACCESS_TOKEN:string, mode: 'backup'|'sync'):Promise<voi
         }
         else{
             await forageStorage.setItem('database/database.bin', dbData)
+            lastSaved = Date.now()
+            localStorage.setItem('risu_lastsaved', `${lastSaved}`)
             location.search = ''
             alertStore.set({
                 type: "wait",

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -958,7 +958,7 @@ export async function getUncleanables(db: Database, uptype: 'basename' | 'pure' 
         for(let cha of db.characters){
             if(cha?.coldstorage){
                 const coldData = await getColdStorageItem(cha.coldstorage!)
-                if(coldData.character && coldData.character.chaId === cha.chaId){
+                if(coldData?.character && coldData.character.chaId === cha.chaId){
                     cha = coldData.character
                 }
             }

--- a/src/ts/process/coldstorage.svelte.ts
+++ b/src/ts/process/coldstorage.svelte.ts
@@ -15,13 +15,14 @@ import { fetchProtectedResource } from "../sionyw"
 import { alertClear, alertError, alertWait } from "../alert"
 import { language } from "src/lang"
 import type { Database, character } from "../storage/database.svelte"
-import { coldStorageHeader, getColdStorageBackupName, listColdDataKeysFromDb } from "./coldstorageData"
+import { coldStorageHeader, getColdStorageBackupName, isColdStorageBackupData, listColdDataKeysFromDb } from "./coldstorageData"
 
 export {
     coldStorageHeader,
     getColdStorageBackupKey,
     getColdStorageBackupName,
     isColdStorageBackupData,
+    replaceColdStoragePayloadResources,
     listColdDataKeysFromDb
 } from "./coldstorageData"
 
@@ -324,16 +325,23 @@ export type ColdStorageBackupPayload = {
 export async function collectColdStorageBackupPayloads(db: Pick<Database, 'characters'> = DBState.db): Promise<{
     payloads: ColdStorageBackupPayload[]
     missingKeys: string[]
+    invalidKeys: string[]
 }> {
     const coldKeys = await listColdDataKeys(db)
     const payloads: ColdStorageBackupPayload[] = []
     const missingKeys: string[] = []
+    const invalidKeys: string[] = []
 
     for (const key of coldKeys) {
         try {
             const value = await getColdStorageItem(key)
             if (!value) {
                 missingKeys.push(key)
+                continue
+            }
+
+            if (!isColdStorageBackupData(value)) {
+                invalidKeys.push(key)
                 continue
             }
 
@@ -349,7 +357,7 @@ export async function collectColdStorageBackupPayloads(db: Pick<Database, 'chara
         }
     }
 
-    return { payloads, missingKeys }
+    return { payloads, missingKeys, invalidKeys }
 }
 
 async function makeColdDataForCharacter(i:number, coldTime:number): Promise<boolean>{

--- a/src/ts/process/coldstorage.svelte.ts
+++ b/src/ts/process/coldstorage.svelte.ts
@@ -15,7 +15,7 @@ import { fetchProtectedResource } from "../sionyw"
 import { alertClear, alertError, alertWait } from "../alert"
 import { language } from "src/lang"
 import type { Database, character } from "../storage/database.svelte"
-import { coldStorageHeader, listColdDataKeysFromDb } from "./coldstorageData"
+import { coldStorageHeader, getColdStorageBackupName, listColdDataKeysFromDb } from "./coldstorageData"
 
 export {
     coldStorageHeader,
@@ -312,6 +312,44 @@ async function removeColdStorageItems(keys:string[]) {
 
 export async function listColdDataKeys(db: Pick<Database, 'characters'> = DBState.db): Promise<string[]> {
     return listColdDataKeysFromDb(db)
+}
+
+export type ColdStorageBackupPayload = {
+    key: string
+    backupName: string
+    value: unknown
+    encoded: Uint8Array
+}
+
+export async function collectColdStorageBackupPayloads(db: Pick<Database, 'characters'> = DBState.db): Promise<{
+    payloads: ColdStorageBackupPayload[]
+    missingKeys: string[]
+}> {
+    const coldKeys = await listColdDataKeys(db)
+    const payloads: ColdStorageBackupPayload[] = []
+    const missingKeys: string[] = []
+
+    for (const key of coldKeys) {
+        try {
+            const value = await getColdStorageItem(key)
+            if (!value) {
+                missingKeys.push(key)
+                continue
+            }
+
+            payloads.push({
+                key,
+                backupName: getColdStorageBackupName(key),
+                value,
+                encoded: new TextEncoder().encode(JSON.stringify(value))
+            })
+        } catch (error) {
+            console.error(`Failed to read cold storage item ${key}:`, error)
+            missingKeys.push(key)
+        }
+    }
+
+    return { payloads, missingKeys }
 }
 
 async function makeColdDataForCharacter(i:number, coldTime:number): Promise<boolean>{

--- a/src/ts/process/coldstorage.svelte.ts
+++ b/src/ts/process/coldstorage.svelte.ts
@@ -14,9 +14,16 @@ import { compress as fflateCompress, decompress as fflateDecompress } from "ffla
 import { fetchProtectedResource } from "../sionyw"
 import { alertClear, alertError, alertWait } from "../alert"
 import { language } from "src/lang"
-import type { character } from "../storage/database.svelte"
+import type { Database, character } from "../storage/database.svelte"
+import { coldStorageHeader, listColdDataKeysFromDb } from "./coldstorageData"
 
-export const coldStorageHeader = '\uEF01COLDSTORAGE\uEF01'
+export {
+    coldStorageHeader,
+    getColdStorageBackupKey,
+    getColdStorageBackupName,
+    isColdStorageBackupData,
+    listColdDataKeysFromDb
+} from "./coldstorageData"
 
 async function decompress(data:Uint8Array) {
     return new Promise<Uint8Array>((resolve, reject) => {
@@ -96,13 +103,10 @@ export async function getColdStorageItem(key:string, opts:{
     }
 }
 
-export async function setColdStorageItem(key:string, value:any):Promise<boolean> {
-    console.log("setting cold storage item", key, value)
-
-    let compressed:Uint8Array
+async function compressColdStorageValue(value:any):Promise<Uint8Array | null> {
     try {
         const json = JSON.stringify(value)
-        compressed = await (new Promise<Uint8Array>((resolve, reject) => {
+        return await (new Promise<Uint8Array>((resolve, reject) => {
             fflateCompress(new TextEncoder().encode(json), (err, result) => {
                 if (err) {
                     return reject(err)
@@ -112,30 +116,49 @@ export async function setColdStorageItem(key:string, value:any):Promise<boolean>
         }))
     } catch (error) {
         console.error('Cold storage compression failed:', error)
+        return null
+    }
+}
+
+export async function setAccountColdStorageItem(key:string, value:any):Promise<boolean> {
+    const compressed = await compressColdStorageValue(value)
+    if(!compressed){
         return false
     }
 
-    if(forageStorage.isAccount){
-        try {
-            const res = await fetchProtectedResource('/hub/account/coldstorage', {
-                method: 'POST',
-                headers: {
-                    'x-risu-key': key,
-                    'content-type': 'application/octet-stream'
-                },
-                body: compressed as any
-            })
-            if(res.status !== 200){
-                console.error('Error setting cold storage item:', await res.text().catch(() => 'unknown'))
-                return false
-            }
-            return true
-        } catch (error) {
-            console.error('Cold storage account write failed:', error)
+    try {
+        const res = await fetchProtectedResource('/hub/account/coldstorage', {
+            method: 'POST',
+            headers: {
+                'x-risu-key': key,
+                'content-type': 'application/octet-stream'
+            },
+            body: compressed as any
+        })
+        if(res.status !== 200){
+            console.error('Error setting cold storage item:', await res.text().catch(() => 'unknown'))
             return false
         }
+        return true
+    } catch (error) {
+        console.error('Cold storage account write failed:', error)
+        return false
     }
-    else if(isNodeServer){
+}
+
+export async function setColdStorageItem(key:string, value:any):Promise<boolean> {
+    console.log("setting cold storage item", key, value)
+
+    if(forageStorage.isAccount){
+        return await setAccountColdStorageItem(key, value)
+    }
+
+    const compressed = await compressColdStorageValue(value)
+    if(!compressed){
+        return false
+    }
+
+    if(isNodeServer){
         try {
             const storage = forageStorage.realStorage as NodeStorage
             await storage.setItem('coldstorage/' + key, compressed)
@@ -287,23 +310,8 @@ async function removeColdStorageItems(keys:string[]) {
     }
 }
 
-export async function listColdDataKeys(): Promise<string[]> {
-    const keys:string[] = []
-    for(let i=0;i<DBState.db.characters.length;i++){
-
-        if(DBState.db.characters[i].coldstorage){
-            keys.push(DBState.db.characters[i].coldstorage!)
-            keys.push(...(DBState.db.characters[i].coldStoragedChats ?? []))
-        }
-        for(let j=0;j<DBState.db.characters[i].chats.length;j++){
-            const chat = DBState.db.characters[i].chats[j]
-            if(chat.message?.[0]?.data?.startsWith(coldStorageHeader)){
-                const coldDataKey = chat.message[0].data.slice(coldStorageHeader.length)
-                keys.push(coldDataKey)
-            }
-        }
-    }
-    return keys
+export async function listColdDataKeys(db: Pick<Database, 'characters'> = DBState.db): Promise<string[]> {
+    return listColdDataKeysFromDb(db)
 }
 
 async function makeColdDataForCharacter(i:number, coldTime:number): Promise<boolean>{

--- a/src/ts/process/coldstorage.svelte.ts
+++ b/src/ts/process/coldstorage.svelte.ts
@@ -12,10 +12,10 @@ import { DBState } from "../stores.svelte"
 import type { NodeStorage } from "../storage/nodeStorage"
 import { compress as fflateCompress, decompress as fflateDecompress } from "fflate"
 import { fetchProtectedResource } from "../sionyw"
-import { alertClear, alertError, alertWait } from "../alert"
+import { alertClear, alertConfirm, alertError, alertWait } from "../alert"
 import { language } from "src/lang"
 import type { Database, character } from "../storage/database.svelte"
-import { coldStorageHeader, getColdStorageBackupName, isColdStorageBackupData, listColdDataKeysFromDb } from "./coldstorageData"
+import { coldStorageHeader, getColdStorageAffectedCharacters, getColdStorageBackupName, isColdStorageBackupData, listColdDataKeysFromDb } from "./coldstorageData"
 
 export {
     coldStorageHeader,
@@ -358,6 +358,33 @@ export async function collectColdStorageBackupPayloads(db: Pick<Database, 'chara
     }
 
     return { payloads, missingKeys, invalidKeys }
+}
+
+export async function confirmIncompleteColdStorageOperation(
+    db: Pick<Database, 'characters'>,
+    unavailableKeys: Iterable<string>,
+    operation: 'backup' | 'restore',
+): Promise<boolean> {
+    const uniqueUnavailableKeys = Array.from(new Set(unavailableKeys))
+    if (uniqueUnavailableKeys.length === 0) {
+        return true
+    }
+
+    const affected = getColdStorageAffectedCharacters(db, uniqueUnavailableKeys)
+    const characterNames = affected.characterNames.join(', ')
+    const message = operation === 'backup'
+        ? language.errors.coldStorageIncompleteBackupConfirm(
+            characterNames,
+            uniqueUnavailableKeys.length,
+            affected.unresolvedKeys.length,
+        )
+        : language.errors.coldStorageIncompleteRestoreConfirm(
+            characterNames,
+            uniqueUnavailableKeys.length,
+            affected.unresolvedKeys.length,
+        )
+
+    return await alertConfirm(message)
 }
 
 async function makeColdDataForCharacter(i:number, coldTime:number): Promise<boolean>{

--- a/src/ts/process/coldstorageData.test.ts
+++ b/src/ts/process/coldstorageData.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+    coldStorageHeader,
+    getColdStorageBackupKey,
+    getColdStorageBackupName,
+    isColdStorageBackupData,
+    listColdDataKeysFromDb,
+} from './coldstorageData'
+
+describe('coldstorageData', () => {
+    it('collects unique character and chat cold storage keys from a database snapshot', () => {
+        const characterKey = '11111111-1111-1111-1111-111111111111'
+        const chatKey = '22222222-2222-2222-2222-222222222222'
+        const nestedChatKey = '33333333-3333-3333-3333-333333333333'
+
+        const keys = listColdDataKeysFromDb({
+            characters: [
+                {
+                    coldstorage: characterKey,
+                    coldStoragedChats: [chatKey, chatKey],
+                    chats: [
+                        {
+                            message: [{
+                                data: coldStorageHeader + nestedChatKey,
+                            }],
+                        },
+                    ],
+                },
+                {
+                    chats: [
+                        {
+                            message: [{
+                                data: coldStorageHeader + chatKey,
+                            }],
+                        },
+                    ],
+                },
+            ],
+        } as any)
+
+        expect(keys).toEqual([characterKey, chatKey, nestedChatKey])
+    })
+
+    it('recognizes supported cold storage backup names', () => {
+        const key = '11111111-1111-1111-1111-111111111111'
+
+        expect(getColdStorageBackupName(key)).toBe(`coldstorage_${key}.json`)
+        expect(getColdStorageBackupKey(`coldstorage_${key}.json`)).toBe(key)
+        expect(getColdStorageBackupKey(`coldstorage/${key}.json`)).toBe(key)
+        expect(getColdStorageBackupKey(`${key}.json`)).toBe(key)
+        expect(getColdStorageBackupKey('assets/profile.png')).toBeNull()
+    })
+
+    it('accepts character, message, and legacy array cold storage payloads', () => {
+        expect(isColdStorageBackupData({ character: {} })).toBe(true)
+        expect(isColdStorageBackupData({ message: [] })).toBe(true)
+        expect(isColdStorageBackupData([])).toBe(true)
+        expect(isColdStorageBackupData({ nope: true })).toBe(false)
+        expect(isColdStorageBackupData(null)).toBe(false)
+    })
+})

--- a/src/ts/process/coldstorageData.test.ts
+++ b/src/ts/process/coldstorageData.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
     coldStorageHeader,
+    getColdStorageAffectedCharacters,
     getColdStorageBackupKey,
     getColdStorageBackupName,
     isColdStorageBackupData,
@@ -40,6 +41,60 @@ describe('coldstorageData', () => {
         } as any)
 
         expect(keys).toEqual([characterKey, chatKey, nestedChatKey])
+    })
+
+    it('maps unavailable cold storage keys to affected character names', () => {
+        const characterKey = '11111111-1111-1111-1111-111111111111'
+        const storedChatKey = '22222222-2222-2222-2222-222222222222'
+        const activeChatKey = '33333333-3333-3333-3333-333333333333'
+        const unknownKey = '44444444-4444-4444-4444-444444444444'
+
+        const affected = getColdStorageAffectedCharacters({
+            characters: [
+                {
+                    name: 'Stored Bot',
+                    chaId: 'stored-bot',
+                    coldstorage: characterKey,
+                    coldStoragedChats: [storedChatKey],
+                    chats: [],
+                },
+                {
+                    name: 'Active Bot',
+                    chaId: 'active-bot',
+                    chats: [{
+                        message: [{
+                            data: coldStorageHeader + activeChatKey,
+                        }],
+                    }],
+                },
+                {
+                    name: 'Healthy Bot',
+                    chaId: 'healthy-bot',
+                    chats: [],
+                },
+            ],
+        } as any, [characterKey, storedChatKey, activeChatKey, unknownKey])
+
+        expect(affected).toEqual({
+            characterNames: ['Stored Bot', 'Active Bot'],
+            unresolvedKeys: [unknownKey],
+        })
+    })
+
+    it('uses the character id when an affected skeleton has no name', () => {
+        const characterKey = '11111111-1111-1111-1111-111111111111'
+
+        const affected = getColdStorageAffectedCharacters({
+            characters: [{
+                name: ' ',
+                chaId: 'fallback-character-id',
+                coldstorage: characterKey,
+                chats: [],
+            }],
+        } as any, [characterKey])
+
+        expect(affected.characterNames).toEqual(['fallback-character-id'])
+        expect(affected.unresolvedKeys).toEqual([])
     })
 
     it('recognizes supported cold storage backup names', () => {

--- a/src/ts/process/coldstorageData.test.ts
+++ b/src/ts/process/coldstorageData.test.ts
@@ -5,6 +5,7 @@ import {
     getColdStorageBackupName,
     isColdStorageBackupData,
     listColdDataKeysFromDb,
+    replaceColdStoragePayloadResources,
 } from './coldstorageData'
 
 describe('coldstorageData', () => {
@@ -57,5 +58,43 @@ describe('coldstorageData', () => {
         expect(isColdStorageBackupData([])).toBe(true)
         expect(isColdStorageBackupData({ nope: true })).toBe(false)
         expect(isColdStorageBackupData(null)).toBe(false)
+    })
+
+    it('rewrites character cold storage asset references without mutating the original payload', () => {
+        const payload = {
+            character: {
+                type: 'character',
+                image: 'assets/local-main.png',
+                emotionImages: [
+                    ['neutral', 'assets/local-neutral.png'],
+                    ['happy', 'assets/local-happy.png'],
+                ],
+                additionalAssets: [
+                    ['prop', 'assets/local-prop.png'],
+                ],
+            },
+        }
+
+        const rewritten = replaceColdStoragePayloadResources(payload, {
+            'assets/local-main.png': 'assets/account-main.png',
+            'assets/local-neutral.png': 'assets/account-neutral.png',
+            'assets/local-prop.png': 'assets/account-prop.png',
+        }) as typeof payload
+
+        expect(rewritten.character.image).toBe('assets/account-main.png')
+        expect(rewritten.character.emotionImages[0][1]).toBe('assets/account-neutral.png')
+        expect(rewritten.character.emotionImages[1][1]).toBe('assets/local-happy.png')
+        expect(rewritten.character.additionalAssets[0][1]).toBe('assets/account-prop.png')
+        expect(payload.character.image).toBe('assets/local-main.png')
+        expect(payload.character.emotionImages[0][1]).toBe('assets/local-neutral.png')
+        expect(payload.character.additionalAssets[0][1]).toBe('assets/local-prop.png')
+    })
+
+    it('leaves non-character cold storage payloads unchanged', () => {
+        const payload = { message: [{ data: 'assets/local.png' }] }
+
+        expect(replaceColdStoragePayloadResources(payload, {
+            'assets/local.png': 'assets/account.png',
+        })).toBe(payload)
     })
 })

--- a/src/ts/process/coldstorageData.ts
+++ b/src/ts/process/coldstorageData.ts
@@ -1,0 +1,44 @@
+import type { Database } from "../storage/database.svelte"
+
+export const coldStorageHeader = '\uEF01COLDSTORAGE\uEF01'
+
+export function getColdStorageBackupKey(name: string): string | null {
+    const match = name.match(/^(?:coldstorage[/_])?([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.json$/)
+    return match?.[1] ?? null
+}
+
+export function getColdStorageBackupName(key: string): string {
+    return `coldstorage_${key}.json`
+}
+
+export function isColdStorageBackupData(data: unknown): boolean {
+    if (Array.isArray(data)) {
+        return true
+    }
+
+    return !!data
+        && typeof data === 'object'
+        && ('character' in data || 'message' in data)
+}
+
+export function listColdDataKeysFromDb(db: Pick<Database, 'characters'> | null | undefined): string[] {
+    const keys = new Set<string>()
+    for (const character of db?.characters ?? []) {
+        if (!character) {
+            continue
+        }
+        if (character.coldstorage) {
+            keys.add(character.coldstorage)
+            for (const key of character.coldStoragedChats ?? []) {
+                keys.add(key)
+            }
+        }
+        for (const chat of character.chats ?? []) {
+            const firstMessage = chat.message?.[0]
+            if (firstMessage?.data?.startsWith(coldStorageHeader)) {
+                keys.add(firstMessage.data.slice(coldStorageHeader.length))
+            }
+        }
+    }
+    return Array.from(keys)
+}

--- a/src/ts/process/coldstorageData.ts
+++ b/src/ts/process/coldstorageData.ts
@@ -61,24 +61,65 @@ export function replaceColdStoragePayloadResources(data: unknown, replacer: { [k
     return cloned
 }
 
+function listColdDataKeysFromCharacter(character: character | groupChat): string[] {
+    const keys: string[] = []
+    if (character.coldstorage) {
+        keys.push(character.coldstorage)
+        keys.push(...(character.coldStoragedChats ?? []))
+    }
+    for (const chat of character.chats ?? []) {
+        const firstMessage = chat.message?.[0]
+        if (firstMessage?.data?.startsWith(coldStorageHeader)) {
+            keys.push(firstMessage.data.slice(coldStorageHeader.length))
+        }
+    }
+    return keys
+}
+
 export function listColdDataKeysFromDb(db: Pick<Database, 'characters'> | null | undefined): string[] {
     const keys = new Set<string>()
     for (const character of db?.characters ?? []) {
         if (!character) {
             continue
         }
-        if (character.coldstorage) {
-            keys.add(character.coldstorage)
-            for (const key of character.coldStoragedChats ?? []) {
-                keys.add(key)
-            }
-        }
-        for (const chat of character.chats ?? []) {
-            const firstMessage = chat.message?.[0]
-            if (firstMessage?.data?.startsWith(coldStorageHeader)) {
-                keys.add(firstMessage.data.slice(coldStorageHeader.length))
-            }
+        for (const key of listColdDataKeysFromCharacter(character)) {
+            keys.add(key)
         }
     }
     return Array.from(keys)
+}
+
+export function getColdStorageAffectedCharacters(
+    db: Pick<Database, 'characters'> | null | undefined,
+    unavailableKeys: Iterable<string>,
+): {
+    characterNames: string[]
+    unresolvedKeys: string[]
+} {
+    const targetKeys = new Set(unavailableKeys)
+    const resolvedKeys = new Set<string>()
+    const characterNames: string[] = []
+
+    for (const character of db?.characters ?? []) {
+        if (!character) {
+            continue
+        }
+
+        let isAffected = false
+        for (const key of listColdDataKeysFromCharacter(character)) {
+            if (targetKeys.has(key)) {
+                resolvedKeys.add(key)
+                isAffected = true
+            }
+        }
+
+        if (isAffected) {
+            characterNames.push(character.name?.trim() || character.chaId || 'Unknown character')
+        }
+    }
+
+    return {
+        characterNames,
+        unresolvedKeys: Array.from(targetKeys).filter((key) => !resolvedKeys.has(key)),
+    }
 }

--- a/src/ts/process/coldstorageData.ts
+++ b/src/ts/process/coldstorageData.ts
@@ -1,4 +1,5 @@
-import type { Database } from "../storage/database.svelte"
+import { safeStructuredClone } from "../polyfill"
+import type { Database, character, groupChat } from "../storage/database.svelte"
 
 export const coldStorageHeader = '\uEF01COLDSTORAGE\uEF01'
 
@@ -19,6 +20,45 @@ export function isColdStorageBackupData(data: unknown): boolean {
     return !!data
         && typeof data === 'object'
         && ('character' in data || 'message' in data)
+}
+
+function replaceData(data: string | undefined, replacer: { [key: string]: string }) {
+    if (!data) {
+        return data
+    }
+    return replacer[data] ?? data
+}
+
+function replaceCharacterResources(cha: character | groupChat, replacer: { [key: string]: string }) {
+    cha.image = replaceData(cha.image, replacer)
+
+    if (cha.emotionImages) {
+        for (let i = 0; i < cha.emotionImages.length; i++) {
+            cha.emotionImages[i][1] = replaceData(cha.emotionImages[i][1], replacer)
+        }
+    }
+
+    if (cha.type !== 'group' && cha.additionalAssets) {
+        for (let i = 0; i < cha.additionalAssets.length; i++) {
+            cha.additionalAssets[i][1] = replaceData(cha.additionalAssets[i][1], replacer)
+        }
+    }
+}
+
+export function replaceColdStoragePayloadResources(data: unknown, replacer: { [key: string]: string }): unknown {
+    if (
+        !data
+        || typeof data !== 'object'
+        || !('character' in data)
+        || !data.character
+        || typeof data.character !== 'object'
+    ) {
+        return data
+    }
+
+    const cloned = safeStructuredClone(data) as { character: character | groupChat }
+    replaceCharacterResources(cloned.character, replacer)
+    return cloned
 }
 
 export function listColdDataKeysFromDb(db: Pick<Database, 'characters'> | null | undefined): string[] {

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -38,7 +38,7 @@ export class AutoStorage{
     }
 
     async checkAccountSync(){
-        let db = getDatabase()
+        let db = getDatabase({ snapshot: true })
         if(this.isAccount){
             return true
         }
@@ -46,7 +46,7 @@ export class AutoStorage{
             return false
         }
         if((localStorage.getItem('dosync') === 'sync' || db?.account?.useSync) && (localStorage.getItem('accountst') !== 'able')){
-            const keys = await this.realStorage.keys()
+            const keys = (await this.realStorage.keys()).filter((key) => key !== 'database/database.bin')
             let i = 0;
             const accountStorage = new AccountStorage()
 
@@ -78,26 +78,16 @@ export class AutoStorage{
                 return false
             }
 
-            let replaced:{[key:string]:string} = {}
-            
-            for(const key of keys){
-                alertStore.set({
-                    type: "wait",
-                    msg: `Migrating your data...(${i}/${keys.length})`
-                })
-                const rkey = await accountStorage.setItem(key,await this.realStorage.getItem(key))
-                if(rkey !== key){
-                    replaced[key] = rkey
-                }
-                i += 1
-            }
-
             const {
                 collectColdStorageBackupPayloads,
                 setAccountColdStorageItem
             } = await import("../process/coldstorage.svelte")
             const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
-            const failedColdKeys:string[] = [...coldStoragePayloads.missingKeys]
+            if(coldStoragePayloads.missingKeys.length > 0){
+                alertError(`Failed to migrate ${coldStoragePayloads.missingKeys.length} cold storage item(s) to account sync.`)
+                return false
+            }
+            const failedColdKeys:string[] = []
             for(let coldIndex = 0; coldIndex < coldStoragePayloads.payloads.length; coldIndex++){
                 const payload = coldStoragePayloads.payloads[coldIndex]
                 alertStore.set({
@@ -110,6 +100,24 @@ export class AutoStorage{
             }
             if(failedColdKeys.length > 0){
                 alertError(`Failed to migrate ${failedColdKeys.length} cold storage item(s) to account sync.`)
+                return false
+            }
+
+            let replaced:{[key:string]:string} = {}
+            try {
+                for(const key of keys){
+                    alertStore.set({
+                        type: "wait",
+                        msg: `Migrating your data...(${i}/${keys.length})`
+                    })
+                    const rkey = await accountStorage.setItem(key,await this.realStorage.getItem(key))
+                    if(rkey !== key){
+                        replaced[key] = rkey
+                    }
+                    i += 1
+                }
+            } catch (error) {
+                alertError(error)
                 return false
             }
 

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -46,7 +46,11 @@ export class AutoStorage{
             return false
         }
         if((localStorage.getItem('dosync') === 'sync' || db?.account?.useSync) && (localStorage.getItem('accountst') !== 'able')){
-            const keys = (await this.realStorage.keys()).filter((key) => key !== 'database/database.bin')
+            const keys = (await this.realStorage.keys()).filter((key) => {
+                return key !== 'database/database.bin'
+                    && !key.startsWith('coldstorage/')
+                    && !key.startsWith('coldstorage_')
+            })
             let i = 0;
             const accountStorage = new AccountStorage()
 
@@ -80,26 +84,13 @@ export class AutoStorage{
 
             const {
                 collectColdStorageBackupPayloads,
+                replaceColdStoragePayloadResources,
                 setAccountColdStorageItem
             } = await import("../process/coldstorage.svelte")
             const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
-            if(coldStoragePayloads.missingKeys.length > 0){
-                alertError(`Failed to migrate ${coldStoragePayloads.missingKeys.length} cold storage item(s) to account sync.`)
-                return false
-            }
-            const failedColdKeys:string[] = []
-            for(let coldIndex = 0; coldIndex < coldStoragePayloads.payloads.length; coldIndex++){
-                const payload = coldStoragePayloads.payloads[coldIndex]
-                alertStore.set({
-                    type: "wait",
-                    msg: `Migrating cold storage data...(${coldIndex + 1}/${coldStoragePayloads.payloads.length})`
-                })
-                if(!await setAccountColdStorageItem(payload.key, payload.value)){
-                    failedColdKeys.push(payload.key)
-                }
-            }
-            if(failedColdKeys.length > 0){
-                alertError(`Failed to migrate ${failedColdKeys.length} cold storage item(s) to account sync.`)
+            const unavailableColdStorageCount = coldStoragePayloads.missingKeys.length + coldStoragePayloads.invalidKeys.length
+            if(unavailableColdStorageCount > 0){
+                alertError(`Failed to migrate ${unavailableColdStorageCount} cold storage item(s) to account sync because they are missing or invalid.`)
                 return false
             }
 
@@ -118,6 +109,23 @@ export class AutoStorage{
                 }
             } catch (error) {
                 alertError(error)
+                return false
+            }
+
+            const failedColdKeys:string[] = []
+            for(let coldIndex = 0; coldIndex < coldStoragePayloads.payloads.length; coldIndex++){
+                const payload = coldStoragePayloads.payloads[coldIndex]
+                alertStore.set({
+                    type: "wait",
+                    msg: `Migrating cold storage data...(${coldIndex + 1}/${coldStoragePayloads.payloads.length})`
+                })
+                const rewrittenPayload = replaceColdStoragePayloadResources(payload.value, replaced)
+                if(!await setAccountColdStorageItem(payload.key, rewrittenPayload)){
+                    failedColdKeys.push(payload.key)
+                }
+            }
+            if(failedColdKeys.length > 0){
+                alertError(`Failed to migrate ${failedColdKeys.length} cold storage item(s) to account sync.`)
                 return false
             }
 

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -86,6 +86,32 @@ export class AutoStorage{
                 i += 1
             }
 
+            const {
+                getColdStorageItem,
+                listColdDataKeys,
+                setAccountColdStorageItem
+            } = await import("../process/coldstorage.svelte")
+            const coldKeys = await listColdDataKeys(db)
+            const failedColdKeys:string[] = []
+            for(let coldIndex = 0; coldIndex < coldKeys.length; coldIndex++){
+                const key = coldKeys[coldIndex]
+                alertStore.set({
+                    type: "wait",
+                    msg: `Migrating cold storage data...(${coldIndex + 1}/${coldKeys.length})`
+                })
+                const data = await getColdStorageItem(key)
+                if(!data){
+                    failedColdKeys.push(key)
+                    continue
+                }
+                if(!await setAccountColdStorageItem(key, data)){
+                    failedColdKeys.push(key)
+                }
+            }
+            if(failedColdKeys.length > 0){
+                throw new Error(`Failed to migrate ${failedColdKeys.length} cold storage item(s) to account sync.`)
+            }
+
             const dba = replaceDbResources(db, replaced)
             const comp = encodeRisuSaveLegacy(dba, 'compression')
             //try decoding

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -3,7 +3,7 @@ import { replaceDbResources } from "../globalApi.svelte"
 import { isNodeServer } from "src/ts/platform"
 import { NodeStorage } from "./nodeStorage"
 import { OpfsStorage } from "./opfsStorage"
-import { alertInput, alertSelect, alertStore } from "../alert"
+import { alertError, alertInput, alertSelect, alertStore } from "../alert"
 import { getDatabase, type Database } from "./database.svelte"
 import { AccountStorage } from "./accountStorage"
 import { decodeRisuSave, encodeRisuSaveLegacy } from "./risuSave";
@@ -50,7 +50,13 @@ export class AutoStorage{
             let i = 0;
             const accountStorage = new AccountStorage()
 
-            const a = accountStorage.getItem('database/database.bin')
+            let a:Buffer | null = null
+            try {
+                a = await accountStorage.getItem('database/database.bin')
+            } catch (error) {
+                alertError(error)
+                return false
+            }
             if(a){
                 const sel = await alertSelect([language.loadDataFromAccount, language.saveCurrentDataToAccount])
                 if(sel === "0"){
@@ -87,29 +93,24 @@ export class AutoStorage{
             }
 
             const {
-                getColdStorageItem,
-                listColdDataKeys,
+                collectColdStorageBackupPayloads,
                 setAccountColdStorageItem
             } = await import("../process/coldstorage.svelte")
-            const coldKeys = await listColdDataKeys(db)
-            const failedColdKeys:string[] = []
-            for(let coldIndex = 0; coldIndex < coldKeys.length; coldIndex++){
-                const key = coldKeys[coldIndex]
+            const coldStoragePayloads = await collectColdStorageBackupPayloads(db)
+            const failedColdKeys:string[] = [...coldStoragePayloads.missingKeys]
+            for(let coldIndex = 0; coldIndex < coldStoragePayloads.payloads.length; coldIndex++){
+                const payload = coldStoragePayloads.payloads[coldIndex]
                 alertStore.set({
                     type: "wait",
-                    msg: `Migrating cold storage data...(${coldIndex + 1}/${coldKeys.length})`
+                    msg: `Migrating cold storage data...(${coldIndex + 1}/${coldStoragePayloads.payloads.length})`
                 })
-                const data = await getColdStorageItem(key)
-                if(!data){
-                    failedColdKeys.push(key)
-                    continue
-                }
-                if(!await setAccountColdStorageItem(key, data)){
-                    failedColdKeys.push(key)
+                if(!await setAccountColdStorageItem(payload.key, payload.value)){
+                    failedColdKeys.push(payload.key)
                 }
             }
             if(failedColdKeys.length > 0){
-                throw new Error(`Failed to migrate ${failedColdKeys.length} cold storage item(s) to account sync.`)
+                alertError(`Failed to migrate ${failedColdKeys.length} cold storage item(s) to account sync.`)
+                return false
             }
 
             const dba = replaceDbResources(db, replaced)
@@ -117,11 +118,14 @@ export class AutoStorage{
             //try decoding
             try {
                 const z:Database = await decodeRisuSave(comp)
-                if(z.formatversion){
-                    await accountStorage.setItem('database/database.bin', comp)
+                if(!z.formatversion){
+                    throw new Error('Encoded account database is invalid.')
                 }
-                
-            } catch (error) {}
+                await accountStorage.setItem('database/database.bin', comp)
+            } catch (error) {
+                alertError(error)
+                return false
+            }
             this.realStorage = accountStorage
             alertStore.set({
                 type: "none",


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes a cold storage sync/backup gap that can leave the database with cold storage pointers but no corresponding cold storage payloads.

This prevents bootstrap and character-switch paths from throwing when an existing cold storage item is missing, and ensures future account sync and backup flows carry the cold storage payloads alongside the database pointers.

## Related Issues

Fixes #1482 and #1425

## Changes

- Guard cold storage reads before dereferencing `character`, so missing payloads do not crash bootstrap or character selection.
- Add shared cold storage helpers for collecting referenced cold storage keys and recognizing backup payload names.
- During account sync migration, copy referenced cold storage items into the account cold storage endpoint before writing the migrated database.
- Include cold storage payloads in Google Drive backup uploads and restore them before applying a loaded Drive database.
- Include cold storage payloads in local and partial local backups even when the current storage backend is account sync, and restore them through the normal cold storage writer.
- Add focused tests for cold storage key collection and backup payload recognition.

## Impact

Users with already-missing cold storage payloads should no longer hit a `Cannot read properties of null (reading 'character')` crash during bootstrap. Those missing payloads are still unrecoverable unless a valid backup exists, but the app can continue loading and future sync/backup operations should no longer create pointer-only cold storage states.

Validation performed:

- `pnpm vitest run src/ts/process/coldstorageData.test.ts`
- `pnpm check`
- `git diff --check`

## Additional Notes

Existing corrupted account data may still require restoring from a backup that contains the missing cold storage payloads.
