### PR TITLE
fix: avoid Tauri resource aborts in Auto Suggest

### DIFF
--- a/src/lib/ChatScreens/Suggestion.svelte
+++ b/src/lib/ChatScreens/Suggestion.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { requestChatData } from "src/ts/process/request/request";
     import { doingChat, type OpenAIChat } from "../../ts/process/index.svelte";
-    import { setDatabase, type character, type Message, type groupChat, type Database } from "../../ts/storage/database.svelte";
+    import { type character, type Message, type groupChat } from "../../ts/storage/database.svelte";
 	import { DBState } from 'src/ts/stores.svelte';
     import { selectedCharID } from "../../ts/stores.svelte";
+    import { isTauri } from 'src/ts/platform';
     import { translate } from "src/ts/translator/translator";
     import { CopyIcon, LanguagesIcon, RefreshCcwIcon } from "@lucide/svelte";
     import { alertConfirm } from "src/ts/alert";
@@ -24,77 +25,111 @@
     let toggleTranslate:boolean = $state(DBState.db.autoTranslate)
     let progress:boolean = $state();
     let progressChatPage=-1;
-    let abortController:AbortController;
+    let abortController:AbortController|undefined;
+    let suggestionRequestId = 0;
     let chatPage:number = $state()
+
+    const cancelSuggestionRequest = () => {
+        suggestionRequestId += 1
+        progress = false
+        abortController?.abort()
+        abortController = undefined
+    }
 
     const updateSuggestions = () => {
         if($selectedCharID > -1 && !$doingChat) {
             if(progressChatPage > 0 && progressChatPage != chatPage){
-                progress=false
-                abortController?.abort()
+                cancelSuggestionRequest()
             }
             let currentChar = DBState.db.characters[$selectedCharID];
             suggestMessages = currentChar?.chats[currentChar.chatPage].suggestMessages
         }
     }
-    
 
