### PR TITLE
fix: support runtime legal config

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -55,6 +55,7 @@ const PROXY_STREAM_MAX_PENDING_EVENTS = 512;
 const PROXY_STREAM_MAX_PENDING_BYTES = 2 * 1024 * 1024;
 const PROXY_STREAM_MAX_BODY_BASE64_BYTES = 8 * 1024 * 1024;
 const proxyStreamJobs = new Map();
+const enabledEnvValues = new Set(['true', '1', 'yes', 'y', 'on']);
 const authenticatedRouteLimiter = rateLimit({
     windowMs: 60 * 1000,
     max: 2000,
@@ -78,6 +79,22 @@ const loginRouteLimiter = rateLimit({
 });
 function isHex(str) {
     return hexRegex.test(str.toUpperCase().trim()) || str === '__password';
+}
+
+function isEnabledEnv(value) {
+    return typeof value === 'string' && enabledEnvValues.has(value.trim().toLowerCase());
+}
+
+function isLegalConfigured() {
+    return isEnabledEnv(process.env.RISU_LEGAL_CONFIGURED) || isEnabledEnv(process.env.VITE_RISU_LEGAL_CONFIGURED);
+}
+
+function createRuntimeConfigScript() {
+    const runtimeConfig = JSON.stringify({
+        legalConfigured: isLegalConfigured()
+    }).replace(/</g, '\\u003c');
+
+    return `<script>globalThis.__NODE__ = true;globalThis.__RISU_RUNTIME_CONFIG__ = ${runtimeConfig}</script>`;
 }
 
 async function hashJSON(json){
@@ -615,7 +632,7 @@ app.get('/', async (req, res, next) => {
         const mainIndex = await fs.readFile(path.join(process.cwd(), 'dist', 'index.html'))
         const root = htmlparser.parse(mainIndex)
         const head = root.querySelector('head')
-        head.innerHTML = `<script>globalThis.__NODE__ = true</script>` + head.innerHTML
+        head.innerHTML = createRuntimeConfigScript() + head.innerHTML
         
         res.send(root.toString())
     } catch (error) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -36,6 +36,7 @@
     import IrisModal from './lib/Others/IrisModal.svelte';
     import Legal from './lib/Others/Legal.svelte';
     import CustomSidebarConfig from './lib/Others/CustomSidebarConfig.svelte';
+    import { isLegalConfigured } from './ts/legal';
 
 
   
@@ -100,7 +101,7 @@
     }
 
 }}>
-    {#if !import.meta.env.VITE_RISU_LEGAL_CONFIGURED}
+    {#if !isLegalConfigured}
         <Legal />
     {:else if aprilFools}
 

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -28,6 +28,7 @@
     import { translateStackTrace } from "../../ts/sourcemap";
     import { getDetailedOSLabel, getFallbackOSLabel, getRisuEnvironmentLabel } from "src/ts/platform";
     import versionData from "../../../version.json";
+    import { isLegalConfigured } from "src/ts/legal";
 
     let showDetails = $state(false);
     let translatedStackTrace = $state('');
@@ -310,7 +311,7 @@
                         })
                     }}>NO</Button>
                 </div>
