### PR TITLE
fix: decrypt local backup data before loading

### DIFF
--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -6,7 +6,7 @@ import { isTauri } from "src/ts/platform"
 import { decodeRisuSave, encodeRisuSaveLegacy } from "../storage/risuSave";
 import { getDatabase, setDatabaseLite } from "../storage/database.svelte";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { encryptBuffer, sleep } from "../util";
+import { decryptBuffer, encryptBuffer, sleep } from "../util";
 import { hubURL } from "../characterCards";
 import { language } from "src/lang";
 import { getColdStorageItem, listColdDataKeys, setColdStorageItem } from "../process/coldstorage.svelte";
@@ -504,7 +504,7 @@ export function LoadLocalBackup(){
                         if(encryptionMeta.type === 'account' && encryptionMeta.time){
                             try {
                                 const key = (await (await fetch(`https://sv.risuai.xyz/cryptokey?key=${encryptionMeta.time}`)).json()).key
-                                const decrypted = await encryptBuffer(db, key)
+                                const decrypted = await decryptBuffer(db, key)
                                 db = new Uint8Array(decrypted)
                             }
                             catch (e) {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes encrypted local backup loading for account-synced web backups.

The encrypted backup path was fetching the stored crypto key correctly, but then called `encryptBuffer` while handling `database.risudat`. That re-encrypted the already encrypted database bytes instead of decrypting them, causing `decodeRisuSave` to receive invalid data and eventually fail with fflate errors such as `invalid distance`.

## Related Issues

None.

## Changes

**`src/ts/drive/backuplocal.ts`**
- Import `decryptBuffer`
- Use `decryptBuffer(db, key)` when loading an encrypted `database.risudat`
- Keep the save path unchanged, where `encryptBuffer(dbData, key)` is still used to create encrypted backups

## Impact

- Encrypted local backups created from account-synced `risuai.xyz` web sessions can be loaded correctly.
- Non-encrypted local backups are unaffected because they do not enter the `encryption.risudat` path.
- Partial local backups are unaffected because they are not encrypted by this path.
- The save format does not change.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
