### PR TITLE
feat(nai): support v4/v4.5 per-character prompts via Lua module API

### DIFF
--- a/src/ts/process/naiCharacterPrompts.ts
+++ b/src/ts/process/naiCharacterPrompts.ts
@@ -1,0 +1,74 @@
+/** NAI clamps character centers to 0~0.9, and treats (0, 0) as automatic placement. */
+const NAI_POSITION_MIN = 0
+const NAI_POSITION_MAX = 0.9
+
+export interface NAICharacterPrompt{
+    /** Positive prompt for this character */
+    prompt: string
+    /** Optional negative prompt for this character */
+    negative?: string
+    /** Optional horizontal position (0~0.9). 0 or omitted means automatic placement */
+    x?: number
+    /** Optional vertical position (0~0.9). 0 or omitted means automatic placement */
+    y?: number
+}
+
+export interface NAIImageGenOptions{
+    /** Per-character prompts for NAI v4/v4.5 multi-character prompting */
+    characters?: NAICharacterPrompt[]
+    /** Force coordinate-based placement. Defaults to true when any character supplies a non-zero x/y */
+    use_coords?: boolean
+}
+
+const naiPosition = (value:unknown):number => {
+    if(typeof value !== 'number' || !Number.isFinite(value)){
+        return NAI_POSITION_MIN
+    }
+    return Math.min(NAI_POSITION_MAX, Math.max(NAI_POSITION_MIN, value))
+}
+
+/** Convert SD-style () emphasis to NAI-style {} emphasis, preserving escaped \( \) */
+export const naiEmphasis = (s:string) => s
+    .replaceAll('\\(', "♧")
+    .replaceAll('\\)', "♤")
+    .replaceAll('(','{')
+    .replaceAll(')','}')
+    .replaceAll('♧','(')
+    .replaceAll('♤',')')
+
+/**
+ * Builds the NAI v4/v4.5 multi-character fields from options supplied by modules via Lua.
+ * Kept out of stableDiff.ts so the shape can be asserted without pulling in the app's stores.
+ */
+export function buildNAICharacterPrompts(naiOptions?:NAIImageGenOptions){
+    const naiCharacters = naiOptions?.characters ?? []
+    const charCenter = (c:NAICharacterPrompt) => ({
+        x: naiPosition(c?.x),
+        y: naiPosition(c?.y)
+    })
+    // (0, 0) is NAI's "auto" center, so coordinates only kick in once one of them is placed.
+    // Only an actual boolean overrides that, so a wrong-typed option falls back to auto-detection.
+    const useCoords = typeof naiOptions?.use_coords === 'boolean'
+        ? naiOptions.use_coords
+        : naiCharacters.some(c => charCenter(c).x !== NAI_POSITION_MIN || charCenter(c).y !== NAI_POSITION_MIN)
+
+    return {
+        useCoords,
+        posCharCaptions: naiCharacters.map((c) => ({
+            char_caption: naiEmphasis(c?.prompt ?? ''),
+            centers: [charCenter(c)]
+        })),
+        negCharCaptions: naiCharacters.map((c) => ({
+            char_caption: c?.negative ?? '',
+            centers: [charCenter(c)]
+        })),
+        // The web client and novelai-python both send characterPrompts alongside v4_prompt.
+        // Left undefined without characters so the request stays identical to a plain generation.
+        characterPrompts: naiCharacters.length > 0 ? naiCharacters.map((c) => ({
+            prompt: naiEmphasis(c?.prompt ?? ''),
+            uc: c?.negative ?? '',
+            center: charCenter(c),
+            enabled: true
+        })) : undefined,
+    }
+}

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -7,7 +7,7 @@ import { get } from "svelte/store";
 import { DBState, ReloadChatPointer, ReloadGUIPointer, selectedCharID } from "../stores.svelte";
 import { alertSelect, alertError, alertInput, alertNormal, alertConfirm } from "../alert";
 import { HypaProcesser } from "./memory/hypamemory";
