### PR TITLE
feat: add setting renderer alert type

### DIFF
--- a/src/lib/Setting/Wrappers/SettingAlert.svelte
+++ b/src/lib/Setting/Wrappers/SettingAlert.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+    import type { Component } from 'svelte';
+    import type { SettingItem, SettingContext } from 'src/ts/setting/types';
+    import { language } from 'src/lang';
+    import { getLabel } from 'src/ts/setting/utils';
+    import { CircleAlert, CircleCheck, CircleX, Info, TriangleAlert } from '@lucide/svelte';
+
+    type AlertVariant = 'info' | 'warning' | 'error' | 'success' | 'neutral';
+
+    interface Props {
+        item: SettingItem;
+        ctx: SettingContext;
+    }
+
+    interface AlertStyle {
+        icon: Component<any>;
+        className: string;
+        iconClassName: string;
+    }
+
+    const alertStyles: Record<AlertVariant, AlertStyle> = {
+        info: {
+            icon: Info,
+            className: 'border-blue-500/40 bg-blue-500/10',
+            iconClassName: 'text-blue-500',
+        },
+        warning: {
+            icon: TriangleAlert,
+            className: 'border-amber-500/50 bg-amber-500/10',
+            iconClassName: 'text-amber-500',
+        },
+        error: {
+            icon: CircleX,
+            className: 'border-draculared/50 bg-draculared/10',
+            iconClassName: 'text-draculared',
+        },
+        success: {
+            icon: CircleCheck,
+            className: 'border-emerald-500/45 bg-emerald-500/10',
+            iconClassName: 'text-emerald-500',
+        },
+        neutral: {
+            icon: CircleAlert,
+            className: 'border-textcolor/20 bg-textcolor/5',
+            iconClassName: 'text-textcolor2',
+        },
+    };
+
+    let { item }: Props = $props();
+
+    let variant = $derived((item.options?.variant ?? 'info') as AlertVariant);
+    let style = $derived(alertStyles[variant] ?? alertStyles.info);
+    let Icon = $derived(style.icon);
+    let title = $derived(
+        item.options?.titleKey && (language as any)[item.options.titleKey]
+            ? (language as any)[item.options.titleKey]
+            : item.options?.title
+    );
+</script>
+
+<div
+    class="flex gap-2 rounded-md border px-3 py-2 text-sm text-textcolor {style.className} {item.classes ?? 'my-2'}"
+>
+    <Icon size={18} class="mt-0.5 shrink-0 {style.iconClassName}" />
+    <div class="min-w-0">
+        {#if title}
+            <div class="mb-1 font-semibold">{title}</div>
+        {/if}
+        <div class="whitespace-pre-wrap break-words leading-relaxed text-textcolor2">{getLabel(item)}</div>
+    </div>
+</div>

--- a/src/ts/setting/settingRegistry.ts
+++ b/src/ts/setting/settingRegistry.ts
@@ -9,6 +9,7 @@ import SettingSelect from 'src/lib/Setting/Wrappers/SettingSelect.svelte';
 import SettingSegmented from 'src/lib/Setting/Wrappers/SettingSegmented.svelte';
 import SettingColor from 'src/lib/Setting/Wrappers/SettingColor.svelte';
 import SettingHeader from 'src/lib/Setting/Wrappers/SettingHeader.svelte';
+import SettingAlert from 'src/lib/Setting/Wrappers/SettingAlert.svelte';
 import SettingButton from 'src/lib/Setting/Wrappers/SettingButton.svelte';
 import SettingAccordion from 'src/lib/Setting/Wrappers/SettingAccordion.svelte';
 import SettingCustom from 'src/lib/Setting/Wrappers/SettingCustom.svelte';
@@ -25,8 +26,8 @@ export const settingRegistry: Record<SettingType, WrapperComponent> = {
     'segmented': SettingSegmented,
     'color': SettingColor,
     'header': SettingHeader,
+    'alert': SettingAlert,
     'button': SettingButton,
     'accordion': SettingAccordion,
     'custom': SettingCustom,
 };
-

--- a/src/ts/setting/types.ts
+++ b/src/ts/setting/types.ts
@@ -31,6 +31,7 @@ export type SettingType =
     | 'segmented'  // Sliding segmented control (SegmentedControl)
     | 'color'      // Color picker (ColorInput)
     | 'header'     // Section header (h2, span, warning)
+    | 'alert'      // Inline informational alert box
     | 'button'     // Action button (Button)
     | 'accordion'  // Collapsible section (Accordion)
     | 'custom';    // Custom component from registry
@@ -90,6 +91,11 @@ export interface SettingOptions {
     
     // header
     level?: 'h2' | 'span' | 'warning';
+
+    // alert
+    variant?: 'info' | 'warning' | 'error' | 'success' | 'neutral';
+    title?: string;
+    titleKey?: string;
     
     // accordion
     styled?: boolean;        // Use styled accordion


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

Adds a reusable `alert` setting item type for inline informational callouts in data-driven settings pages.

## Related Issues

Part of the replacement split for #1486.

## Changes

- Adds `SettingType = 'alert'` and alert-specific setting options.
- Registers `SettingAlert.svelte` in the settings renderer registry.
- Supports info, warning, error, success, and neutral callout variants.

## Impact

Existing settings behavior is unchanged unless a settings data file opts into the new `alert` type.

## Additional Notes

Validation:

- `git diff --check upstream/main...HEAD`
- `pnpm check`
