### PR TITLE
fix: avoid duplicate module creation

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -959,6 +959,7 @@ export const languageEnglish = {
     account: "Account",
     remove: "Remove",
     able: "Able",
+    close: "Close",
     assetWidth: "Asset Images Max Width",
     animationSpeed: "Animation Speed",
     screenshot: "Screenshot",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -944,6 +944,7 @@ export const languageEnglish = {
     account: "Account",
     remove: "Remove",
     able: "Able",
+    close: "Close",
     assetWidth: "Asset Images Max Width",
     animationSpeed: "Animation Speed",
     screenshot: "Screenshot",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -821,6 +821,7 @@ export const languageKorean = {
     "account": "계정",
     "remove": "삭제",
     "able": "활성화됨",
+    "close": "닫기",
     "assetWidth": "에셋 넓이",
     "animationSpeed": "에니메이션 속도",
     "screenshot": "스크린샷",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -811,6 +811,7 @@ export const languageKorean = {
     "account": "계정",
     "remove": "삭제",
     "able": "활성화됨",
+    "close": "닫기",
     "assetWidth": "에셋 넓이",
     "animationSpeed": "에니메이션 속도",
     "screenshot": "스크린샷",

--- a/src/lib/Setting/Pages/Module/ModuleSettings.svelte
+++ b/src/lib/Setting/Pages/Module/ModuleSettings.svelte
@@ -179,9 +179,8 @@
     <h2 class="mb-2 text-2xl font-bold mt-2">{language.createModule}</h2>
     <ModuleMenu bind:currentModule={tempModule}/>
     <Button className="mt-6" onclick={() => {
-        DBState.db.modules.push(tempModule)
         mode = 0
-    }}>{language.createModule}</Button>
+    }}>{language.close}</Button>
 {:else if mode === 2}
     <h2 class="mb-2 text-2xl font-bold mt-2">{language.editModule}</h2>
     <ModuleMenu bind:currentModule={tempModule}/>


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes module creation adding the same new module twice.

The module settings page already adds a new module to `DBState.db.modules` when the plus button is clicked, so closing the settings page, switching tabs, or using hotkeys while editing still keeps the newly created module. The create-mode footer button also pushed the same `tempModule` again, which could leave two copies after pressing it.

This PR keeps the initial create behavior and changes the footer button into a close action instead of a second create action.

## Related Issues

None.

## Changes

**`src/lib/Setting/Pages/Module/ModuleSettings.svelte`**
- Removed the second `DBState.db.modules.push(tempModule)` from the create-mode footer button
- Changed the create-mode footer button label from `Create Module` to `Close`

**`src/lang/en.ts`**
- Added the English `close` label

**`src/lang/ko.ts`**
- Added the Korean `close` label

## Impact

- Creating a module no longer adds a duplicate when the footer button is pressed.
- The existing behavior where a new module is added immediately after pressing the plus button is preserved.
- Exiting module creation through settings close, hotkeys, or tab changes still keeps the newly created module.
- Other locales fall back to the English `Close` label through the existing language merge behavior.
- No model behavior, request handling, storage format, database schema, or platform-specific logic is changed.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`
