### PR TITLE
fix: skip auto-translation while response is streaming

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -55,6 +55,7 @@
         currentPage?: number;
         totalPages?: number;
         isComment?: boolean;
+        isStreaming?: boolean;
         disabled?: boolean | 'allBefore';
         isOptimizedStreamingMessage?: boolean;
         streamingOptimizationMode?: StreamingDisplayOptimizationMode;
@@ -80,6 +81,7 @@
         currentPage = 1,
         totalPages = 1,
         isComment = false,
+        isStreaming = false,
         disabled = false,
         isOptimizedStreamingMessage = false,
         streamingOptimizationMode = 'off',
@@ -518,6 +520,7 @@
                     {name}
                     {bodyRoot}
                     renderRevision={chatBodyRevision}
+                    {isStreaming}
                     modelShortName={
                         messageGenerationInfo ? getModelInfo(messageGenerationInfo?.model).shortName : ''
                     }

--- a/src/lib/ChatScreens/ChatBody.svelte
+++ b/src/lib/ChatScreens/ChatBody.svelte
@@ -21,6 +21,7 @@
         retranslate: boolean
         renderRevision?: number
         bodyRoot?: HTMLElement|null
+        isStreaming?: boolean
         modelShortName: string
         renderRawStreaming?: boolean
         rawStreamingText?: string
@@ -37,6 +38,7 @@
         retranslate = $bindable(false),
         renderRevision = 0,
         bodyRoot,
+        isStreaming = false,
         modelShortName = '',
         renderRawStreaming = false,
         rawStreamingText = '',
@@ -80,7 +82,7 @@
                 lastChatId = chatID
                 let translateText = false
                 try {
-                    if(DBState.db.autoTranslate){
+                    if(DBState.db.autoTranslate && !isStreaming){
                         if(DBState.db.autoTranslateCachedOnly && DBState.db.translatorType === 'llm'){
                             const cache = DBState.db.translateBeforeHTMLFormatting
                             ? await getLLMCache(data)
@@ -110,7 +112,7 @@
                     console.error(error)
                 }
             }
-            if(retranslate || translated){
+            if(!isStreaming && (retranslate || translated)){
                 if (DBState.db.showTranslationLoading && !preservePendingContent) {
                     lastParsed = `<div style="display:flex;justify-content:center;align-items:center;height:48px;"><div style="animation: spin 1s linear infinite; border-radius: 50%; height: 32px; width: 32px; border: 2px solid #3b82f6; border-top: 2px solid transparent;"></div></div><style>@keyframes spin { to { transform: rotate(360deg); } }</style>`
                 }

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -95,9 +95,10 @@
             const message = messages[i];
             const messageLargePortrait = message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false);
             const reloadPointer = reloadPointerMap[i] ?? 0;
+            const isStreaming = currentChat?.isStreaming === true && i === messages.length - 1 && message.role === 'char';
             const activeStreamingMessage = i === activeStreamingIndex && message.role === 'char';
             const hashMessageData = activeStreamingMessage ? '' : message.data;
-            let hashd = hashMessageData + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + reloadPointer.toString();
+            let hashd = hashMessageData + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + reloadPointer.toString() + isStreaming.toString();
             const currentHash = hashCode(hashd);
             currentHashes.add(currentHash);
             if(!hashes.has(currentHash)){
@@ -119,6 +120,7 @@
                         largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false),
                         messageGenerationInfo: message.generationInfo,
                         role: message.role,
+                        isStreaming,
                         name: message.role === 'user' ? currentUsername : currentCharacter.name,
                         isComment: message.isComment ?? false,
                         disabled: message.disabled ?? false,


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes automatic translation blocking streamed response display.

When automatic translation was enabled, `ChatBody` tried to translate each intermediate streaming update. This made the translation button flicker rapidly and prevented the response from being displayed normally until streaming finished.

## Related Issues

Fixes #1426.

## Changes

**`src/lib/ChatScreens/Chats.svelte`**
- Detect when the active chat is currently streaming its latest character message
- Include that streaming state in the chat component hash so the final non-streaming message remounts cleanly
- Pass the streaming state down to `Chat`

**`src/lib/ChatScreens/Chat.svelte`**
- Add an optional `isStreaming` prop
- Pass the streaming state down to `ChatBody`

**`src/lib/ChatScreens/ChatBody.svelte`**
- Skip automatic translation and cached LLM translation lookup while the message is still streaming
- Keep the existing translation flow for non-streaming messages

## Impact

- Streaming responses remain visible while automatic translation is enabled.
- Automatic translation still runs after the streamed response finishes.
- Existing non-streaming messages keep the same translation behavior.
- The change is limited to chat rendering and translation timing; it does not change request handling, stored data, model settings, or platform-specific behavior.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`