-            {:else if $alertStore.type === 'tos' && import.meta.env.VITE_RISU_LEGAL_CONFIGURED}
+            {:else if $alertStore.type === 'tos' && isLegalConfigured}
                 <div class="flex gap-2 w-full">
                     <Button className="mt-4 grow" onclick={() => {
                         alertStore.set({

--- a/src/lib/Others/Legal.svelte
+++ b/src/lib/Others/Legal.svelte
@@ -4,7 +4,7 @@
     and instructions on how to configure them.
 
     DO NOT REMOVE THIS NOTICE if you are editing the source code IN ANY CASE.
-    And DO NOT AUTOMATICALLY SET VITE_RISU_LEGAL_CONFIGURED to TRUE
+    And DO NOT AUTOMATICALLY SET VITE_RISU_LEGAL_CONFIGURED or RISU_LEGAL_CONFIGURED to TRUE
     without fully complying with the requirements listed in this notice.
 
     This notice is required to make sure there are no legal issues for you,
@@ -28,11 +28,11 @@
                 <li>创建您的服务条款页面，并将源代码中的服务条款URL更改为您自己的URL。</li>
                 <li>创建您的隐私政策页面，并将源代码中的隐私政策URL更改为您自己的URL。</li>
                 <li>在使用Risuai服务的部分（如登录和API调用）添加原始服务条款和隐私政策警报。</li>
-                <li>如果您确定已正确配置所有内容，可以通过在环境变量中将VITE_RISU_LEGAL_CONFIGURED设置为TRUE来继续。</li>
+                <li>如果您确定已正确配置所有内容，可以通过在环境变量中将VITE_RISU_LEGAL_CONFIGURED或RISU_LEGAL_CONFIGURED设置为TRUE来继续。</li>
             </ul>
 
             <p>
-                如果您是从原始存储库为私人使用运行的自托管实例，或者只是为了测试和开发而简单地分叉以PR回原始存储库，则可以通过在环境变量中将VITE_RISU_LEGAL_CONFIGURED设置为TRUE来继续，而无需执行上述任何操作。
+                如果您是从原始存储库为私人使用运行的自托管实例，或者只是为了测试和开发而简单地分叉以PR回原始存储库，则可以通过在环境变量中将VITE_RISU_LEGAL_CONFIGURED或RISU_LEGAL_CONFIGURED设置为TRUE来继续，而无需执行上述任何操作。
             </p>
 
         
@@ -48,11 +48,11 @@
                 <li>서비스 약관 페이지를 만들고 소스 코드에서 서비스 약관 URL을 자신의 URL로 변경합니다.</li>
                 <li>개인 정보 보호 정책 페이지를 만들고 소스 코드에서 개인 정보 보호 정책 URL을 자신의 URL로 변경합니다.</li>
                 <li>로그인 및 API 호출과 같은 Risuai 서비스를 사용하는 부분에 원래 서비스 약관 및 개인 정보 보호 정책 경고를 추가합니다.</li>
-                <li>모든 것을 올바르게 구성했다고 확신하는 경우 환경 변수에서 VITE_RISU_LEGAL_CONFIGURED를 TRUE로 설정하여 계속할 수 있습니다.</li>
+                <li>모든 것을 올바르게 구성했다고 확신하는 경우 환경 변수에서 VITE_RISU_LEGAL_CONFIGURED 또는 RISU_LEGAL_CONFIGURED를 TRUE로 설정하여 계속할 수 있습니다.</li>
             </ul>
 
             <p>
-                기존 Repository에서 개인 사용을 위해 자체 호스팅 인스턴스를 실행하거나 단순히 테스트 및 개발을 위해 원래 Repo에 PR하기 위한 간단한 포크인 경우 위의 작업을 수행할 필요 없이 환경 변수에서 VITE_RISU_LEGAL_CONFIGURED를 TRUE로 설정하여 계속할 수 있습니다.
+                기존 Repository에서 개인 사용을 위해 자체 호스팅 인스턴스를 실행하거나 단순히 테스트 및 개발을 위해 원래 Repo에 PR하기 위한 간단한 포크인 경우 위의 작업을 수행할 필요 없이 환경 변수에서 VITE_RISU_LEGAL_CONFIGURED 또는 RISU_LEGAL_CONFIGURED를 TRUE로 설정하여 계속할 수 있습니다.
             </p>
 
         {:else}
@@ -67,11 +67,11 @@
                 <li>Create your Terms of Service page and change the Terms of Service URL in the source code to your own.</li>
                 <li>Create your Privacy Policy page and change the Privacy Policy URL in the source code to your own.</li>
                 <li>Add Original Terms of Service and Privacy Policy alerts to parts that use Risuai services, such as login and API calls.</li>
-                <li>If you are sure you have configured everything correctly, you can proceed by setting VITE_RISU_LEGAL_CONFIGURED to TRUE in your environment variables.</li>
+                <li>If you are sure you have configured everything correctly, you can proceed by setting VITE_RISU_LEGAL_CONFIGURED or RISU_LEGAL_CONFIGURED to TRUE in your environment variables.</li>
             </ul>
 
             <p>
-                If you are running a running a 'self-hosted instance for private use from the original repository', or 'simple fork for testing and development to PR back to the original repository', you can proceed by setting VITE_RISU_LEGAL_CONFIGURED to TRUE in your environment variables, without needing to do any of the above.
+                If you are running a running a 'self-hosted instance for private use from the original repository', or 'simple fork for testing and development to PR back to the original repository', you can proceed by setting VITE_RISU_LEGAL_CONFIGURED or RISU_LEGAL_CONFIGURED to TRUE in your environment variables, without needing to do any of the above.
             </p>
 
         {/if}

--- a/src/ts/legal.ts
+++ b/src/ts/legal.ts
@@ -1,0 +1,25 @@
+type RisuRuntimeConfig = {
+    legalConfigured?: unknown
+}
+
+const enabledValues = new Set(['true', '1', 'yes', 'y', 'on'])
+
+function isEnabledFlag(value: unknown): boolean {
+    if (value === true) {
+        return true
+    }
+
+    if (typeof value !== 'string') {
+        return false
+    }
+
+    return enabledValues.has(value.trim().toLowerCase())
+}
+
+const runtimeConfig = (globalThis as typeof globalThis & {
+    __RISU_RUNTIME_CONFIG__?: RisuRuntimeConfig
+}).__RISU_RUNTIME_CONFIG__
+
+export const isLegalConfigured =
+    isEnabledFlag(import.meta.env.VITE_RISU_LEGAL_CONFIGURED) ||
+    isEnabledFlag(runtimeConfig?.legalConfigured)


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it will not break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it does not, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Allow node-hosted builds to honor the legal configuration flag at runtime. This keeps the existing build-time `VITE_RISU_LEGAL_CONFIGURED` behavior while allowing Docker users to opt in without rebuilding the frontend bundle.

## Related Issues

None

## Changes

- Added a shared `isLegalConfigured` helper that checks both the build-time Vite flag and the runtime config injected by the Node server.
- Updated the Node server HTML injection to include `globalThis.__RISU_RUNTIME_CONFIG__` with `legalConfigured` derived from `RISU_LEGAL_CONFIGURED` or `VITE_RISU_LEGAL_CONFIGURED`.
- Updated the Legal screen and TOS alert gate to use the shared legal configuration check.
- Updated Legal notice text to mention both supported environment variable names.

## Impact

Docker image users can now run with `RISU_LEGAL_CONFIGURED=TRUE` or `VITE_RISU_LEGAL_CONFIGURED=TRUE` and have the setting take effect at container runtime. Existing build-time configuration remains supported, and the default unset state still shows the Legal notice.

This does not change model requests, prompting, or response handling.

## Additional Notes

Validation performed:

- `node --check server/node/server.cjs`
- `git diff --check`
- `pnpm check`
- `pnpm build`
- Manual Node server response checks confirmed runtime injection for `RISU_LEGAL_CONFIGURED=TRUE`, `VITE_RISU_LEGAL_CONFIGURED=TRUE`, and the unset default.
