### PR TITLE
fix: add popup editor accessibility labels

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -911,6 +911,7 @@ export const languageEnglish = {
     fixedChatTextarea: "Fixed at the bottom of the chat window(When unchecked, Shift + Enter changes to send a message.)",
     clickToEdit: "Click Text to Edit",
     enableBlockPartialEdit: "Enable Block Partial Edit (Hover to edit individual blocks)",
+    longPressToPopupEditor: "Long press to open Popup Editor",
     enableDragPartialEdit: "Enable Drag Partial Edit (Select text to edit)",
     setNodePassword: "Set your password to security",
     inputNodePassword: "Input your password. if you can't remember, remove save/__password.txt in your server files and restart the server.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -896,6 +896,7 @@ export const languageEnglish = {
     fixedChatTextarea: "Fixed at the bottom of the chat window(When unchecked, Shift + Enter changes to send a message.)",
     clickToEdit: "Click Text to Edit",
     enableBlockPartialEdit: "Enable Block Partial Edit (Hover to edit individual blocks)",
+    longPressToPopupEditor: "Long press to open Popup Editor",
     enableDragPartialEdit: "Enable Drag Partial Edit (Select text to edit)",
     setNodePassword: "Set your password to security",
     inputNodePassword: "Input your password. if you can't remember, remove save/__password.txt in your server files and restart the server.",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -773,6 +773,7 @@ export const languageKorean = {
     "fixedChatTextarea": "채팅창 하단 고정",
     "clickToEdit": "클릭해서 수정하기",
     "enableBlockPartialEdit": "블록 부분 수정 활성화 (블록에 마우스를 올려 개별 수정)",
+    "longPressToPopupEditor": "길게 눌러 팝업 편집기 열기",
     "enableDragPartialEdit": "드래그 부분 수정 활성화 (텍스트 선택 후 수정)",
     "setNodePassword": "보안을 위해 비밀번호를 정해주세요",
     "inputNodePassword": "비밀번호를 입력해주세요. 기억이 안나신다면, save/__password를 지우고 서버를 재시작해주세요.",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -763,6 +763,7 @@ export const languageKorean = {
     "fixedChatTextarea": "채팅창 하단 고정",
     "clickToEdit": "클릭해서 수정하기",
     "enableBlockPartialEdit": "블록 부분 수정 활성화 (블록에 마우스를 올려 개별 수정)",
+    "longPressToPopupEditor": "길게 눌러 팝업 편집기 열기",
     "enableDragPartialEdit": "드래그 부분 수정 활성화 (텍스트 선택 후 수정)",
     "setNodePassword": "보안을 위해 비밀번호를 정해주세요",
     "inputNodePassword": "비밀번호를 입력해주세요. 기억이 안나신다면, save/__password를 지우고 서버를 재시작해주세요.",


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds the missing English and Korean labels for the `longPressToPopupEditor` accessibility setting.

The setting itself already exists and opens the Popup Editor from textarea context menu / long-press handling. However, the language key was missing on `main`, so the Accessibility page rendered the option as a checkbox with no visible label.

## Related Issues

None.

## Changes

**`src/lang/en.ts`**
- Added the English label for `longPressToPopupEditor`

**`src/lang/ko.ts`**
- Added the Korean label for `longPressToPopupEditor`

## Impact

- Accessibility settings now show a visible label for the Popup Editor long-press option.
- No behavior change. This only restores the missing display text for an existing setting.
- Other locales continue to fall back to the English base string through the existing language merge behavior.

## Additional Notes

Validated with:

- `pnpm check`
