### PR TITLE
fix: include presetRegex in edittrans translation regex application

### DIFF
--- a/src/ts/translator/edittransRegex.test.ts
+++ b/src/ts/translator/edittransRegex.test.ts
@@ -12,9 +12,14 @@ vi.mock("../process/modules", () => ({
     moduleUpdate: () => {},
 }));
 
+const parserCalls: { data: string, chatID: number }[] = [];
+
 vi.mock("../parser/parser.svelte", () => ({
     applyMarkdownToNode: () => {},
-    risuChatParser: (data: string) => data.replaceAll("{{char}}", "Risu"),
+    risuChatParser: (data: string, arg: { chatID?: number } = {}) => {
+        parserCalls.push({ data, chatID: arg.chatID ?? -1 });
+        return data.replaceAll("{{char}}", "Risu");
+    },
 }));
 
 import { applyEdittransRegex } from "./translator";
@@ -29,13 +34,14 @@ const script = (v: Partial<customscript>): customscript => ({
 
 const alwaysExistChar = { customscript: [] } as unknown as character;
 
-const apply = (text: string, scripts: customscript[]) => {
+const apply = (text: string, scripts: customscript[], chatID = -1) => {
     database.presetRegex = scripts;
-    return applyEdittransRegex(text, "chatid", alwaysExistChar);
+    return applyEdittransRegex(text, "chatid", alwaysExistChar, chatID);
 };
 
 beforeEach(() => {
     database.presetRegex = [];
+    parserCalls.length = 0;
     vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
@@ -82,6 +88,14 @@ describe("applyEdittransRegex", () => {
         expect(apply("Risu said hi", [
             script({ in: "{{char}}", out: "Seia", ableFlag: true, flag: "g" }),
         ])).toBe("Risu said hi");
+        expect(parserCalls).toEqual([]);
+    });
+
+    it("forwards the chatID to the parser so message scoped syntaxes resolve", () => {
+        apply("Risu said hi", [
+            script({ in: "{{char}}", out: "Seia", ableFlag: true, flag: "g<cbs>" }),
+        ], 7);
+        expect(parserCalls).toEqual([{ data: "{{char}}", chatID: 7 }]);
     });
 
     it("sorts scripts by the order flag, higher first", () => {

--- a/src/ts/translator/edittransRegex.test.ts
+++ b/src/ts/translator/edittransRegex.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { character, customscript } from "../storage/database.svelte";
+
+const database: { presetRegex: customscript[] } = { presetRegex: [] };
+
+vi.mock("../storage/database.svelte", () => ({
+    getDatabase: () => database,
+}));
+
+vi.mock("../process/modules", () => ({
+    getModuleRegexScripts: () => [] as customscript[],
+    moduleUpdate: () => {},
+}));
+
+vi.mock("../parser/parser.svelte", () => ({
+    applyMarkdownToNode: () => {},
+    risuChatParser: (data: string) => data.replaceAll("{{char}}", "Risu"),
+}));
+
+import { applyEdittransRegex } from "./translator";
+
+const script = (v: Partial<customscript>): customscript => ({
+    comment: "",
+    in: "",
+    out: "",
+    type: "edittrans",
+    ...v,
+} as customscript);
+
+const alwaysExistChar = { customscript: [] } as unknown as character;
+
+const apply = (text: string, scripts: customscript[]) => {
+    database.presetRegex = scripts;
+    return applyEdittransRegex(text, "chatid", alwaysExistChar);
+};
+
+beforeEach(() => {
+    database.presetRegex = [];
+    vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("applyEdittransRegex", () => {
+    it("applies preset scripts of the edittrans type only", () => {
+        expect(apply("hello world", [
+            script({ in: "world", out: "there" }),
+            script({ in: "hello", out: "bye", type: "editdisplay" }),
+        ])).toBe("hello there");
+    });
+
+    it("skips a script with an invalid regex and keeps the remaining ones", () => {
+        expect(apply("hello world", [
+            script({ in: "(unclosed", out: "x" }),
+            script({ in: "world", out: "there" }),
+        ])).toBe("hello there");
+    });
+
+    it("skips a script with an empty in", () => {
+        expect(apply("hello", [
+            script({ in: "", out: "INJECTED" }),
+        ])).toBe("hello");
+    });
+
+    it("drops unsupported and repeated flags instead of throwing", () => {
+        expect(apply("Hello hello", [
+            script({ in: "hello", out: "hi", ableFlag: true, flag: "ggi z" }),
+        ])).toBe("hi hi");
+    });
+
+    it("falls back to the u flag when no native flag is left", () => {
+        expect(apply("aaa", [
+            script({ in: "a", out: "b", ableFlag: true, flag: "<cbs>" }),
+        ])).toBe("baa");
+    });
+
+    it("parses curly braced syntaxes in IN with the cbs flag", () => {
+        expect(apply("Risu said hi", [
+            script({ in: "{{char}}", out: "Seia", ableFlag: true, flag: "g<cbs>" }),
+        ])).toBe("Seia said hi");
+    });
+
+    it("does not parse curly braced syntaxes in IN without the cbs flag", () => {
+        expect(apply("Risu said hi", [
+            script({ in: "{{char}}", out: "Seia", ableFlag: true, flag: "g" }),
+        ])).toBe("Risu said hi");
+    });
+
+    it("sorts scripts by the order flag, higher first", () => {
+        expect(apply("a", [
+            script({ in: "b", out: "c", ableFlag: true, flag: "g<order 1>" }),
+            script({ in: "a", out: "b", ableFlag: true, flag: "g<order 2>" }),
+        ])).toBe("c");
+    });
+
+    it("keeps the declaration order when no order flag is set", () => {
+        expect(apply("a", [
+            script({ in: "b", out: "c" }),
+            script({ in: "a", out: "b" }),
+        ])).toBe("b");
+    });
+
+    it("moves the match to the top with the move_top flag", () => {
+        expect(apply("body\n<note>keep</note>", [
+            script({ in: "<note>.*?</note>", out: "$&", ableFlag: true, flag: "g<move_top>" }),
+        ])).toBe("<note>keep</note>\nbody\n");
+    });
+
+    it("moves the match to the bottom with the move_bottom flag", () => {
+        expect(apply("<note>keep</note>\nbody", [
+            script({ in: "<note>(.*?)</note>", out: "[$1]", ableFlag: true, flag: "g<move_bottom>" }),
+        ])).toBe("\nbody\n[keep]");
+    });
+
+    it("leaves the text alone when a move script does not match", () => {
+        expect(apply("body", [
+            script({ in: "<note>.*?</note>", out: "$&", ableFlag: true, flag: "g<move_top>" }),
+        ])).toBe("body");
+    });
+
+    it("ignores custom flags that are not supported here", () => {
+        expect(apply("hello world", [
+            script({ in: "world", out: "there", ableFlag: true, flag: "g<repeat_back><no_end_nl>" }),
+        ])).toBe("hello there");
+    });
+
+    it("returns the text untouched for an empty charArg", () => {
+        database.presetRegex = [script({ in: "hello", out: "bye" })];
+        expect(applyEdittransRegex("hello", "", alwaysExistChar)).toBe("hello");
+    });
+});

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -619,14 +619,15 @@ export async function clearLLMCache():Promise<void>{
 
 
 function applyEdittransRegex(
-      text: string, 
-      charArg: simpleCharacterArgument | string, 
+      text: string,
+      charArg: simpleCharacterArgument | string,
       alwaysExistChar: character | groupChat | simpleCharacterArgument
   ): string {
       if (charArg === '') return text
 
+      const db = getDatabase()
       let scripts: customscript[] = []
-      scripts = (getModuleRegexScripts() ?? []).concat(alwaysExistChar?.customscript ?? [])
+      scripts = (db.presetRegex ?? []).concat(getModuleRegexScripts() ?? []).concat(alwaysExistChar?.customscript ?? [])
 
       for (const script of scripts) {
           if (script.type === 'edittrans') {

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -292,7 +292,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
             audio.play().catch(() => {});
         }
 
-        return applyEdittransRegex(r, charArg, alwaysExistChar)
+        return applyEdittransRegex(r, charArg, alwaysExistChar, chatID)
     }
     if(db.translatorType == "bergamot" && db.htmlTranslation) {
         const from = db.aiModel.startsWith('novellist') ? 'ja' : 'en'
@@ -303,7 +303,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
             bergamotTranslate = bergamotTranslator.bergamotTranslate
         }
  
-        return applyEdittransRegex(await bergamotTranslate(html, from, to, true), charArg, alwaysExistChar)
+        return applyEdittransRegex(await bergamotTranslate(html, from, to, true), charArg, alwaysExistChar, chatID)
     }
     const dom = new DOMParser().parseFromString(html, 'text/html');
     console.log(html)
@@ -489,7 +489,7 @@ export async function translateHTML(html: string, reverse:boolean, charArg:simpl
     // Remove the outer <html|body|head> tags
     translatedHTML = translatedHTML.replace(/<\/?(html|body|head)[^>]*>/g, '');
 
-    translatedHTML = applyEdittransRegex(translatedHTML, charArg, alwaysExistChar);
+    translatedHTML = applyEdittransRegex(translatedHTML, charArg, alwaysExistChar, chatID);
 
     // console.log(html)
     // console.log(translatedHTML)
@@ -628,7 +628,8 @@ interface pEdittransScript {
 export function applyEdittransRegex(
       text: string,
       charArg: simpleCharacterArgument | string,
-      alwaysExistChar: character | groupChat | simpleCharacterArgument
+      alwaysExistChar: character | groupChat | simpleCharacterArgument,
+      chatID = -1
   ): string {
       if (charArg === '') return text
 
@@ -698,7 +699,7 @@ export function applyEdittransRegex(
 
               let input = script.in
               if (pscript.actions.includes('cbs')) {
-                  input = risuChatParser(input)
+                  input = risuChatParser(input, { chatID: chatID })
               }
 
               const reg = new RegExp(input, pscript.flag)

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -643,6 +643,9 @@ function applyEdittransRegex(
                   flag = script.flag || 'g'
               }
 
+              //remove custom flags, which are only handled in processScriptFull
+              flag = flag.replace(/<(.+?)>/g, '')
+
               //remove unsupported flag
               flag = flag.trim().replace(/[^dgimsuvy]/g, '')
 

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -630,10 +630,34 @@ function applyEdittransRegex(
       scripts = (db.presetRegex ?? []).concat(getModuleRegexScripts() ?? []).concat(alwaysExistChar?.customscript ?? [])
 
       for (const script of scripts) {
-          if (script.type === 'edittrans') {
-              const reg = new RegExp(script.in, script.ableFlag ? script.flag : 'g')
+          if (script.type !== 'edittrans') {
+              continue
+          }
+          if (!script.in) {
+              continue
+          }
+
+          try {
+              let flag = 'g'
+              if (script.ableFlag) {
+                  flag = script.flag || 'g'
+              }
+
+              //remove unsupported flag
+              flag = flag.trim().replace(/[^dgimsuvy]/g, '')
+
+              //remove repeated flags
+              flag = flag.split('').filter((v, i, a) => a.indexOf(v) === i).join('')
+
+              if (flag.length === 0) {
+                  flag = 'u'
+              }
+
+              const reg = new RegExp(script.in, flag)
               let outScript = script.out.replaceAll("$n", "\n")
               text = text.replace(reg, outScript)
+          } catch (error) {
+              console.error(error)
           }
       }
       return text

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -720,9 +720,11 @@ export function applyEdittransRegex(
                                   return v
                               })
                               .replace(/\$\&/g, inData)
-                              .replace(/(?<!\$)\$<([^>]+)>/g, (v, p1) => {
-                                  if (matched.groups && matched.groups[p1]) {
-                                      return matched.groups[p1]
+                              //kept identical to processScriptFull, where parseInt on a group name never resolves
+                              .replace(/(?<!\$)\$<([^>]+)>/g, (v) => {
+                                  const groupName = parseInt(v.substring(2, v.length - 1))
+                                  if (matched.groups && matched.groups[groupName]) {
+                                      return matched.groups[groupName]
                                   }
                                   return v
                               })

--- a/src/ts/translator/translator.ts
+++ b/src/ts/translator/translator.ts
@@ -11,7 +11,7 @@ import { isTauri, isNodeServer } from "src/ts/platform"
 import { alertError } from "../alert"
 import { requestChatData } from "../process/request/request"
 import { doingChat, type OpenAIChat } from "../process/index.svelte"
-import { applyMarkdownToNode, type simpleCharacterArgument } from "../parser/parser.svelte"
+import { applyMarkdownToNode, risuChatParser, type simpleCharacterArgument } from "../parser/parser.svelte"
 import { selectedCharID } from "../stores.svelte"
 import { getModuleRegexScripts } from "../process/modules"
 import { getNodetextToSentence, sleep } from "../util"
@@ -618,7 +618,14 @@ export async function clearLLMCache():Promise<void>{
 }
 
 
-function applyEdittransRegex(
+interface pEdittransScript {
+    script: customscript
+    flag: string
+    order: number
+    actions: string[]
+}
+
+export function applyEdittransRegex(
       text: string,
       charArg: simpleCharacterArgument | string,
       alwaysExistChar: character | groupChat | simpleCharacterArgument
@@ -629,6 +636,9 @@ function applyEdittransRegex(
       let scripts: customscript[] = []
       scripts = (db.presetRegex ?? []).concat(getModuleRegexScripts() ?? []).concat(alwaysExistChar?.customscript ?? [])
 
+      const parsedScripts: pEdittransScript[] = []
+      let orderChanged = false
+
       for (const script of scripts) {
           if (script.type !== 'edittrans') {
               continue
@@ -637,28 +647,97 @@ function applyEdittransRegex(
               continue
           }
 
+          let flag = 'g'
+          if (script.ableFlag) {
+              flag = script.flag || 'g'
+          }
+
+          let order = 0
+          const actions: string[] = []
+
+          //parse custom flags, same as processScriptFull
+          flag = flag.replace(/<(.+?)>/g, (v: string, p1: string) => {
+              const meta = p1.split(',').map((v) => v.trim())
+              for (const m of meta) {
+                  if (m.startsWith('order ')) {
+                      order = parseInt(m.substring(6))
+                      orderChanged = true
+                  }
+                  else {
+                      actions.push(m)
+                  }
+              }
+
+              return ''
+          })
+
+          if (actions.includes('move_top') || actions.includes('move_bottom')) {
+              flag = flag.replace('g', '') //temperary fix
+          }
+
+          //remove unsupported flag
+          flag = flag.trim().replace(/[^dgimsuvy]/g, '')
+
+          //remove repeated flags
+          flag = flag.split('').filter((v, i, a) => a.indexOf(v) === i).join('')
+
+          if (flag.length === 0) {
+              flag = 'u'
+          }
+
+          parsedScripts.push({ script, flag, order, actions })
+      }
+
+      if (orderChanged) {
+          parsedScripts.sort((a, b) => b.order - a.order) //sort by order
+      }
+
+      for (const pscript of parsedScripts) {
           try {
-              let flag = 'g'
-              if (script.ableFlag) {
-                  flag = script.flag || 'g'
+              const script = pscript.script
+
+              let input = script.in
+              if (pscript.actions.includes('cbs')) {
+                  input = risuChatParser(input)
               }
 
-              //remove custom flags, which are only handled in processScriptFull
-              flag = flag.replace(/<(.+?)>/g, '')
+              const reg = new RegExp(input, pscript.flag)
+              const outScript = script.out.replaceAll("$n", "\n")
 
-              //remove unsupported flag
-              flag = flag.trim().replace(/[^dgimsuvy]/g, '')
-
-              //remove repeated flags
-              flag = flag.split('').filter((v, i, a) => a.indexOf(v) === i).join('')
-
-              if (flag.length === 0) {
-                  flag = 'u'
+              if (pscript.actions.includes('move_top') || pscript.actions.includes('move_bottom')) {
+                  const isGlobal = pscript.flag.includes('g')
+                  const matchAll = isGlobal ? text.matchAll(reg) : [text.match(reg)]
+                  text = text.replace(reg, "")
+                  for (const matched of matchAll) {
+                      if (matched) {
+                          const inData = matched[0]
+                          const out = outScript
+                              .replace(/(?<!\$)\$[0-9]+/g, (v) => {
+                                  const index = parseInt(v.substring(1))
+                                  if (index < matched.length) {
+                                      return matched[index]
+                                  }
+                                  return v
+                              })
+                              .replace(/\$\&/g, inData)
+                              .replace(/(?<!\$)\$<([^>]+)>/g, (v, p1) => {
+                                  if (matched.groups && matched.groups[p1]) {
+                                      return matched.groups[p1]
+                                  }
+                                  return v
+                              })
+                          if (pscript.actions.includes('move_top')) {
+                              text = out + '\n' + text
+                          }
+                          else {
+                              text = text + '\n' + out
+                          }
+                      }
+                  }
               }
-
-              const reg = new RegExp(script.in, flag)
-              let outScript = script.out.replaceAll("$n", "\n")
-              text = text.replace(reg, outScript)
+              else {
+                  text = text.replace(reg, outScript)
+              }
           } catch (error) {
               console.error(error)
           }


### PR DESCRIPTION


## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

applyEdittransRegex was only collecting module and character scripts, missing db.presetRegex (preset/prompt-side regex scripts). This caused edittrans regex placed in the prompt preset to have no effect on any translation type, including LLM translation. Aligns collection order with processScriptFull: presetRegex → module → character.

## Related Issues

None

## Changes

기존에 번역문 수정 정규식이 원래부터 프롬프트 정규식 스크립트를 무시하고 적용되고 있었고, 제가 LLM 번역에도 번역문 수정 정규식이 작동되게 수정할 때 그걸 단순히 가져다 써서 누락되어 있었습니다. 누락된걸 뒤늦게 확인해 적용했습니다.

## Impact

프롬프트 소속의 작동하지 않던 정규식이 이제 작동할 뿐입니다.

## Additional Notes
