### PR TITLE
fix: improve hotkey settings layout

### DIFF
--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1350,7 +1350,9 @@ export const languageKorean = {
         "export": "내보내기",
         "webcam": "웹캠 토글",
         "focusInput": "입력창 포커스",
-        "scrollToActiveChar": "활성 캐릭터로 스크롤"
+        "scrollToActiveChar": "활성 캐릭터로 스크롤",
+        "popupEditor": "팝업 에디터",
+        "loadout": "로드아웃"
     },
     "screenTooSmall": "화면이 너무 작아서 인터페이스를 표시할 수 없습니다.",
     "advancedModelSettings": "고급 모델 설정",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1340,7 +1340,9 @@ export const languageKorean = {
         "export": "내보내기",
         "webcam": "웹캠 토글",
         "focusInput": "입력창 포커스",
-        "scrollToActiveChar": "활성 캐릭터로 스크롤"
+        "scrollToActiveChar": "활성 캐릭터로 스크롤",
+        "popupEditor": "팝업 에디터",
+        "loadout": "로드아웃"
     },
     "screenTooSmall": "화면이 너무 작아서 인터페이스를 표시할 수 없습니다.",
     "advancedModelSettings": "고급 모델 설정",

--- a/src/lib/Setting/Pages/HotkeySettings.svelte
+++ b/src/lib/Setting/Pages/HotkeySettings.svelte
@@ -2,72 +2,76 @@
     import { language } from "src/lang";
     import { DBState } from "src/ts/stores.svelte";
 
-    
+    function formatHotkeyKey(key: string) {
+        if (key === ' ') {
+            return 'SPACE';
+        }
+
+        return key?.toLocaleUpperCase() ?? '';
+    }
 </script>
 