-    const unsub = doingChat.subscribe(async (v) => {
-        if(v) {
-            progress=false
-            abortController?.abort()
-            suggestMessages = []
+    const requestSuggestions = () => {
+        if($doingChat || $selectedCharID <= -1 || (suggestMessages && suggestMessages.length > 0) || progress){
+            return
         }
-        if(!v && $selectedCharID > -1 && (!suggestMessages || suggestMessages.length === 0) && !progress){
-            let currentChar:character|groupChat = DBState.db.characters[$selectedCharID];
-            let messages:Message[] = []
-            
-            messages = [...messages, ...currentChar.chats[currentChar.chatPage].message];
-            let lastMessages:Message[] = messages.slice(Math.max(messages.length - 10, 0));
-            if(lastMessages.length === 0)
-                return
-            const prompt = DBState.db.autoSuggestPrompt && DBState.db.autoSuggestPrompt.length > 0 ? DBState.db.autoSuggestPrompt : defaultAutoSuggestPrompt
-            let promptbody:OpenAIChat[] = [
+
+        const requestCharId = $selectedCharID
+        const currentChar:character|groupChat = DBState.db.characters[requestCharId];
+        if(!currentChar){
+            return
+        }
+        const requestChatPage = currentChar.chatPage
+        const currentChat = currentChar.chats[requestChatPage]
+        if(!currentChat){
+            return
+        }
+        let messages:Message[] = []
+        
+        messages = [...messages, ...currentChat.message];
+        let lastMessages:Message[] = messages.slice(Math.max(messages.length - 10, 0));
+        if(lastMessages.length === 0)
+            return
+        const prompt = DBState.db.autoSuggestPrompt && DBState.db.autoSuggestPrompt.length > 0 ? DBState.db.autoSuggestPrompt : defaultAutoSuggestPrompt
+        let promptbody:OpenAIChat[] = [
             {
                 role:'system',
                 content: replacePlaceholders(prompt, currentChar.name)
-            }
-            ,{
+            },
+            {
                 role: 'user', 
                 content: lastMessages.map(b=>(b.role==='char'? currentChar.name : getUserName())+":"+b.data).reduce((a,b)=>a+','+b)
             }
+        ]
+
+        if(DBState.db.subModel === "textgen_webui" || DBState.db.subModel === 'mancer' || DBState.db.subModel.startsWith('local_')){
+            promptbody = [
+                {
+                    role: 'system',
+                    content: replacePlaceholders(DBState.db.autoSuggestPrompt, currentChar.name)
+                },
+                ...lastMessages.map(({ role, data }) => ({
+                    role: role === "user" ? "user" as const : "assistant" as const,
+                    content: data,
+                })),
             ]
+        }
 
-            if(DBState.db.subModel === "textgen_webui" || DBState.db.subModel === 'mancer' || DBState.db.subModel.startsWith('local_')){
-                promptbody = [
-                    {
-                        role: 'system',
-                        content: replacePlaceholders(DBState.db.autoSuggestPrompt, currentChar.name)
-                    },
-                    ...lastMessages.map(({ role, data }) => ({
-                        role: role === "user" ? "user" as const : "assistant" as const,
-                        content: data,
-                    })),
-                ]
+        const requestId = suggestionRequestId + 1
+        const requestController = isTauri ? undefined : new AbortController()
+        suggestionRequestId = requestId
+        abortController = requestController
+        progress = true
+        progressChatPage = requestChatPage
+
+        requestChatData({
+            formated: promptbody,
+            bias: {},
+            currentChar : currentChar as character
+        }, 'submodel', requestController?.signal ?? null).then(rq2=>{
+            const stillCurrentRequest = suggestionRequestId === requestId && $selectedCharID === requestCharId && DBState.db.characters[requestCharId]?.chatPage === requestChatPage
+            const currentTargetChat = DBState.db.characters[requestCharId]?.chats[requestChatPage]
+            if(rq2.type !== 'fail' && rq2.type !== 'streaming' && rq2.type !== 'multiline' && progress && stillCurrentRequest && currentTargetChat){
+                var suggestMessagesNew = rq2.result.split('\n').filter(msg => msg.startsWith('-')).map(msg => msg.replace('-','').trim())
+                currentTargetChat.suggestMessages = suggestMessagesNew
+                suggestMessages = suggestMessagesNew
             }
-
-            progress = true
-            progressChatPage = chatPage
-            abortController = new AbortController()
-            requestChatData({
-                formated: promptbody,
-                bias: {},
-                currentChar : currentChar as character
-            }, 'submodel', abortController.signal).then(rq2=>{
-                if(rq2.type !== 'fail' && rq2.type !== 'streaming' && rq2.type !== 'multiline' && progress){
-                    var suggestMessagesNew = rq2.result.split('\n').filter(msg => msg.startsWith('-')).map(msg => msg.replace('-','').trim())
-                    const db:Database = DBState.db;
-                    db.characters[$selectedCharID].chats[currentChar.chatPage].suggestMessages = suggestMessagesNew
-                    suggestMessages = suggestMessagesNew
-                }
+        }).catch(error => {
+            if(!requestController?.signal.aborted && suggestionRequestId === requestId){
+                console.error(error)
+            }
+        }).finally(() => {
+            if(suggestionRequestId === requestId){
                 progress = false
-            })
+                abortController = undefined
             }
+        })
+    }
+
+    const unsub = doingChat.subscribe(async (v) => {
+        if(v) {
+            cancelSuggestionRequest()
+            suggestMessages = []
+            return
+        }
+        requestSuggestions()
     })
 
     const translateSuggest = async (toggle, messages)=>{
@@ -108,7 +143,10 @@
         }
     }
 
-    onDestroy(unsub)
+    onDestroy(() => {
+        cancelSuggestionRequest()
+        unsub()
+    })
 
     $effect.pre(() => {
         $selectedCharID
@@ -145,8 +183,8 @@
                     alertConfirm(language.askReRollAutoSuggestions).then((result) => {
                         if(result) {
                             suggestMessages = []
-                            doingChat.set(true)
-                            doingChat.set(false)        
+                            cancelSuggestionRequest()
+                            requestSuggestions()
                         }
                     })
                 }}

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -834,7 +834,7 @@ async function fetchWithTauri(url: string, arg: GlobalFetchArgs): Promise<Global
         addFetchLogInGlobalFetch(data, ok, url, arg, response.status);
         return { ok, data, headers: Object.fromEntries(response.headers), status: response.status };
     } catch (error) {
-
+        return { ok: false, data: `${error}`, headers: {}, status: 400 };
     }
 }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes Auto Suggest triggering Tauri HTTP resource errors such as `The resource id ... is invalid`.

Auto Suggest used an `AbortController` to cancel in-flight suggestion requests when chat state changed, the chat page changed, or suggestions were re-rolled. On Tauri desktop, that abort signal is passed into `@tauri-apps/plugin-http`, where aborting around response body reads can race with native resource cleanup and surface an invalid resource id error.

## Related Issues

Fixes #1443.

## Changes

**`src/lib/ChatScreens/Suggestion.svelte`**
- Replace Auto Suggest's request cancellation state with a request id guard
- Avoid passing a native abort signal for Auto Suggest requests on Tauri
- Keep abort behavior for non-Tauri environments
- Only write suggestion results when the request id, selected character, and chat page still match
- Stop using `doingChat.set(true); doingChat.set(false)` to re-roll suggestions
- Invalidate pending suggestion results when the component is destroyed

**`src/ts/globalApi.svelte.ts`**
- Return a normalized failed fetch result when Tauri HTTP fetch throws

## Impact

- Auto Suggest no longer uses Tauri native HTTP aborts, avoiding the plugin-http resource id race.
- Stale Auto Suggest responses are discarded instead of being written to the current chat.
- Re-rolling suggestions no longer toggles the global chat-in-progress state.
- On Tauri, canceled Auto Suggest requests may still finish on the backend, but their results are ignored if they are no longer current.
- Existing stored data and database schema are unchanged.
- Web and non-Tauri abort behavior is preserved.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`

`git diff --check` only reported existing CRLF conversion warnings.
