### PR TITLE
fix: preserve remote save cleanup grace period

### DIFF
--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -32,6 +32,7 @@ import { initMobileGesture } from "./hotkey";
 import { moduleUpdate } from "./process/modules";
 import type { AccountStorage } from "./storage/accountStorage";
 import { makeColdData } from "./process/coldstorage.svelte";
+import { getRemoteSaveCleanupAction, getRemoteSavePayloadName } from "./storage/remoteSaveCleanup";
 import {
     forageStorage,
     saveDb,
@@ -548,35 +549,38 @@ async function cleanChunks(options:{
         for (const remote of remotes) {
             try {
                 const remoteFileName = getBasename(remote.name)
-                if(!remoteFileName.endsWith('.local.bin')){
+                const remotePayloadName = getRemoteSavePayloadName(remoteFileName)
+                if(!remotePayloadName){
                     continue
                 }
-                const name = remoteFileName.slice(0, -'.local.bin'.length)
-                const fexists = remoteUncleanables.has(name)
+                const fexists = remoteUncleanables.has(remotePayloadName)
                 if(!fexists){
 
-                    let okayToDelete = false
                     const metaPath = 'remotes/' + remote.name + '.meta'
+                    let metaExists = false
+                    let metaLastUsed:unknown
                     try {
-                        const metaExists = await exists(metaPath, { baseDir: BaseDirectory.AppData })
+                        metaExists = await exists(metaPath, { baseDir: BaseDirectory.AppData })
                         if (metaExists) {
                             const meta = await readFile(metaPath, { baseDir: BaseDirectory.AppData })
                             const metaJson = JSON.parse(new TextDecoder().decode(meta))
-                            const lastUsed = metaJson.lastUsed as number
-
-                            if(Date.now() - lastUsed > 1000 * 60 * 60 * 24 * 7) { //not used for 7 days
-                                okayToDelete = true
-                            }
-                        }
-                        else{
-                            //write meta for next time
-                            const metaJson = {
-                                lastUsed: Date.now()
-                            }
-                            await writeFile(metaPath, new TextEncoder().encode(JSON.stringify(metaJson)), { baseDir: BaseDirectory.AppData })
+                            metaLastUsed = metaJson.lastUsed
                         }
                     } catch (error) {}
-                    if(okayToDelete){
+
+                    const cleanupAction = getRemoteSaveCleanupAction({
+                        fileName: remoteFileName,
+                        activeCharacterIds: remoteUncleanables,
+                        hasMeta: metaExists,
+                        metaLastUsed
+                    })
+                    if(cleanupAction === 'create-meta'){
+                        const metaJson = {
+                            lastUsed: Date.now()
+                        }
+                        await writeFile(metaPath, new TextEncoder().encode(JSON.stringify(metaJson)), { baseDir: BaseDirectory.AppData })
+                    }
+                    else if(cleanupAction === 'delete'){
                         await remove('remotes/' + remote.name, { baseDir: BaseDirectory.AppData })
                         await remove(metaPath, { baseDir: BaseDirectory.AppData })
                     }

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -547,13 +547,17 @@ async function cleanChunks(options:{
         )
         for (const remote of remotes) {
             try {
-                const name = getBasename(remote.name).slice(0, -10) //remove .local.bin
+                const remoteFileName = getBasename(remote.name)
+                if(!remoteFileName.endsWith('.local.bin')){
+                    continue
+                }
+                const name = remoteFileName.slice(0, -'.local.bin'.length)
                 const fexists = remoteUncleanables.has(name)
                 if(!fexists){
 
                     let okayToDelete = false
+                    const metaPath = 'remotes/' + remote.name + '.meta'
                     try {
-                        const metaPath = 'remotes/' + remote.name + '.meta'
                         const metaExists = await exists(metaPath, { baseDir: BaseDirectory.AppData })
                         if (metaExists) {
                             const meta = await readFile(metaPath, { baseDir: BaseDirectory.AppData })
@@ -572,7 +576,10 @@ async function cleanChunks(options:{
                             await writeFile(metaPath, new TextEncoder().encode(JSON.stringify(metaJson)), { baseDir: BaseDirectory.AppData })
                         }
                     } catch (error) {}
-                    await remove('remotes/' + remote.name, { baseDir: BaseDirectory.AppData })
+                    if(okayToDelete){
+                        await remove('remotes/' + remote.name, { baseDir: BaseDirectory.AppData })
+                        await remove(metaPath, { baseDir: BaseDirectory.AppData })
+                    }
                 }
             } catch (error) {
                 console.log('error', remote.name)

--- a/src/ts/storage/remoteSaveCleanup.test.ts
+++ b/src/ts/storage/remoteSaveCleanup.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    getRemoteSaveCleanupAction,
+    getRemoteSavePayloadName,
+    remoteSaveCleanupGraceMs,
+} from './remoteSaveCleanup'
+
+const now = 10_000_000_000
+
+describe('getRemoteSavePayloadName', () => {
+    it('extracts the character id from remote save payload files', () => {
+        expect(getRemoteSavePayloadName('character-id.local.bin')).toBe('character-id')
+    })
+
+    it('ignores metadata and unrelated files', () => {
+        expect(getRemoteSavePayloadName('character-id.local.bin.meta')).toBeNull()
+        expect(getRemoteSavePayloadName('character-id.bin')).toBeNull()
+    })
+})
+
+describe('getRemoteSaveCleanupAction', () => {
+    it('keeps payloads for active characters', () => {
+        expect(getRemoteSaveCleanupAction({
+            fileName: 'active-character.local.bin',
+            activeCharacterIds: new Set(['active-character']),
+            hasMeta: false,
+            now,
+        })).toBe('keep')
+    })
+
+    it('creates metadata before deleting orphaned payloads', () => {
+        expect(getRemoteSaveCleanupAction({
+            fileName: 'orphan-character.local.bin',
+            activeCharacterIds: new Set(),
+            hasMeta: false,
+            now,
+        })).toBe('create-meta')
+    })
+
+    it('keeps orphaned payloads inside the cleanup grace period', () => {
+        expect(getRemoteSaveCleanupAction({
+            fileName: 'orphan-character.local.bin',
+            activeCharacterIds: new Set(),
+            hasMeta: true,
+            metaLastUsed: now - remoteSaveCleanupGraceMs + 1,
+            now,
+        })).toBe('keep')
+    })
+
+    it('deletes orphaned payloads after the cleanup grace period', () => {
+        expect(getRemoteSaveCleanupAction({
+            fileName: 'orphan-character.local.bin',
+            activeCharacterIds: new Set(),
+            hasMeta: true,
+            metaLastUsed: now - remoteSaveCleanupGraceMs - 1,
+            now,
+        })).toBe('delete')
+    })
+
+    it('keeps orphaned payloads with malformed metadata', () => {
+        expect(getRemoteSaveCleanupAction({
+            fileName: 'orphan-character.local.bin',
+            activeCharacterIds: new Set(),
+            hasMeta: true,
+            metaLastUsed: 'not-a-number',
+            now,
+        })).toBe('keep')
+    })
+})

--- a/src/ts/storage/remoteSaveCleanup.ts
+++ b/src/ts/storage/remoteSaveCleanup.ts
@@ -1,0 +1,38 @@
+export const remoteSavePayloadExtension = '.local.bin'
+export const remoteSaveCleanupGraceMs = 1000 * 60 * 60 * 24 * 7
+
+export type RemoteSaveCleanupAction = 'ignore' | 'keep' | 'create-meta' | 'delete'
+
+export function getRemoteSavePayloadName(fileName:string){
+    if(!fileName.endsWith(remoteSavePayloadExtension)){
+        return null
+    }
+    return fileName.slice(0, -remoteSavePayloadExtension.length)
+}
+
+export function getRemoteSaveCleanupAction(arg:{
+    fileName:string
+    activeCharacterIds:Set<string>
+    hasMeta:boolean
+    metaLastUsed?:unknown
+    now?:number
+}):RemoteSaveCleanupAction{
+    const payloadName = getRemoteSavePayloadName(arg.fileName)
+    if(!payloadName){
+        return 'ignore'
+    }
+    if(arg.activeCharacterIds.has(payloadName)){
+        return 'keep'
+    }
+    if(!arg.hasMeta){
+        return 'create-meta'
+    }
+    if(
+        typeof arg.metaLastUsed === 'number' &&
+        Number.isFinite(arg.metaLastUsed) &&
+        (arg.now ?? Date.now()) - arg.metaLastUsed > remoteSaveCleanupGraceMs
+    ){
+        return 'delete'
+    }
+    return 'keep'
+}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This fixes the Tauri cleanup path for Remote Saving files so orphaned `remotes/*.local.bin` payloads respect the same grace period as the web/localforage path.

## Related Issues

None

## Changes

The Tauri `cleanChunks()` branch now only treats `.local.bin` files as Remote Saving payloads. When an orphaned remote payload has no metadata file, the cleanup pass creates the metadata and leaves the payload in place. When the metadata is already present and older than the seven-day grace period, both the payload and its metadata are removed.

The cleanup decision is now covered by a small pure helper and a focused `.test.ts` file for payload detection, active-character preservation, metadata creation, grace-period retention, stale deletion, and malformed metadata handling.

## Impact

Users with Remote Saving enabled on Tauri get a safer cleanup path. Current character payloads are still preserved, and old orphaned payloads are still cleaned after the intended grace period.

## Additional Notes

Validated with:

- `git diff --check`
- `pnpm exec vitest run src/ts/storage/remoteSaveCleanup.test.ts`
- `pnpm check`