-import { generateAIImage } from "./stableDiff";
+import { generateAIImage, type NAIImageGenOptions } from "./stableDiff";
 import { writeInlayImage, getInlayAsset } from "./files/inlays";
 import type { OpenAIChat, MultiModal } from "./index.svelte";
 import { requestChatData, type StreamResponseChunk } from "./request/request";
@@ -360,11 +360,12 @@ export async function runScripted(code:string, arg:{
                 }
             })
 
-            declareAPI('generateImage', async (id:string, value:string, negValue:string = '') => {
+            declareAPI('generateImage', async (id:string, value:string, negValue:string = '', optionsStr:string = '') => {
                 if(!ScriptingLowLevelIds.has(id)){
                     return
                 }
-                const gen = await generateAIImage(value, char as character, negValue, 'inlay')
+                const options = parseLuaOptions(optionsStr) as NAIImageGenOptions
+                const gen = await generateAIImage(value, char as character, negValue, 'inlay', options)
                 if(!gen){
                     return 'Error: Image generation failed'
                 }

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -364,15 +364,21 @@ export async function runScripted(code:string, arg:{
                 if(!ScriptingLowLevelIds.has(id)){
                     return
                 }
-                const options = parseLuaOptions(optionsStr) as NAIImageGenOptions
-                const gen = await generateAIImage(value, char as character, negValue, 'inlay', options)
-                if(!gen){
+                try {
+                    const options = parseLuaOptions(optionsStr) as NAIImageGenOptions
+                    const gen = await generateAIImage(value, char as character, negValue, 'inlay', options)
+                    if(!gen){
+                        return 'Error: Image generation failed'
+                    }
+                    const imgHTML = new Image()
+                    imgHTML.src = gen
+                    const inlay = await writeInlayImage(imgHTML)
+                    return `{{inlay::${inlay}}}`
+                } catch (error) {
+                    // Keep failures inside the script instead of aborting the whole run
+                    console.error('Error in generateImage:', error)
                     return 'Error: Image generation failed'
                 }
-                const imgHTML = new Image()
-                imgHTML.src = gen
-                const inlay = await writeInlayImage(imgHTML)
-                return `{{inlay::${inlay}}}`
             })
 
             declareAPI('getCharacterImageMain', async (id:string) => {

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -61,7 +61,25 @@ export async function stableDiff(currentChar:character,prompt:string){
     return await generateAIImage(genPrompt, currentChar, neg, '')
 }
 
-export async function generateAIImage(genPrompt:string, currentChar:character, neg:string, returnSdData:string):Promise<string|false>{
+export interface NAICharacterPrompt{
+    /** Positive prompt for this character */
+    prompt: string
+    /** Optional negative prompt for this character */
+    negative?: string
+    /** Optional horizontal position (0~1). When given, coordinate placement is enabled */
+    x?: number
+    /** Optional vertical position (0~1). When given, coordinate placement is enabled */
+    y?: number
+}
+
+export interface NAIImageGenOptions{
+    /** Per-character prompts for NAI v4/v4.5 multi-character prompting */
+    characters?: NAICharacterPrompt[]
+    /** Force coordinate-based placement. Defaults to true when any character supplies x/y */
+    use_coords?: boolean
+}
+
+export async function generateAIImage(genPrompt:string, currentChar:character, neg:string, returnSdData:string, naiOptions?:NAIImageGenOptions):Promise<string|false>{
     const db = getDatabase()
     console.log(db.sdProvider)
     if(db.sdProvider === 'webui'){
@@ -121,13 +139,33 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
         }
     }
     if(db.sdProvider === 'novelai'){
-        genPrompt = genPrompt
+        // Convert SD-style () emphasis to NAI-style {} emphasis, preserving escaped \( \)
+        const naiEmphasis = (s:string) => s
             .replaceAll('\\(', "♧")
             .replaceAll('\\)', "♤")
             .replaceAll('(','{')
             .replaceAll(')','}')
             .replaceAll('♧','(')
             .replaceAll('♤',')')
+
+        genPrompt = naiEmphasis(genPrompt)
+
+        // Per-character prompts (NAI v4/v4.5 multi-character prompting), supplied by modules via Lua
+        const naiCharacters = naiOptions?.characters ?? []
+        const useCoords = naiOptions?.use_coords ??
+            naiCharacters.some(c => typeof c?.x === 'number' || typeof c?.y === 'number')
+        const charCenter = (c:NAICharacterPrompt) => ({
+            x: typeof c?.x === 'number' ? c.x : 0.5,
+            y: typeof c?.y === 'number' ? c.y : 0.5
+        })
+        const posCharCaptions = naiCharacters.map((c) => ({
+            char_caption: naiEmphasis(c?.prompt ?? ''),
+            centers: [charCenter(c)]
+        }))
+        const negCharCaptions = naiCharacters.map((c) => ({
+            char_caption: c?.negative ?? '',
+            centers: [charCenter(c)]
+        }))
 
         let reqlist:any = {}
 
@@ -159,20 +197,20 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                     "legacy": false,
                     //add v4
                     "autoSmea": false,
-                    "use_coords": false,
+                    "use_coords": useCoords,
                     "legacy_uc": db.NAIImgConfig.legacy_uc,
                     "v4_prompt":{
                         caption:{
                             base_caption:genPrompt,
-                            char_captions: []
+                            char_captions: posCharCaptions
                         },
-                        use_coords: false,
-                        use_order: true,
+                        use_coords: useCoords,
+                        use_order: !useCoords,
                     },
                     "v4_negative_prompt":{
                         caption:{
                             base_caption:neg,
-                            char_captions: []
+                            char_captions: negCharCaptions
                         },
                         legacy_uc: db.NAIImgConfig.legacy_uc,
                     },

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -8,6 +8,7 @@ import type { OpenAIChat } from "./index.svelte"
 import { processZip } from "./processzip"
 import { keiServerURL } from "../kei/kei"
 import random from "lodash/random"
+import { buildNAICharacterPrompts, naiEmphasis, type NAICharacterPrompt, type NAIImageGenOptions } from "./naiCharacterPrompts"
 
 export async function stableDiff(currentChar:character,prompt:string){
     let db = getDatabase()
@@ -61,23 +62,7 @@ export async function stableDiff(currentChar:character,prompt:string){
     return await generateAIImage(genPrompt, currentChar, neg, '')
 }
 
-export interface NAICharacterPrompt{
-    /** Positive prompt for this character */
-    prompt: string
-    /** Optional negative prompt for this character */
-    negative?: string
-    /** Optional horizontal position (0~1). When given, coordinate placement is enabled */
-    x?: number
-    /** Optional vertical position (0~1). When given, coordinate placement is enabled */
-    y?: number
-}
-
-export interface NAIImageGenOptions{
-    /** Per-character prompts for NAI v4/v4.5 multi-character prompting */
-    characters?: NAICharacterPrompt[]
-    /** Force coordinate-based placement. Defaults to true when any character supplies x/y */
-    use_coords?: boolean
-}
+export type { NAICharacterPrompt, NAIImageGenOptions }
 
 export async function generateAIImage(genPrompt:string, currentChar:character, neg:string, returnSdData:string, naiOptions?:NAIImageGenOptions):Promise<string|false>{
     const db = getDatabase()
@@ -139,33 +124,10 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
         }
     }
     if(db.sdProvider === 'novelai'){
-        // Convert SD-style () emphasis to NAI-style {} emphasis, preserving escaped \( \)
-        const naiEmphasis = (s:string) => s
-            .replaceAll('\\(', "♧")
-            .replaceAll('\\)', "♤")
-            .replaceAll('(','{')
-            .replaceAll(')','}')
-            .replaceAll('♧','(')
-            .replaceAll('♤',')')
-
         genPrompt = naiEmphasis(genPrompt)
 
         // Per-character prompts (NAI v4/v4.5 multi-character prompting), supplied by modules via Lua
-        const naiCharacters = naiOptions?.characters ?? []
-        const useCoords = naiOptions?.use_coords ??
-            naiCharacters.some(c => typeof c?.x === 'number' || typeof c?.y === 'number')
-        const charCenter = (c:NAICharacterPrompt) => ({
-            x: typeof c?.x === 'number' ? c.x : 0.5,
-            y: typeof c?.y === 'number' ? c.y : 0.5
-        })
-        const posCharCaptions = naiCharacters.map((c) => ({
-            char_caption: naiEmphasis(c?.prompt ?? ''),
-            centers: [charCenter(c)]
-        }))
-        const negCharCaptions = naiCharacters.map((c) => ({
-            char_caption: c?.negative ?? '',
-            centers: [charCenter(c)]
-        }))
+        const { useCoords, posCharCaptions, negCharCaptions, characterPrompts } = buildNAICharacterPrompts(naiOptions)
 
         let reqlist:any = {}
 
@@ -198,6 +160,7 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                     //add v4
                     "autoSmea": false,
                     "use_coords": useCoords,
+                    "characterPrompts": characterPrompts,
                     "legacy_uc": db.NAIImgConfig.legacy_uc,
                     "v4_prompt":{
                         caption:{
@@ -205,7 +168,8 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                             char_captions: posCharCaptions
                         },
                         use_coords: useCoords,
-                        use_order: !useCoords,
+                        // novelai-python keeps use_order on even with coordinates enabled
+                        use_order: true,
                     },
                     "v4_negative_prompt":{
                         caption:{

--- a/src/ts/process/tests/naiCharacterPrompts.test.ts
+++ b/src/ts/process/tests/naiCharacterPrompts.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { buildNAICharacterPrompts, type NAIImageGenOptions } from "../naiCharacterPrompts";
+
+// Modules hand these options over as a JSON string through the Lua bridge, so the
+// parsed value is only guaranteed to be an object. Anything else has to degrade
+// to a documented default rather than corrupt the request.
+const fromLua = (json: string) => JSON.parse(json) as NAIImageGenOptions;
+
+describe("buildNAICharacterPrompts", () => {
+    it("leaves the request untouched when no options are supplied", () => {
+        expect(buildNAICharacterPrompts()).toEqual({
+            useCoords: false,
+            posCharCaptions: [],
+            negCharCaptions: [],
+            characterPrompts: undefined,
+        });
+    });
+
+    it("builds char_captions and characterPrompts for multiple characters", () => {
+        const built = buildNAICharacterPrompts(
+            fromLua('{"characters":[{"prompt":"1girl","negative":"blurry"},{"prompt":"1boy"}]}')
+        );
+
+        expect(built.posCharCaptions).toEqual([
+            { char_caption: "1girl", centers: [{ x: 0, y: 0 }] },
+            { char_caption: "1boy", centers: [{ x: 0, y: 0 }] },
+        ]);
+        expect(built.negCharCaptions).toEqual([
+            { char_caption: "blurry", centers: [{ x: 0, y: 0 }] },
+            { char_caption: "", centers: [{ x: 0, y: 0 }] },
+        ]);
+        expect(built.characterPrompts).toEqual([
+            { prompt: "1girl", uc: "blurry", center: { x: 0, y: 0 }, enabled: true },
+            { prompt: "1boy", uc: "", center: { x: 0, y: 0 }, enabled: true },
+        ]);
+    });
+
+    it("converts SD-style emphasis in character prompts, preserving escaped parens", () => {
+        const built = buildNAICharacterPrompts(
+            fromLua('{"characters":[{"prompt":"(smile), artist \\\\(name\\\\)"}]}')
+        );
+
+        expect(built.posCharCaptions[0].char_caption).toBe("{smile}, artist (name)");
+    });
+
+    describe("coordinate placement", () => {
+        it("stays off while every character is on NAI's auto center", () => {
+            expect(buildNAICharacterPrompts(fromLua('{"characters":[{"prompt":"a"}]}')).useCoords).toBe(false);
+        });
+
+        it("turns on as soon as one character is actually placed", () => {
+            const built = buildNAICharacterPrompts(
+                fromLua('{"characters":[{"prompt":"1girl","x":0.3,"y":0.5},{"prompt":"1boy","x":0.7,"y":0.5}]}')
+            );
+
+            expect(built.useCoords).toBe(true);
+            expect(built.posCharCaptions.map((c) => c.centers[0])).toEqual([
+                { x: 0.3, y: 0.5 },
+                { x: 0.7, y: 0.5 },
+            ]);
+        });
+
+        it("clamps centers into NAI's 0~0.9 range", () => {
+            const built = buildNAICharacterPrompts(
+                fromLua('{"characters":[{"prompt":"a","x":1,"y":-5}]}')
+            );
+
+            expect(built.posCharCaptions[0].centers[0]).toEqual({ x: 0.9, y: 0 });
+        });
+
+        it("honours an explicit use_coords over the auto-detection", () => {
+            expect(buildNAICharacterPrompts(fromLua('{"use_coords":true,"characters":[{"prompt":"a"}]}')).useCoords).toBe(true);
+            expect(buildNAICharacterPrompts(fromLua('{"use_coords":false,"characters":[{"prompt":"a","x":0.3}]}')).useCoords).toBe(false);
+        });
+    });
+
+    describe("malformed options", () => {
+        it("ignores a non-boolean use_coords instead of treating it as truthy", () => {
+            // "false" is a truthy string, so a plain ?? would enable coordinates here
+            expect(buildNAICharacterPrompts(fromLua('{"use_coords":"false","characters":[{"prompt":"a"}]}')).useCoords).toBe(false);
+        });
+
+        it("falls back to the auto center for non-numeric positions", () => {
+            const built = buildNAICharacterPrompts(
+                fromLua('{"characters":[{"prompt":"a","x":"0.3","y":null}]}')
+            );
+
+            expect(built.posCharCaptions[0].centers[0]).toEqual({ x: 0, y: 0 });
+            expect(built.useCoords).toBe(false);
+        });
+
+        it("treats a missing prompt as an empty caption", () => {
+            const built = buildNAICharacterPrompts(fromLua('{"characters":[null]}'));
+
+            expect(built.posCharCaptions).toEqual([{ char_caption: "", centers: [{ x: 0, y: 0 }] }]);
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Wire NAI v4/v4.5 multi-character prompting through `generateAIImage` and expose it to Lua modules so they can supply per-character prompts.

- `generateAIImage` now accepts an optional `naiOptions` param carrying per-character prompts (prompt, negative, x, y).
- Build `v4_prompt` / `v4_negative_prompt` `char_captions` with centers from those options instead of hardcoding empty arrays, and send `parameters.characterPrompts` alongside them.
- Enable `use_coords` automatically when any character has a non-auto center. `use_order` stays `true`, matching every reference client.
- `generateImage` Lua API gains an optional 4th JSON options arg, parsed via `parseLuaOptions` and passed through. Fully backward compatible.

Claude-Session: https://claude.ai/code/session_01Ko5GAw8P9N7548yUaaakgY


## Related Issues

NONE


## Changes

### `generateImage` options argument

This PR adds an optional, backward-compatible options argument that lets modules pass **per-character prompts** for NovelAI v4 / v4.5 multi-character prompting.

#### Lua API

```
generateImage(id, prompt, negative, options)
```

| Arg | Type | Required | Description |
|-----|------|----------|-------------|
| `id` | string | ✓ | Low-level access trigger id |
| `prompt` | string | ✓ | Base (scene-level) positive prompt |
| `negative` | string | ✗ | Base negative prompt |
| `options` | string (JSON) | ✗ | JSON-encoded options object (see below). Omit, or pass `""`/invalid JSON, to fall back to the legacy single-prompt behavior |

The 4th argument is a **JSON string** (consistent with the existing `LLM` / `axLLM` convention, parsed via `parseLuaOptions`). On the TypeScript side it maps to `NAIImageGenOptions` and is passed to `generateAIImage(...)`.

#### Options schema (`NAIImageGenOptions`)

```jsonc
{
  // Per-character prompts, max 6 (NAI's limit — exceeding it is rejected by the API).
  // Order always matters: the model places characters in listed order
  // (first prompt → left). Coordinates are an additional nudge on top,
  // so keep the order consistent with the positions you set.
  "characters": [
    {
      "prompt":   "1girl, smile",  // required — this character's positive prompt
      "negative": "blurry",        // optional — this character's negative prompt (default "")

      // Character center, 0–0.9. Both optional.
      // 0 (or omitted) means automatic placement. The web UI's position
      // picker is a 5×5 grid over 0.1–0.9. Out-of-range values are clamped,
      // non-numeric values fall back to 0.
      "x": 0.3,
      "y": 0.5
    }
  ],

  // Optional. Forces coordinate placement on or off.
  // Omitted: enabled automatically when any character has a non-auto center.
  // Only an actual boolean is honoured; anything else falls back to auto-detection.
  "use_coords": true
}
```

#### Field semantics

| Field | Default | Notes |
|-------|---------|-------|
| `characters` | `[]` | Empty/absent → legacy single-prompt request (`char_captions` stays empty, no `characterPrompts` key). |
| `characters[].prompt` | `""` | Mapped to `v4_prompt.caption.char_captions[].char_caption`. SD-style `()` emphasis is converted to NAI-style `{}` (same as the base prompt); use `\(` `\)` for literal parentheses. |
| `characters[].negative` | `""` | Mapped to `v4_negative_prompt.caption.char_captions[].char_caption`. Passed through verbatim (no emphasis conversion, matching base-negative behavior). |
| `characters[].x` / `.y` | `0` (auto) | Written to `centers: [{ x, y }]`. `(0,0)` is NAI's `AUTO` placement, not top-left. Values are clamped to `0`–`0.9`; non-numeric values fall back to `0`. |
| `use_coords` | auto | `true` → NAI places characters by `centers`. Auto-detection enables it when any character has a center other than `(0,0)`. Only an actual boolean overrides the auto-detection. |

> **Note:** `use_coords` is global to the request. If any character provides a position, coordinate mode is enabled for **all** characters. When using coordinates, provide positions for every character to avoid overlap.

`use_order` is always sent as `true` and is not derived from `use_coords`. Order and position are reinforcing signals rather than alternatives — this matches novelai-python, Aedial/novelai-api, SillyTavern and the ComfyUI NAI nodes, none of which ever turn it off, and the NAI docs' guidance that positions "should not conflict with the order of your character prompt boxes".

`parameters.characterPrompts` is sent alongside `v4_prompt`, as every reference client does. It is omitted entirely when no characters are supplied, so a plain generation is byte-identical to before.

Example
```Lua
local result = generateImage(id, basePrompt, negPrompt, json.encode({
    characters = {
        { prompt = "1girl, smile", x = 0.3, y = 0.5 },
        { prompt = "1boy",         x = 0.7, y = 0.5 },
    }
})):await()
-- returns "{{inlay::...}}" on success, or "Error: Image generation failed"
```

### Error handling

Malformed options degrade instead of propagating. A wrong-typed field falls back to its documented default, and anything that does throw is caught and returned to the script as `'Error: Image generation failed'` — the same contract a failed generation always had. A bad options object never aborts the script run.

### Structure and tests

The multi-character field building lives in `src/ts/process/naiCharacterPrompts.ts`, separate from `stableDiff.ts` so it can be asserted without pulling in the app's stores. `src/ts/process/tests/naiCharacterPrompts.test.ts` covers the option handling, including malformed input.

## Impact

Existing callers using `generateImage(id, prompt, negative)` are unaffected — the options argument is optional, and when absent the request is identical to before this change: `use_coords: false`, `use_order: true`, empty `char_captions`, and no `characterPrompts` key. Non-NAI providers are untouched.

## Additional Notes

Module used for test: https://drive.proton.me/urls/5ZC3KMR860#BYEluVwBfLgV

How to test: Type /test. Then it generates image using Prompts, negative prompt, character prompt, character negative prompt(Optional), character location(optional) in lorebook
