### PR TITLE
feat: apply OpenRouter attribution headers globally

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -43,7 +43,7 @@ import type { AccountStorage } from "./storage/accountStorage";
 import { getColdStorageItem, makeColdData } from "./process/coldstorage.svelte";
 import { isTauri, isNodeServer } from "./platform";
 import { isLocalNetworkUrl } from "./network/localNetwork";
-import { withOpenRouterAttributionHeaders } from "./network/openRouterHeaders";
+import { isOpenRouterUrl, withOpenRouterAttributionHeaders } from "./network/openRouterHeaders";
 import { decodeProxyJobWsChunk, formatProxyStreamErrorMessage, parseProxyJobWsEvent } from "./network/proxyJobWs";
 import { getNodeServerProxyAuth } from "./storage/nodeStorage";
 
@@ -681,9 +681,11 @@ export function addFetchLog(arg: {
  */
 export async function globalFetch(url: string, arg: GlobalFetchArgs = {}): Promise<GlobalFetchResult> {
     try {
-        arg = {
-            ...arg,
-            headers: withOpenRouterAttributionHeaders(url, arg.headers),
+        if(isOpenRouterUrl(url)){
+            const headers = withOpenRouterAttributionHeaders(url, arg.headers)
+            if(headers !== arg.headers){
+                arg = { ...arg, headers }
+            }
         }
         const db = getDatabase();
         if (arg.abortSignal?.aborted) { return { ok: false, data: 'aborted', headers: {}, status: 400 }; }
@@ -1728,9 +1730,11 @@ export async function fetchNative(url: string, arg: {
     networkRoute?: 'auto' | 'local_network'
 } = {}): Promise<Response> {
 
-    arg = {
-        ...arg,
-        headers: withOpenRouterAttributionHeaders(url, arg.headers),
+    if(isOpenRouterUrl(url)){
+        const headers = withOpenRouterAttributionHeaders(url, arg.headers)
+        if(headers !== arg.headers){
+            arg = { ...arg, headers }
+        }
     }
     const useInterceptor = !!arg.interceptor
     console.log(arg.body, 'body')

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -43,6 +43,7 @@ import type { AccountStorage } from "./storage/accountStorage";
 import { getColdStorageItem, makeColdData } from "./process/coldstorage.svelte";
 import { isTauri, isNodeServer } from "./platform";
 import { isLocalNetworkUrl } from "./network/localNetwork";
+import { withOpenRouterAttributionHeaders } from "./network/openRouterHeaders";
 import { decodeProxyJobWsChunk, formatProxyStreamErrorMessage, parseProxyJobWsEvent } from "./network/proxyJobWs";
 import { getNodeServerProxyAuth } from "./storage/nodeStorage";
 
@@ -680,6 +681,10 @@ export function addFetchLog(arg: {
  */
 export async function globalFetch(url: string, arg: GlobalFetchArgs = {}): Promise<GlobalFetchResult> {
     try {
+        arg = {
+            ...arg,
+            headers: withOpenRouterAttributionHeaders(url, arg.headers),
+        }
         const db = getDatabase();
         if (arg.abortSignal?.aborted) { return { ok: false, data: 'aborted', headers: {}, status: 400 }; }
 
@@ -1721,8 +1726,12 @@ export async function fetchNative(url: string, arg: {
     logFetch?: boolean
     requestTimeoutMs?: number
     networkRoute?: 'auto' | 'local_network'
-}): Promise<Response> {
+} = {}): Promise<Response> {
 
+    arg = {
+        ...arg,
+        headers: withOpenRouterAttributionHeaders(url, arg.headers),
+    }
     const useInterceptor = !!arg.interceptor
     console.log(arg.body, 'body')
     if (arg.body === undefined && (arg.method === 'POST' || arg.method === 'PUT')) {

--- a/src/ts/network/openRouterHeaders.test.ts
+++ b/src/ts/network/openRouterHeaders.test.ts
@@ -6,11 +6,11 @@ describe('withOpenRouterAttributionHeaders', () => {
     it('adds attribution headers for OpenRouter and its subdomains', () => {
         expect(withOpenRouterAttributionHeaders('https://openrouter.ai/api/v1/chat/completions')).toEqual({
             'HTTP-Referer': 'https://risuai.xyz',
-            'X-OpenRouter-Title': 'RisuAI',
+            'X-OpenRouter-Title': 'Risuai',
         })
         expect(withOpenRouterAttributionHeaders('https://api.openrouter.ai/v1/models')).toEqual({
             'HTTP-Referer': 'https://risuai.xyz',
-            'X-OpenRouter-Title': 'RisuAI',
+            'X-OpenRouter-Title': 'Risuai',
         })
     })
 
@@ -58,7 +58,7 @@ describe('withOpenRouterAttributionHeaders', () => {
 
         expect(result.get('Authorization')).toBe('Bearer plugin-key')
         expect(result.get('HTTP-Referer')).toBe('https://risuai.xyz')
-        expect(result.get('X-OpenRouter-Title')).toBe('RisuAI')
+        expect(result.get('X-OpenRouter-Title')).toBe('Risuai')
         expect(input.has('HTTP-Referer')).toBe(false)
     })
 
@@ -71,8 +71,17 @@ describe('withOpenRouterAttributionHeaders', () => {
 
         expect(result.get('Authorization')).toBe('Bearer plugin-key')
         expect(result.get('HTTP-Referer')).toBe('https://risuai.xyz')
-        expect(result.get('X-OpenRouter-Title')).toBe('RisuAI')
+        expect(result.get('X-OpenRouter-Title')).toBe('Risuai')
         expect(input).toEqual([['Authorization', 'Bearer plugin-key']])
+    })
+
+    it('joins repeated tuple-array header values like the Headers API', () => {
+        const result = new Headers(withOpenRouterAttributionHeaders(
+            'https://openrouter.ai/api/v1/chat/completions',
+            [['X-Plugin-Value', 'one'], ['x-plugin-value', 'two']],
+        ))
+
+        expect(result.get('X-Plugin-Value')).toBe('one, two')
     })
 
     it('does not restore attribution headers explicitly removed after applying defaults', () => {

--- a/src/ts/network/openRouterHeaders.test.ts
+++ b/src/ts/network/openRouterHeaders.test.ts
@@ -48,4 +48,40 @@ describe('withOpenRouterAttributionHeaders', () => {
         })
         expect(result).not.toHaveProperty('X-OpenRouter-Title')
     })
+
+    it('preserves Headers instances from plugin RequestInit options', () => {
+        const input = new Headers({ Authorization: 'Bearer plugin-key' })
+        const result = new Headers(withOpenRouterAttributionHeaders(
+            'https://openrouter.ai/api/v1/chat/completions',
+            input,
+        ))
+
+        expect(result.get('Authorization')).toBe('Bearer plugin-key')
+        expect(result.get('HTTP-Referer')).toBe('https://risuai.xyz')
+        expect(result.get('X-OpenRouter-Title')).toBe('RisuAI')
+        expect(input.has('HTTP-Referer')).toBe(false)
+    })
+
+    it('preserves tuple-array headers from plugin RequestInit options', () => {
+        const input: [string, string][] = [['Authorization', 'Bearer plugin-key']]
+        const result = new Headers(withOpenRouterAttributionHeaders(
+            'https://openrouter.ai/api/v1/chat/completions',
+            input,
+        ))
+
+        expect(result.get('Authorization')).toBe('Bearer plugin-key')
+        expect(result.get('HTTP-Referer')).toBe('https://risuai.xyz')
+        expect(result.get('X-OpenRouter-Title')).toBe('RisuAI')
+        expect(input).toEqual([['Authorization', 'Bearer plugin-key']])
+    })
+
+    it('does not restore attribution headers explicitly removed after applying defaults', () => {
+        const headers = withOpenRouterAttributionHeaders('https://openrouter.ai/api/v1/chat/completions')
+        delete headers['HTTP-Referer']
+        delete headers['X-OpenRouter-Title']
+
+        expect(withOpenRouterAttributionHeaders('https://openrouter.ai/api/v1/chat/completions', headers)).toBe(headers)
+        expect(headers).not.toHaveProperty('HTTP-Referer')
+        expect(headers).not.toHaveProperty('X-OpenRouter-Title')
+    })
 })

--- a/src/ts/network/openRouterHeaders.test.ts
+++ b/src/ts/network/openRouterHeaders.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { withOpenRouterAttributionHeaders } from './openRouterHeaders'
+
+describe('withOpenRouterAttributionHeaders', () => {
+    it('adds attribution headers for OpenRouter and its subdomains', () => {
+        expect(withOpenRouterAttributionHeaders('https://openrouter.ai/api/v1/chat/completions')).toEqual({
+            'HTTP-Referer': 'https://risuai.xyz',
+            'X-OpenRouter-Title': 'RisuAI',
+        })
+        expect(withOpenRouterAttributionHeaders('https://api.openrouter.ai/v1/models')).toEqual({
+            'HTTP-Referer': 'https://risuai.xyz',
+            'X-OpenRouter-Title': 'RisuAI',
+        })
+    })
+
+    it('does not modify requests to other or misleading hosts', () => {
+        const headers = { Authorization: 'Bearer test-key' }
+
+        expect(withOpenRouterAttributionHeaders('https://example.com/v1/chat', headers)).toBe(headers)
+        expect(withOpenRouterAttributionHeaders('https://openrouter.ai.example.com/v1/chat', headers)).toBe(headers)
+        expect(withOpenRouterAttributionHeaders('not-a-url', headers)).toBe(headers)
+    })
+
+    it('preserves custom attribution headers without regard to casing', () => {
+        const headers = {
+            Authorization: 'Bearer test-key',
+            'http-referer': 'https://plugin.example',
+            'x-openrouter-title': 'Plugin App',
+        }
+
+        expect(withOpenRouterAttributionHeaders('https://openrouter.ai/api/v1/chat/completions', headers)).toEqual(headers)
+        expect(headers).toEqual({
+            Authorization: 'Bearer test-key',
+            'http-referer': 'https://plugin.example',
+            'x-openrouter-title': 'Plugin App',
+        })
+    })
+
+    it('treats the legacy X-Title header as a custom title', () => {
+        const result = withOpenRouterAttributionHeaders('https://openrouter.ai/api/v1/chat/completions', {
+            'X-Title': 'Legacy Plugin App',
+        })
+
+        expect(result).toEqual({
+            'X-Title': 'Legacy Plugin App',
+            'HTTP-Referer': 'https://risuai.xyz',
+        })
+        expect(result).not.toHaveProperty('X-OpenRouter-Title')
+    })
+})

--- a/src/ts/network/openRouterHeaders.ts
+++ b/src/ts/network/openRouterHeaders.ts
@@ -1,9 +1,32 @@
 const openRouterHostname = 'openrouter.ai'
+const openRouterAttributionApplied = Symbol('openRouterAttributionApplied')
+
+type ProcessedOpenRouterHeaders = Record<string, string> & {
+    [openRouterAttributionApplied]?: true
+}
+
+function toHeaderRecord(currentHeaders: HeadersInit): Record<string, string> {
+    if(typeof Headers !== 'undefined' && currentHeaders instanceof Headers){
+        return Object.fromEntries(currentHeaders.entries())
+    }
+    if(Array.isArray(currentHeaders)){
+        return Object.fromEntries(currentHeaders)
+    }
+    return { ...currentHeaders }
+}
 
 export function withOpenRouterAttributionHeaders(
     url: string,
-    currentHeaders: Record<string, string> = {},
-): Record<string, string> {
+    currentHeaders?: Record<string, string>,
+): Record<string, string>
+export function withOpenRouterAttributionHeaders(
+    url: string,
+    currentHeaders: HeadersInit,
+): HeadersInit
+export function withOpenRouterAttributionHeaders(
+    url: string,
+    currentHeaders: HeadersInit = {},
+): HeadersInit {
     let hostname: string
     try {
         hostname = new URL(url).hostname.toLowerCase()
@@ -15,7 +38,11 @@ export function withOpenRouterAttributionHeaders(
         return currentHeaders
     }
 
-    const headers = { ...currentHeaders }
+    if((currentHeaders as ProcessedOpenRouterHeaders)[openRouterAttributionApplied]){
+        return currentHeaders
+    }
+
+    const headers = toHeaderRecord(currentHeaders) as ProcessedOpenRouterHeaders
     const headerNames = new Set(Object.keys(headers).map((name) => name.toLowerCase()))
 
     if(!headerNames.has('http-referer')){
@@ -24,6 +51,8 @@ export function withOpenRouterAttributionHeaders(
     if(!headerNames.has('x-openrouter-title') && !headerNames.has('x-title')){
         headers['X-OpenRouter-Title'] = 'RisuAI'
     }
+
+    Object.defineProperty(headers, openRouterAttributionApplied, { value: true })
 
     return headers
 }

--- a/src/ts/network/openRouterHeaders.ts
+++ b/src/ts/network/openRouterHeaders.ts
@@ -1,0 +1,29 @@
+const openRouterHostname = 'openrouter.ai'
+
+export function withOpenRouterAttributionHeaders(
+    url: string,
+    currentHeaders: Record<string, string> = {},
+): Record<string, string> {
+    let hostname: string
+    try {
+        hostname = new URL(url).hostname.toLowerCase()
+    } catch {
+        return currentHeaders
+    }
+
+    if(hostname !== openRouterHostname && !hostname.endsWith(`.${openRouterHostname}`)){
+        return currentHeaders
+    }
+
+    const headers = { ...currentHeaders }
+    const headerNames = new Set(Object.keys(headers).map((name) => name.toLowerCase()))
+
+    if(!headerNames.has('http-referer')){
+        headers['HTTP-Referer'] = 'https://risuai.xyz'
+    }
+    if(!headerNames.has('x-openrouter-title') && !headerNames.has('x-title')){
+        headers['X-OpenRouter-Title'] = 'RisuAI'
+    }
+
+    return headers
+}

--- a/src/ts/network/openRouterHeaders.ts
+++ b/src/ts/network/openRouterHeaders.ts
@@ -1,5 +1,6 @@
 const openRouterHostname = 'openrouter.ai'
 const openRouterAttributionApplied = Symbol('openRouterAttributionApplied')
+const openRouterTitleHeaders = new Set(['x-title', 'x-openrouter-title'])
 
 type ProcessedOpenRouterHeaders = Record<string, string> & {
     [openRouterAttributionApplied]?: true
@@ -10,9 +11,52 @@ function toHeaderRecord(currentHeaders: HeadersInit): Record<string, string> {
         return Object.fromEntries(currentHeaders.entries())
     }
     if(Array.isArray(currentHeaders)){
-        return Object.fromEntries(currentHeaders)
+        if(typeof Headers !== 'undefined'){
+            return Object.fromEntries(new Headers(currentHeaders).entries())
+        }
+
+        const headers: Record<string, string> = {}
+        for(const [name, value] of currentHeaders){
+            headers[name] = headers[name] ? `${headers[name]}, ${value}` : value
+        }
+        return headers
     }
     return { ...(currentHeaders as Record<string, string>) }
+}
+
+export function isOpenRouterUrl(url: string): boolean {
+    try {
+        const hostname = new URL(url).hostname.toLowerCase()
+        return hostname === openRouterHostname || hostname.endsWith(`.${openRouterHostname}`)
+    } catch {
+        return false
+    }
+}
+
+export function applyOpenRouterHeaderOverride(
+    headers: Record<string, string>,
+    name: string,
+    value?: string,
+): boolean {
+    if(!(headers as ProcessedOpenRouterHeaders)[openRouterAttributionApplied]){
+        return false
+    }
+
+    const normalizedName = name.toLowerCase()
+    const matchingNames = openRouterTitleHeaders.has(normalizedName)
+        ? openRouterTitleHeaders
+        : new Set([normalizedName])
+
+    for(const existingName of Object.keys(headers)){
+        if(matchingNames.has(existingName.toLowerCase())){
+            delete headers[existingName]
+        }
+    }
+
+    if(value !== undefined){
+        headers[name] = value
+    }
+    return true
 }
 
 export function withOpenRouterAttributionHeaders(
@@ -27,14 +71,7 @@ export function withOpenRouterAttributionHeaders(
     url: string,
     currentHeaders: HeadersInit = {},
 ): HeadersInit {
-    let hostname: string
-    try {
-        hostname = new URL(url).hostname.toLowerCase()
-    } catch {
-        return currentHeaders
-    }
-
-    if(hostname !== openRouterHostname && !hostname.endsWith(`.${openRouterHostname}`)){
+    if(!isOpenRouterUrl(url)){
         return currentHeaders
     }
 
@@ -49,7 +86,7 @@ export function withOpenRouterAttributionHeaders(
         headers['HTTP-Referer'] = 'https://risuai.xyz'
     }
     if(!headerNames.has('x-openrouter-title') && !headerNames.has('x-title')){
-        headers['X-OpenRouter-Title'] = 'RisuAI'
+        headers['X-OpenRouter-Title'] = 'Risuai'
     }
 
     Object.defineProperty(headers, openRouterAttributionApplied, { value: true })

--- a/src/ts/network/openRouterHeaders.ts
+++ b/src/ts/network/openRouterHeaders.ts
@@ -12,7 +12,7 @@ function toHeaderRecord(currentHeaders: HeadersInit): Record<string, string> {
     if(Array.isArray(currentHeaders)){
         return Object.fromEntries(currentHeaders)
     }
-    return { ...currentHeaders }
+    return { ...(currentHeaders as Record<string, string>) }
 }
 
 export function withOpenRouterAttributionHeaders(

--- a/src/ts/plugins/plugins.svelte.ts
+++ b/src/ts/plugins/plugins.svelte.ts
@@ -506,47 +506,10 @@ export const allowedDbKeys = [
     'characterOrder'
 ]
 
-const pluginFetchHeaderRules = [
-    {
-        matches: (hostname: string) => hostname === 'openrouter.ai' || hostname.endsWith('.openrouter.ai'),
-        headers: {
-            'X-Title': 'RisuAI',
-            'HTTP-Referer': 'https://risuai.xyz'
-        }
-    }
-]
-
-function withPluginFetchHeaders(url: string, arg: any = {}) {
-    let hostname = ''
-    try {
-        hostname = new URL(url).hostname.toLowerCase()
-    } catch {
-        return arg
-    }
-
-    const rule = pluginFetchHeaderRules.find((rule) => rule.matches(hostname))
-    if(!rule){
-        return arg
-    }
-
-    const headers = { ...(arg.headers ?? {}) }
-    const hasHeader = (name: string) => Object.keys(headers).some((key) => key.toLowerCase() === name.toLowerCase())
-    for(const [name, value] of Object.entries(rule.headers)){
-        if(!hasHeader(name)){
-            headers[name] = value
-        }
-    }
-
-    return {
-        ...arg,
-        headers
-    }
-}
-
 export const getV2PluginAPIs = () => {
     return {
-        risuFetch: (url: string, arg?: any) => globalFetch(url, withPluginFetchHeaders(url, arg)),
-        nativeFetch: (url: string, arg?: any) => fetchNative(url, withPluginFetchHeaders(url, arg)),
+        risuFetch: globalFetch,
+        nativeFetch: fetchNative,
         getArg: (arg: string) => {
             const db = getDatabase()
             const [name, realArg] = arg.split('::')

--- a/src/ts/plugins/plugins.svelte.ts
+++ b/src/ts/plugins/plugins.svelte.ts
@@ -506,10 +506,47 @@ export const allowedDbKeys = [
     'characterOrder'
 ]
 
+const pluginFetchHeaderRules = [
+    {
+        matches: (hostname: string) => hostname === 'openrouter.ai' || hostname.endsWith('.openrouter.ai'),
+        headers: {
+            'X-Title': 'RisuAI',
+            'HTTP-Referer': 'https://risuai.xyz'
+        }
+    }
+]
+
+function withPluginFetchHeaders(url: string, arg: any = {}) {
+    let hostname = ''
+    try {
+        hostname = new URL(url).hostname.toLowerCase()
+    } catch {
+        return arg
+    }
+
+    const rule = pluginFetchHeaderRules.find((rule) => rule.matches(hostname))
+    if(!rule){
+        return arg
+    }
+
+    const headers = { ...(arg.headers ?? {}) }
+    const hasHeader = (name: string) => Object.keys(headers).some((key) => key.toLowerCase() === name.toLowerCase())
+    for(const [name, value] of Object.entries(rule.headers)){
+        if(!hasHeader(name)){
+            headers[name] = value
+        }
+    }
+
+    return {
+        ...arg,
+        headers
+    }
+}
+
 export const getV2PluginAPIs = () => {
     return {
-        risuFetch: globalFetch,
-        nativeFetch: fetchNative,
+        risuFetch: (url: string, arg?: any) => globalFetch(url, withPluginFetchHeaders(url, arg)),
+        nativeFetch: (url: string, arg?: any) => fetchNative(url, withPluginFetchHeaders(url, arg)),
         getArg: (arg: string) => {
             const db = getDatabase()
             const [name, realArg] = arg.split('::')

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -370,6 +370,35 @@ describe('OpenAI Responses API helpers', () => {
         expect(preview.body.extra).toEqual({ enabled: true })
     })
 
+    it('includes OpenRouter attribution headers in Responses previews', async () => {
+        const result = await requestOpenAIResponseAPI(baseArg({
+            aiModel: 'reverse_proxy',
+            customURL: 'https://openrouter.ai/api/v1',
+            previewBody: true,
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.headers['HTTP-Referer']).toBe('https://risuai.xyz')
+        expect(preview.headers['X-OpenRouter-Title']).toBe('RisuAI')
+    })
+
+    it('preserves an explicit OpenRouter attribution opt-out in Responses previews', async () => {
+        mocks.db.additionalParams = [['header::X-Title', '{{none}}']]
+
+        const result = await requestOpenAIResponseAPI(baseArg({
+            aiModel: 'reverse_proxy',
+            customURL: 'https://openrouter.ai/api/v1',
+            previewBody: true,
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.headers['HTTP-Referer']).toBe('https://risuai.xyz')
+        expect(preview.headers).not.toHaveProperty('X-Title')
+        expect(preview.headers).not.toHaveProperty('X-OpenRouter-Title')
+    })
+
     it('does not duplicate top-level output_text when message output blocks are also present', () => {
         const text = __testResponsesAPI.extractResponsesText({
             output_text: 'final text',

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer } from 'src/ts/model/types'
 import { fetchNative } from 'src/ts/globalApi.svelte'
 import { callTool } from '../../mcp/mcp'
-import { __testResponsesAPI, requestOpenAIResponseAPI } from './requests'
+import { __testResponsesAPI, requestOpenAI, requestOpenAILegacyInstruct, requestOpenAIResponseAPI } from './requests'
 
 const mocks = vi.hoisted(() => ({
     db: {
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
         jsonSchema: '{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}',
         jsonSchemaEnabled: false,
         localNetworkMode: false,
+        mistralKey: 'mistral-key',
         modelTools: [] as string[],
         newOAIHandle: true,
         nanogptKey: 'nanogpt-key',
@@ -380,7 +381,7 @@ describe('OpenAI Responses API helpers', () => {
         expect(result.type).toBe('success')
         const preview = JSON.parse(result.result as string)
         expect(preview.headers['HTTP-Referer']).toBe('https://risuai.xyz')
-        expect(preview.headers['X-OpenRouter-Title']).toBe('RisuAI')
+        expect(preview.headers['X-OpenRouter-Title']).toBe('Risuai')
     })
 
     it('preserves an explicit OpenRouter attribution opt-out in Responses previews', async () => {
@@ -397,6 +398,50 @@ describe('OpenAI Responses API helpers', () => {
         expect(preview.headers['HTTP-Referer']).toBe('https://risuai.xyz')
         expect(preview.headers).not.toHaveProperty('X-Title')
         expect(preview.headers).not.toHaveProperty('X-OpenRouter-Title')
+    })
+
+    it('includes OpenRouter attribution headers in Mistral previews', async () => {
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'xcustom:::mistral',
+            customURL: 'https://openrouter.ai/api/v1/chat/completions',
+            previewBody: true,
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                format: LLMFormat.Mistral,
+                id: 'xcustom:::mistral',
+            },
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.headers['HTTP-Referer']).toBe('https://risuai.xyz')
+        expect(preview.headers['X-OpenRouter-Title']).toBe('Risuai')
+    })
+
+    it('preserves an explicit OpenRouter attribution opt-out for Legacy Instruct', async () => {
+        mocks.db.additionalParams = [['header::X-Title', '{{none}}']]
+        mocks.globalFetch.mockResolvedValueOnce({
+            ok: true,
+            data: { choices: [{ text: 'ok' }] },
+        })
+
+        const result = await requestOpenAILegacyInstruct(baseArg({
+            aiModel: 'reverse_proxy',
+            customURL: 'https://openrouter.ai/api/v1/completions',
+        }))
+
+        expect(result).toEqual({ type: 'success', result: 'ok' })
+        expect(mocks.globalFetch).toHaveBeenCalledWith(
+            'https://openrouter.ai/api/v1/completions',
+            expect.objectContaining({
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer openai-key',
+                    'HTTP-Referer': 'https://risuai.xyz',
+                },
+            }),
+        )
     })
 
     it('does not duplicate top-level output_text when message output blocks are also present', () => {

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -7,6 +7,7 @@ import { getFreeOpenRouterModels } from "src/ts/model/openrouter"
 import { addFetchLog, fetchNative, globalFetch, textifyReadableStream } from "src/ts/globalApi.svelte"
 import { isNodeServer, isTauri } from "src/ts/platform"
 import { simplifySchema } from "src/ts/util"
+import { withOpenRouterAttributionHeaders } from "src/ts/network/openRouterHeaders"
 
 import { extractJSON, getOpenAIJSONSchema } from "../../templates/jsonSchema"
 import { applyChatTemplate } from "../../templates/chatTemplate"
@@ -544,17 +545,13 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         body.service_tier = 'flex'
     }
 
-    let headers = {
+    let headers: Record<string, string> = {
         "Authorization": "Bearer " + (arg.key ?? (aiModel === 'nanogpt' ? db.nanogptKey : aiModel === 'reverse_proxy' ?  db.proxyKey : (aiModel === 'openrouter' ? db.openrouterKey : db.openAIKey))),
         "Content-Type": "application/json"
     }
 
     if(arg.modelInfo?.keyIdentifier){
         headers["Authorization"] = "Bearer " + db.OaiCompAPIKeys[arg.modelInfo.keyIdentifier]
-    }
-    if(aiModel === 'openrouter'){
-        headers["X-Title"] = 'RisuAI'
-        headers["HTTP-Referer"] = 'https://risuai.xyz'
     }
     if(aiModel === 'nanogpt' && db.nanogptProvider){
         headers["X-Provider"] = db.nanogptProvider
@@ -574,6 +571,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
     }
     
     body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
+    headers = withOpenRouterAttributionHeaders(replacerURL, headers)
 
     // Some aux flows are intentionally non-streaming (e.g. memory/translate).
     // If custom Additional Parameters contains stream=true, force non-stream mode back.

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -282,6 +282,9 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
 
         const requestURL = arg.customURL ?? "https://api.mistral.ai/v1/chat/completions"
         const networkOptions = getLocalNetworkRequestOptions(requestURL, db, false)
+        const headers = withOpenRouterAttributionHeaders(requestURL, {
+            "Authorization": "Bearer " + (arg.key ?? db.mistralKey),
+        })
 
         const targs = {
             body: applyParameters({
@@ -292,9 +295,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
             }, ['temperature', 'presence_penalty', 'frequency_penalty', 'top_p'], {}, arg.mode, {
                 modelId: arg.modelInfo.id
             } ),
-            headers: {
-                "Authorization": "Bearer " + (arg.key ?? db.mistralKey),
-            },
+            headers,
             abortSignal: arg.abortSignal,
             chatId: arg.chatId,
             interceptor: 'mistral',
@@ -939,14 +940,16 @@ export async function requestOpenAILegacyInstruct(arg:RequestDataArgumentExtende
         frequency_penalty: arg.frequencyPenalty || (db.frequencyPenalty / 100),
     }
 
-    let headers:any = {
+    const requestURL = arg.customURL ?? "https://api.openai.com/v1/completions"
+    let headers: Record<string, string> = {
         "Content-Type": "application/json",
         "Authorization": "Bearer " + (arg.key ?? db.openAIKey)
     }
 
+    headers = withOpenRouterAttributionHeaders(requestURL, headers)
     body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
 
-    const response = await globalFetch(arg.customURL ?? "https://api.openai.com/v1/completions", {
+    const response = await globalFetch(requestURL, {
         body: body,
         headers: headers,
         chatId: arg.chatId,

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -570,8 +570,8 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         body.n = db.genTime
     }
     
-    body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
     headers = withOpenRouterAttributionHeaders(replacerURL, headers)
+    body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))
 
     // Some aux flows are intentionally non-streaming (e.g. memory/translate).
     // If custom Additional Parameters contains stream=true, force non-stream mode back.

--- a/src/ts/process/request/openAI/responses.ts
+++ b/src/ts/process/request/openAI/responses.ts
@@ -5,6 +5,7 @@ import { LLMFlags } from "src/ts/model/modellist"
 import { addFetchLog, fetchNative, globalFetch, textifyReadableStream } from "src/ts/globalApi.svelte"
 import { simplifySchema } from "src/ts/util"
 import { NANOGPT_RESPONSES_ENDPOINT, NANOGPT_SUBSCRIPTION_RESPONSES_ENDPOINT } from "src/ts/model/providers/nanogpt"
+import { withOpenRouterAttributionHeaders } from "src/ts/network/openRouterHeaders"
 
 import { extractJSON, getOpenAIJSONSchema } from "../../templates/jsonSchema"
 import { callTool, decodeToolCall, encodeToolCall } from "../../mcp/mcp"
@@ -802,7 +803,7 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
     const aiModel = arg.aiModel
     let body = await buildResponsesBody(arg)
     const { requestURL, risuIdentify } = getResponsesRequestURL(arg)
-    const headers = buildResponsesHeaders(arg, risuIdentify)
+    const headers = withOpenRouterAttributionHeaders(requestURL, buildResponsesHeaders(arg, risuIdentify))
 
     if(aiModel === 'reverse_proxy' || aiModel?.startsWith('xcustom:::')){
         body = applyAdditionalParameters(body, headers, getAdditionalParameters(aiModel))

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -91,7 +91,16 @@ export function applyAdditionalParameters<T extends Record<string, any>>(
 
         if (value === '{{none}}') {
             if (key.startsWith('header::')) {
-                delete headers[key.replace('header::', '')]
+                const headerName = key.replace('header::', '').toLowerCase()
+                const headerNames = headerName === 'x-title' || headerName === 'x-openrouter-title'
+                    ? new Set(['x-title', 'x-openrouter-title'])
+                    : new Set([headerName])
+
+                for(const existingHeader of Object.keys(headers)){
+                    if(headerNames.has(existingHeader.toLowerCase())){
+                        delete headers[existingHeader]
+                    }
+                }
             }
             else {
                 delete body[key]

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -1,4 +1,5 @@
 import { getDatabase } from 'src/ts/storage/database.svelte'
+import { applyOpenRouterHeaderOverride } from 'src/ts/network/openRouterHeaders'
 import { parseAdditionalParamJsonValue } from './additionalParams'
 
 export type LLMParameter =
@@ -91,15 +92,9 @@ export function applyAdditionalParameters<T extends Record<string, any>>(
 
         if (value === '{{none}}') {
             if (key.startsWith('header::')) {
-                const headerName = key.replace('header::', '').toLowerCase()
-                const headerNames = headerName === 'x-title' || headerName === 'x-openrouter-title'
-                    ? new Set(['x-title', 'x-openrouter-title'])
-                    : new Set([headerName])
-
-                for(const existingHeader of Object.keys(headers)){
-                    if(headerNames.has(existingHeader.toLowerCase())){
-                        delete headers[existingHeader]
-                    }
+                const headerName = key.replace('header::', '')
+                if(!applyOpenRouterHeaderOverride(headers, headerName)){
+                    delete headers[headerName]
                 }
             }
             else {
@@ -109,7 +104,10 @@ export function applyAdditionalParameters<T extends Record<string, any>>(
         }
 
         if (key.startsWith('header::')) {
-            headers[key.replace('header::', '')] = value
+            const headerName = key.replace('header::', '')
+            if(!applyOpenRouterHeaderOverride(headers, headerName, value)){
+                headers[headerName] = value
+            }
             continue
         }
 

--- a/src/ts/process/request/tests/additionalParams.test.ts
+++ b/src/ts/process/request/tests/additionalParams.test.ts
@@ -64,4 +64,32 @@ describe("applyAdditionalParameters", () => {
             "X-Custom": "kept",
         });
     });
+
+    it("replaces OpenRouter title aliases and differently-cased referers", () => {
+        const headers = withOpenRouterAttributionHeaders("https://openrouter.ai/api/v1", {
+            Authorization: "Bearer test-key",
+        });
+
+        applyAdditionalParameters({}, headers, [
+            ["header::X-Title", "MyApp"],
+            ["header::http-referer", "https://example.com"],
+        ]);
+
+        expect(headers).toEqual({
+            Authorization: "Bearer test-key",
+            "X-Title": "MyApp",
+            "http-referer": "https://example.com",
+        });
+    });
+
+    it("keeps exact header deletion semantics outside OpenRouter", () => {
+        const headers = {
+            "X-Title": "remove",
+            "x-title": "keep",
+        };
+
+        applyAdditionalParameters({}, headers, [["header::X-Title", "{{none}}"]]);
+
+        expect(headers).toEqual({ "x-title": "keep" });
+    });
 });

--- a/src/ts/process/request/tests/additionalParams.test.ts
+++ b/src/ts/process/request/tests/additionalParams.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("src/ts/storage/database.svelte", () => ({
+    getDatabase: () => ({}),
+}));
 
 import { parseAdditionalParamJsonValue } from "../additionalParams";
+import { applyAdditionalParameters } from "../shared";
+import { withOpenRouterAttributionHeaders } from "../../../network/openRouterHeaders";
 
 describe("parseAdditionalParamJsonValue", () => {
     it("parses standard JSON additional parameter values", () => {
@@ -40,5 +46,22 @@ describe("parseAdditionalParamJsonValue", () => {
 
     it("returns undefined for invalid json:: payloads", () => {
         expect(parseAdditionalParamJsonValue('{"enable_thinking": Truthy}')).toBeUndefined();
+    });
+});
+
+describe("applyAdditionalParameters", () => {
+    it("removes OpenRouter title aliases case-insensitively", () => {
+        const headers = withOpenRouterAttributionHeaders("https://openrouter.ai/api/v1", {
+            "x-title": "Legacy title",
+            "X-Custom": "kept",
+        });
+
+        applyAdditionalParameters({}, headers, [["header::X-Title", "{{none}}"]]);
+
+        expect(withOpenRouterAttributionHeaders("https://openrouter.ai/api/v1", headers)).toBe(headers);
+        expect(headers).toEqual({
+            "HTTP-Referer": "https://risuai.xyz",
+            "X-Custom": "kept",
+        });
     });
 });


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? No public types were changed.
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models? The policy is limited by destination hostname, and non-OpenRouter hosts remain unchanged.
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? The shared request paths used by these targets are covered; packaged platform runs were not performed.
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This centralizes default OpenRouter app-attribution headers in the shared request layer.

Requests whose destination is `openrouter.ai` or one of its subdomains now receive `HTTP-Referer: https://risuai.xyz` and `X-OpenRouter-Title: RisuAI` when they pass through `globalFetch` or `fetchNative`, unless the caller already supplied attribution values.

## Related Issues

None.

## Changes

- Added a shared, URL-based OpenRouter attribution-header helper.
- Applied the helper to both `globalFetch` and `fetchNative`, covering non-streaming and streaming request paths.
- Reused the same helper in the OpenAI-compatible request builder so provider-body previews match real requests.
- Preserved caller-provided headers case-insensitively, including the legacy `X-Title` alias.
- Added focused coverage for exact hosts, subdomains, misleading hosts, invalid URLs, and custom headers.

## Impact

Built-in OpenRouter requests, plugin requests, and custom or reverse-proxy requests that target an OpenRouter host through the shared request APIs receive consistent app attribution.

Requests to other hosts remain unchanged. OpenRouter model and provider discovery currently use raw `fetch` directly, so those non-generation requests remain outside this shared policy.

## Additional Notes

Validated with:

- `pnpm exec vitest run src/ts/process/request/openAI/requests.responses.test.ts src/ts/network/openRouterHeaders.test.ts` (28 tests)
- `pnpm check`
- `git diff --check upstream/main...HEAD`
- conflict-free merge-tree check against the latest `upstream/main`
