### PR TITLE
fix: evaluate CBS before counting lorebook tokens for cutoff

### DIFF
--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -4,6 +4,7 @@ import {selectedCharID} from '../stores.svelte'
 import { type Message, type loreBook } from "../storage/database.svelte";
 import { DBState } from '../stores.svelte';
 import { tokenize } from "../tokenizer";
+import { risuChatParser } from "../parser/parser.svelte";
 import { findCharacterbyId, pickHashRand, selectSingleFile } from "../util";
 import { alertError, alertNormal } from "../alert";
 import { language } from "../../lang";
@@ -568,7 +569,11 @@ export async function loadLoreBookV3Prompt(){
                     prompt: content,
                     role: role,
                     order: order,
-                    tokens: await tokenize(content),
+                    // Count tokens against the CBS-evaluated text (e.g. {{#if}}, {{getglobalvar}})
+                    // so cutoff reflects what actually reaches the context, not the unevaluated source.
+                    // runVar is left false (matching the output path in index.svelte.ts), so this
+                    // evaluation has no side effects like setvar.
+                    tokens: await tokenize(risuChatParser(content, {chara: char})),
                     priority: priority,
                     source: fullLore[i].comment || `lorebook ${i}`,
                     inject: inject ?? null


### PR DESCRIPTION
Token counting and cutoff ran on the raw lorebook content before CBS (e.g. {{#if}}, {{getglobalvar}}) was applied, inflating token estimates for conditional entries and letting less context through than the configured max token budget. Count tokens against the CBS-evaluated text instead (runVar left false, so no side effects like setvar).

## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

 ## Summary

  Lorebook token counting and cutoff ran on the raw entry content before CBS
  (e.g. {{#if}}, {{getglobalvar}}) was applied. For conditional/dynamic entries
  this inflated token estimates, so the cutoff charged the budget for branches
  that never actually reach the context — letting less content through than the
  configured max token budget. This counts tokens against the CBS-evaluated text
  instead.

  ## Related Issues

  None.

  ## Changes

  - `src/ts/process/lorebook.svelte.ts`: when building each active entry, count
    tokens against `risuChatParser(content, { chara })` instead of the raw
    `content`. `runVar` is left at its default (`false`), matching the output
    path in `index.svelte.ts`, so this evaluation produces no side effects such
    as `setvar` / `addvar` / `setglobalvar`.

  The matching loop, recursive scanning, the stored `act.prompt`, and the
  `index.svelte.ts` output path are all left untouched — only the token estimate
  used for cutoff changes.

  ## Impact

  - Conditional/dynamic lorebooks now consume budget based on what they actually
    expand to, so the max token budget is filled as intended instead of being
    cut short.
  - CBS side effects still run exactly once, on the existing output path; the new
    evaluation is read-only (runVar: false), so there is no double execution.
  - `{{position::}}` and inject_lore text remain outside the token budget, same
    as before this change.

  ## Additional Notes

  - Verified with `vitest run` (180 passed / 3 skipped) and `svelte-check`
    (no type errors in the changed file).
  - Manual in-app verification of the dynamic-lorebook + cutoff scenario is
    recommended in addition to the automated checks.

Please describe any potential impacts this PR may have on existing functionality or users.

## Additional Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lore content token calculation to evaluate content before counting, ensuring accurate context-budget constraints and more reliable lore integration in conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->