### PR TITLE
fix: align spacing in advanced settings and request info

### DIFF
--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -409,7 +409,7 @@
                 </div>
             {:else if $alertStore.type === 'requestdata'}
                 {#if aiLawApplies()}
-                <div>
+                <div class="mb-2">
                     {language.generatedByAIDisclaimer}
                 </div>
                 {/if}

--- a/src/ts/setting/advancedSettingsData.ts
+++ b/src/ts/setting/advancedSettingsData.ts
@@ -198,6 +198,7 @@ export const advancedSettingsItems: SettingItem[] = [
     },
     {
         id: 'adv.remoteSave', type: 'check', labelKey: 'enableRemoteSaving', bindKey: 'enableRemoteSaving',
+        classes: 'mt-4'
     },
 
     // Dynamic Assets & Others

--- a/src/ts/setting/advancedSettingsData.ts
+++ b/src/ts/setting/advancedSettingsData.ts
@@ -181,6 +181,7 @@ export const advancedSettingsItems: SettingItem[] = [
     },
     {
         id: 'adv.remoteSave', type: 'check', labelKey: 'enableRemoteSaving', bindKey: 'enableRemoteSaving',
+        classes: 'mt-4'
     },
 
     // Dynamic Assets & Others


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Aligns spacing in two small UI spots where adjacent elements were rendered too tightly.

The Advanced Settings page had a tighter gap before `Enable Remote Saving` because that item did not use the same `mt-4` wrapper spacing as the surrounding checkbox settings. The request info popup also rendered the AI-generated content disclaimer directly against the tab buttons, making the header area feel cramped.

## Related Issues

None.

## Changes

**`src/ts/setting/advancedSettingsData.ts`**
- Added `mt-4` spacing to the `enableRemoteSaving` setting item

**`src/lib/Others/AlertComp.svelte`**
- Added `mb-2` spacing below the AI-generated content disclaimer in the request info popup

## Impact

- Advanced Settings checkbox spacing is more consistent.
- The request info popup has a little more breathing room between the disclaimer and tab controls.
- No behavior change. This only adjusts layout spacing.
- No data, settings, request, or platform-specific logic is changed.

## Screenshots

### Advanced Settings

| Before | After |
|---|---|
| <img width="613" height="312" alt="Advanced Settings spacing before" src="https://github.com/user-attachments/assets/7e5b18d8-7038-4861-996e-c1de2d8af0a5" /> | <img width="671" height="328" alt="Advanced Settings spacing after" src="https://github.com/user-attachments/assets/d9185665-2eca-425b-8d4f-5d790b8d54ab" /> |

### Request Info Popup

| Before | After |
|---|---|
| <img width="1121" height="305" alt="Request info popup spacing before" src="https://github.com/user-attachments/assets/a7b54aae-9982-48dc-9608-023ba9da5925" /> | <img width="1081" height="252" alt="Request info popup spacing after" src="https://github.com/user-attachments/assets/cee6fb80-7613-4b2a-88d8-7a401529c003" /> |

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm build`