-{#if window.innerWidth < 768}
-    <span class="text-red-500">
-        {language.screenTooSmall}
-    </span>
+<h2 class="mb-2 text-2xl font-bold mt-2">{language.hotkey}</h2>
 
-{:else}
-
-    <table>
-        <thead>
-            <tr>
-                <th>{language.hotkey}</th>
-            </tr>
-        </thead>
-        <tbody>
-            {#each DBState.db.hotkeys as hotkey}
-                <tr>
-                    <td>{language.hotkeyDesc[hotkey.action]}</td>
-                    <td>
-
-                        <button
-                            class:text-textcolor={hotkey.ctrl}
-                            class:text-textcolor2={!hotkey.ctrl}
-                            onclick={() => {
-                                hotkey.ctrl = !hotkey.ctrl;
-                            }}
-                        >
-                            Ctrl
-                        </button>
-                    </td>
-                    <td>
-                        <button
-                            class:text-textcolor={hotkey.shift}
-                            class:text-textcolor2={!hotkey.shift}
-                            onclick={() => {
-                                hotkey.shift = !hotkey.shift;
-                            }}
-                        >
-                            Shift
-                        </button>
-                    </td>
-                    <td>
-                        <button
-                            class:text-textcolor={hotkey.alt}
-                            class:text-textcolor2={!hotkey.alt}
-                            onclick={() => {
-                                hotkey.alt = !hotkey.alt;
-                            }}
-                        >
-                            Alt
-                        </button>
-                    </td>
-                    <td>
-                        <input
-                            value={hotkey.key === ' ' ? "SPACE" : hotkey.key?.toLocaleUpperCase()}
-                            class="bg-bgcolor border-none w-16"
-                            onkeydown={(e) => {
-                                e.preventDefault();
-                                hotkey.key = e.key;
-                            }}
-                        >
-                    </td>
-                </tr>
-            {/each}
-        </tbody>
-    </table>
-{/if}
+<div class="w-full rounded-md border border-darkborderc">
+    <div class="border-b border-darkborderc px-3 py-2 text-xs text-textcolor2">
+        <div class="sm:hidden">{language.action} / {language.hotkey}</div>
+        <div class="hidden sm:flex sm:items-center sm:justify-between">
+            <div>{language.action}</div>
+            <div class="flex w-[17.5rem] justify-start">{language.hotkey}</div>
+        </div>
+    </div>
+    {#each DBState.db.hotkeys as hotkey}
+        <div class="flex flex-col gap-2 border-b border-darkborderc px-3 py-2 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+            <div class="min-w-0 text-sm text-textcolor">
+                {language.hotkeyDesc[hotkey.action]}
+            </div>
+            <div class="flex w-full flex-wrap items-center gap-2 sm:w-[17.5rem]">
+                <button
+                    class="h-7 min-w-12 rounded-md px-2 text-xs transition-colors hover:text-textcolor"
+                    class:bg-selected={hotkey.ctrl}
+                    class:bg-transparent={!hotkey.ctrl}
+                    class:text-textcolor={hotkey.ctrl}
+                    class:text-textcolor2={!hotkey.ctrl}
+                    onclick={() => {
+                        hotkey.ctrl = !hotkey.ctrl;
+                    }}
+                >
+                    Ctrl
+                </button>
+                <button
+                    class="h-7 min-w-12 rounded-md px-2 text-xs transition-colors hover:text-textcolor"
+                    class:bg-selected={hotkey.shift}
+                    class:bg-transparent={!hotkey.shift}
+                    class:text-textcolor={hotkey.shift}
+                    class:text-textcolor2={!hotkey.shift}
+                    onclick={() => {
+                        hotkey.shift = !hotkey.shift;
+                    }}
+                >
+                    Shift
+                </button>
+                <button
+                    class="h-7 min-w-12 rounded-md px-2 text-xs transition-colors hover:text-textcolor"
+                    class:bg-selected={hotkey.alt}
+                    class:bg-transparent={!hotkey.alt}
+                    class:text-textcolor={hotkey.alt}
+                    class:text-textcolor2={!hotkey.alt}
+                    onclick={() => {
+                        hotkey.alt = !hotkey.alt;
+                    }}
+                >
+                    Alt
+                </button>
+                <input
+                    value={formatHotkeyKey(hotkey.key)}
+                    class="h-7 w-16 rounded-md border border-darkborderc bg-transparent px-2 text-center text-xs text-textcolor transition-colors focus:border-borderc focus:outline-hidden focus:ring-2 focus:ring-borderc"
+                    onkeydown={(e) => {
+                        e.preventDefault();
+                        hotkey.key = e.key;
+                    }}
+                >
+            </div>
+        </div>
+    {/each}
+</div>

--- a/src/lib/Setting/Settings.svelte
+++ b/src/lib/Setting/Settings.svelte
@@ -227,7 +227,7 @@
                         <PromptSettings onGoBack={() => {
                             $SettingsMenuIndex = 1
                         }}/>
-                    {:else if $SettingsMenuIndex === 15 && window.innerWidth >= 768}
+                    {:else if $SettingsMenuIndex === 15}
                         <HotkeySettings/>
                     {:else if $SettingsMenuIndex === 77}
                         <ThanksPage/>


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes the Hotkey Settings page rendering as an empty settings panel on narrow widths.

The settings shell only rendered `HotkeySettings` when `window.innerWidth >= 768`, while the page itself also had a separate small-screen fallback. This made the selected Hotkey tab show no usable content at narrower widths.

This PR removes that width gate and updates the Hotkey Settings layout so it remains readable on both narrow and wider settings views.

## Related Issues

None.

## Changes

**`src/lib/Setting/Settings.svelte`**
- Always render `HotkeySettings` when the Hotkey settings menu is selected
- Remove the `window.innerWidth >= 768` condition that could leave the content panel empty

**`src/lib/Setting/Pages/HotkeySettings.svelte`**
- Remove the small-screen `screenTooSmall` branch
- Replace the table layout with a responsive bordered list layout
- Add a page title to match the other settings pages
- Add an action / hotkey header row
- Align the hotkey header with the hotkey control column on wider widths
- Keep the narrow-width header compact as `Action / Hotkey`
- Keep Ctrl, Shift, and Alt toggle buttons visually simple without active borders
- Format the key input display consistently, including `SPACE`

**`src/lang/ko.ts`**
- Add missing Korean labels for the Popup Editor and Loadout hotkey actions

## Impact

- The Hotkey Settings page is visible and usable at narrow widths instead of showing an empty panel.
- Existing hotkey data and hotkey behavior are unchanged.
- The change is limited to settings-page rendering, layout, and missing Korean display text.
- No request handling, model behavior, storage format, database schema, or platform-specific logic is changed.

## Screenshots

| Desktop | Narrow width |
|---|---|
| <img width="1165" height="773" alt="Hotkey settings desktop layout" src="https://github.com/user-attachments/assets/6b4c456b-2c8e-4aed-88c8-697e9e9b3697" /> | <img width="642" height="783" alt="Hotkey settings narrow width layout" src="https://github.com/user-attachments/assets/b84af809-b982-4040-9a7a-d95be6889f09" /> |

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

`pnpm build` completed with existing non-blocking warnings.
