### PR TITLE
fix: update openrouter attribution headers

### DIFF
--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -553,8 +553,9 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         headers["Authorization"] = "Bearer " + db.OaiCompAPIKeys[arg.modelInfo.keyIdentifier]
     }
     if(aiModel === 'openrouter'){
-        headers["X-Title"] = 'RisuAI'
+        headers["X-OpenRouter-Title"] = 'Risuai'
         headers["HTTP-Referer"] = 'https://risuai.xyz'
+        headers["X-OpenRouter-Categories"] = 'roleplay,general-chat'
     }
     if(aiModel === 'nanogpt' && db.nanogptProvider){
         headers["X-Provider"] = db.nanogptProvider


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This PR updates the OpenRouter attribution headers to use the current OpenRouter-specific header name and reflects the recent project name change from `RisuAI` to `Risuai`.

## Changes

* Replaced the legacy `X-Title` OpenRouter attribution header with `X-OpenRouter-Title`
* Updated the OpenRouter app title value from `RisuAI` to `Risuai`
* Added `X-OpenRouter-Categories` for clearer OpenRouter app categorization

## Notes

This PR does not change internal Risu proxy identification headers, since those may be used for compatibility outside of OpenRouter attribution.