### PR TITLE
feat: add role selection for prompt blocks

### DIFF
--- a/src/lib/SideBars/LoreBook/LoreBookData.svelte
+++ b/src/lib/SideBars/LoreBook/LoreBookData.svelte
@@ -9,6 +9,8 @@
     import TextInput from "../../UI/GUI/TextInput.svelte";
     import NumberInput from "../../UI/GUI/NumberInput.svelte";
     import TextAreaInput from "../../UI/GUI/TextAreaInput.svelte";
+    import SelectInput from "../../UI/GUI/SelectInput.svelte";
+    import OptionInput from "../../UI/GUI/OptionInput.svelte";
     import { tokenizeAccurate } from "src/ts/tokenizer";
     import { DBState } from "src/ts/stores.svelte";
     import LoreBookList from "./LoreBookList.svelte";
@@ -281,6 +283,14 @@
                     <Help key="useRegexLorebook" name={language.useRegexLorebook}/>
                 </div>
             {/if}
+            <span class="text-textcolor mt-4">{language.role}</span>
+            <SelectInput size="sm" value={value.role ?? 'system'} onchange={(e) => {
+                value.role = e.currentTarget.value as 'system'|'user'|'assistant'
+            }}>
+                <OptionInput value="system">{language.systemPrompt}</OptionInput>
+                <OptionInput value="user">{language.user}</OptionInput>
+                <OptionInput value="assistant">{language.character}</OptionInput>
+            </SelectInput>
         </div>
         {/if}
     {/if}

--- a/src/lib/UI/PromptDataItem.svelte
+++ b/src/lib/UI/PromptDataItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { PromptItem, PromptItemChat } from "src/ts/process/prompt";
+    import type { PromptItem, PromptItemChat, PromptRole } from "src/ts/process/prompt";
     import OptionInput from "./GUI/OptionInput.svelte";
     import TextAreaInput from "./GUI/TextAreaInput.svelte";
     import SelectInput from "./GUI/SelectInput.svelte";
@@ -50,6 +50,10 @@
             currentprompt.rangeEnd = 'end'
         }
         promptItem = currentprompt
+    }
+
+    const hasPromptBlockRole = (promptItem: PromptItem): promptItem is PromptItem & { role?: PromptRole } => {
+        return promptItem.type === 'persona' || promptItem.type === 'authornote'
     }
 
     function getName(promptItem:PromptItem){
@@ -328,6 +332,18 @@
                     }
                 }} />
             {/if}
+        {/if}
+        {#if hasPromptBlockRole(promptItem)}
+            <span>{language.role}</span>
+            <SelectInput value={promptItem.role ?? 'system'} onchange={(event) => {
+                if(hasPromptBlockRole(promptItem)){
+                    promptItem.role = event.currentTarget.value as PromptRole
+                }
+            }}>
+                <OptionInput value="user">{language.user}</OptionInput>
+                <OptionInput value="bot">{language.character}</OptionInput>
+                <OptionInput value="system">{language.systemPrompt}</OptionInput>
+            </SelectInput>
         {/if}
     {/if}
 </div>

--- a/src/lib/UI/PromptDataItem.svelte
+++ b/src/lib/UI/PromptDataItem.svelte
@@ -56,6 +56,10 @@
         return promptItem.type === 'persona' || promptItem.type === 'description' || promptItem.type === 'authornote' || promptItem.type === 'memory'
     }
 
+    const isPromptRole = (role: unknown): role is PromptRole => {
+        return role === 'user' || role === 'bot' || role === 'system'
+    }
+
     function getName(promptItem:PromptItem){
 
         if(promptItem.name){
@@ -237,6 +241,9 @@
                 promptItem.rangeStart = -1000
                 promptItem.rangeEnd = 'end'
             }
+            if(hasPromptBlockRole(promptItem) && !isPromptRole(promptItem.role)){
+                promptItem.role = 'system'
+            }
         }} >
             <OptionInput value="plain">{language.formating.plain}</OptionInput>
             <OptionInput value="jailbreak">{language.formating.jailbreak}</OptionInput>
@@ -282,7 +289,7 @@
             <SelectInput bind:value={promptItem.role}>
                 <OptionInput value="all">{language.all}</OptionInput>
                 <OptionInput value="user">{language.user}</OptionInput>
-                <OptionInput value="bot">{language.character}</OptionInput>
+                <OptionInput value="assistant">{language.character}</OptionInput>
                 <OptionInput value="system">{language.systemPrompt}</OptionInput>
             </SelectInput>
         {/if}

--- a/src/lib/UI/PromptDataItem.svelte
+++ b/src/lib/UI/PromptDataItem.svelte
@@ -53,7 +53,7 @@
     }
 
     const hasPromptBlockRole = (promptItem: PromptItem): promptItem is PromptItem & { role?: PromptRole } => {
-        return promptItem.type === 'persona' || promptItem.type === 'description' || promptItem.type === 'authornote'
+        return promptItem.type === 'persona' || promptItem.type === 'description' || promptItem.type === 'authornote' || promptItem.type === 'memory'
     }
 
     function getName(promptItem:PromptItem){

--- a/src/lib/UI/PromptDataItem.svelte
+++ b/src/lib/UI/PromptDataItem.svelte
@@ -53,7 +53,7 @@
     }
 
     const hasPromptBlockRole = (promptItem: PromptItem): promptItem is PromptItem & { role?: PromptRole } => {
-        return promptItem.type === 'persona' || promptItem.type === 'authornote'
+        return promptItem.type === 'persona' || promptItem.type === 'description' || promptItem.type === 'authornote'
     }
 
     function getName(promptItem:PromptItem){

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -407,6 +407,10 @@ export async function sendChat(chatProcessIndex = -1,arg:{
         unformated.globalNote.push(...formatPrompt(risuChatParser(currentChar.replaceGlobalNote?.replaceAll('{{original}}', DBState.db.globalNote) || DBState.db.globalNote, {chara:currentChar})))
     }
 
+    let baseDescriptionPrompt:OpenAIChat|null = null
+    let beforeDescriptionPrompts:OpenAIChat[] = []
+    let afterDescriptionPrompts:OpenAIChat[] = []
+
     if(currentChat.note){
         unformated.authorNote.push({
             role: 'system',
@@ -444,10 +448,11 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             description += risuChatParser("\n\nCircumstances and context of the dialogue: " + currentChar.scenario, {chara: currentChar})
         }
 
-        unformated.description.push({
+        baseDescriptionPrompt = {
             role: 'system',
             content: description
-        })
+        }
+        unformated.description.push(baseDescriptionPrompt)
 
         if(nowChatroom.type === 'group'){
             const systemMsg = `[Write the next reply only as ${currentChar.name}]`
@@ -511,9 +516,11 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             content: risuChatParser(resolvePosition(lorebook.prompt), {chara: currentChar})
         }
         if(lorebook.pos === 'before_desc'){
+            beforeDescriptionPrompts.unshift(c)
             unformated.description.unshift(c)
         }
         else{
+            afterDescriptionPrompts.push(c)
             unformated.description.push(c)
         }
     }
@@ -621,6 +628,18 @@ export async function sendChat(chatProcessIndex = -1,arg:{
         }
     }
 
+    function getDescriptionPrompts(role?: 'user'|'bot'|'system'){
+        const pmt = [
+            ...safeStructuredClone(beforeDescriptionPrompts),
+            ...(baseDescriptionPrompt ? [safeStructuredClone(baseDescriptionPrompt)] : []),
+            ...safeStructuredClone(afterDescriptionPrompts)
+        ]
+        if(baseDescriptionPrompt){
+            applyPromptBlockRole([pmt[beforeDescriptionPrompts.length]], role)
+        }
+        return pmt
+    }
+
     if(promptTemplate){
         const template = promptTemplate
 
@@ -646,7 +665,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     break
                 }
                 case 'description':{
-                    let pmt = safeStructuredClone(unformated.description)
+                    let pmt = getDescriptionPrompts(card.role)
                     if(card.innerFormat && pmt.length > 0){
                         for(let i=0;i<pmt.length;i++){
                             pmt[i].content = risuChatParser(positionParser(card.innerFormat,card.type), {chara: currentChar}).replace('{{slot}}', pmt[i].content)
@@ -1238,7 +1257,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     break
                 }
                 case 'description':{
-                    let pmt = safeStructuredClone(unformated.description)
+                    let pmt = getDescriptionPrompts(card.role)
                     if(card.innerFormat && pmt.length > 0){
                         for(let i=0;i<pmt.length;i++){
                             pmt[i].content = risuChatParser(positionParser(card.innerFormat,card.type), {chara: currentChar}).replace('{{slot}}', pmt[i].content)

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -1395,6 +1395,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                 }
                 case 'memory':{
                     let pmt = safeStructuredClone(memories)
+                    applyPromptBlockRole(pmt, card.role)
                     if(card.innerFormat && pmt.length > 0){
                         for(let i=0;i<pmt.length;i++){
                             pmt[i].content = risuChatParser(card.innerFormat, {chara: currentChar}).replace('{{slot}}', pmt[i].content)

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -606,6 +606,21 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     }
 
     let hasCachePoint = false
+    const convertPromptRole = {
+        "system": "system",
+        "user": "user",
+        "bot": "assistant"
+    } as const
+
+    function applyPromptBlockRole(chats:OpenAIChat[], role?: 'user'|'bot'|'system'){
+        if(!role){
+            return
+        }
+        for(const chat of chats){
+            chat.role = convertPromptRole[role]
+        }
+    }
+
     if(promptTemplate){
         const template = promptTemplate
 
@@ -620,6 +635,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             switch(card.type){
                 case 'persona':{
                     let pmt = safeStructuredClone(unformated.personaPrompt)
+                    applyPromptBlockRole(pmt, card.role)
                     if(card.innerFormat && pmt.length > 0){
                         for(let i=0;i<pmt.length;i++){
                             pmt[i].content = risuChatParser(positionParser(card.innerFormat,card.type), {chara: currentChar}).replace('{{slot}}', pmt[i].content)
@@ -642,6 +658,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                 }
                 case 'authornote':{
                     let pmt = safeStructuredClone(unformated.authorNote)
+                    applyPromptBlockRole(pmt, card.role)
                     if(card.innerFormat && pmt.length > 0){
                         for(let i=0;i<pmt.length;i++){
                             pmt[i].content = risuChatParser(positionParser(card.innerFormat,card.type), {chara: currentChar}).replace('{{slot}}', pmt[i].content || card.defaultText || '')
@@ -675,12 +692,6 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                         continue
                     }
 
-                    const convertRole = {
-                        "system": "system",
-                        "user": "user",
-                        "bot": "assistant"
-                    } as const
-
                     const posType = card.type === 'plain' ? card.type2 : card.type
                     let content = positionParser(card.text, posType)
 
@@ -702,7 +713,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     }
 
                     const prompt:OpenAIChat ={
-                        role: convertRole[card.role],
+                        role: convertPromptRole[card.role],
                         content: content
                     }
 
@@ -1212,6 +1223,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             switch(card.type){
                 case 'persona':{
                     let pmt = safeStructuredClone(unformated.personaPrompt)
+                    applyPromptBlockRole(pmt, card.role)
                     if(card.innerFormat && pmt.length > 0){
                         for(let i=0;i<pmt.length;i++){
                             pmt[i].content = risuChatParser(positionParser(card.innerFormat,card.type), {chara: currentChar}).replace('{{slot}}', pmt[i].content)
@@ -1242,6 +1254,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                 }
                 case 'authornote':{
                     let pmt = safeStructuredClone(unformated.authorNote)
+                    applyPromptBlockRole(pmt, card.role)
                     if(card.innerFormat && pmt.length > 0){
                         for(let i=0;i<pmt.length;i++){
                             pmt[i].content = risuChatParser(positionParser(card.innerFormat,card.type), {chara: currentChar}).replace('{{slot}}', pmt[i].content || card.defaultText || '')
@@ -1279,12 +1292,6 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                         continue
                     }
 
-                    const convertRole = {
-                        "system": "system",
-                        "user": "user",
-                        "bot": "assistant"
-                    } as const
-
                     const posType = card.type === 'plain' ? card.type2 : card.type
                     let content = positionParser(card.text, posType)
 
@@ -1305,7 +1312,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     }
 
                     const prompt:OpenAIChat ={
-                        role: convertRole[card.role],
+                        role: convertPromptRole[card.role],
                         content: content
                     }
 

--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -272,7 +272,7 @@ export async function loadLoreBookV3Prompt(){
             let order = fullLore[i].insertorder
             let priority = fullLore[i].insertorder
             let forceState:string = 'none'
-            let role:'system'|'user'|'assistant' = 'system'
+            let role:'system'|'user'|'assistant' = fullLore[i].role ?? 'system'
             let searchQueries:{
                 keys:string[],
                 negative:boolean,
@@ -289,6 +289,8 @@ export async function loadLoreBookV3Prompt(){
                             fullLore[i].comment = fullLore[j].comment
                             fullLore[i].content = fullLore[j].content
                             fullLore[i].alwaysActive = true
+                            fullLore[i].role = fullLore[j].role
+                            role = fullLore[j].role ?? 'system'
                             activated = true
                         }
                         break

--- a/src/ts/process/prompt.ts
+++ b/src/ts/process/prompt.ts
@@ -90,6 +90,16 @@ export async function tokenizePreset(prompts:PromptItem[], consti:boolean = fals
     return total
 }
 
+function normalizeImportedPromptRole(role: unknown): PromptRole {
+    if(role === 'user' || role === 'bot' || role === 'system'){
+        return role
+    }
+    if(role === 'assistant' || role === 'char'){
+        return 'bot'
+    }
+    return 'system'
+}
+
 export function detectPromptJSONType(text:string){
 
     function notNull<T>(x:T|null):x is T{
@@ -163,7 +173,7 @@ export function stChatConvert(pre:any){
                         type: 'plain',
                         type2: 'main',
                         text: p.content ?? "",
-                        role: p.role ?? "system"
+                        role: normalizeImportedPromptRole(p.role)
                     })
                     break
                 }
@@ -173,7 +183,7 @@ export function stChatConvert(pre:any){
                         type: 'jailbreak',
                         type2: 'normal',
                         text: p.content ?? "",
-                        role: p.role ?? "system"
+                        role: normalizeImportedPromptRole(p.role)
                     })
                     break
                 }
@@ -217,7 +227,7 @@ export function stChatConvert(pre:any){
                         type: 'plain',
                         type2: 'normal',
                         text: p.content ?? "",
-                        role: p.role ?? "system"
+                        role: normalizeImportedPromptRole(p.role)
                     })
                 }
             }

--- a/src/ts/process/prompt.ts
+++ b/src/ts/process/prompt.ts
@@ -17,11 +17,13 @@ export type PromptSettings = {
     trimStartNewChat?: boolean
 }
 
+export type PromptRole = 'user'|'bot'|'system'
+
 export interface PromptItemPlain {
     type: 'plain'|'jailbreak'|'cot';
     type2: 'normal'|'globalNote'|'main'
     text: string;
-    role: 'user'|'bot'|'system';
+    role: PromptRole;
     name?: string
 }
 
@@ -34,6 +36,7 @@ export interface PromptItemChatML {
 export interface PromptItemTyped {
     type: 'persona'|'description'|'lorebook'|'postEverything'|'memory'
     innerFormat?: string,
+    role?: PromptRole
     name?: string
 }
 
@@ -41,6 +44,7 @@ export interface PromptItemAuthorNote {
     type : 'authornote'
     innerFormat?: string
     defaultText?: string
+    role?: PromptRole
     name?: string
 }
 

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -25,6 +25,60 @@ import {
 export let appVer = "2026.6.210" //<APP_VERSION_POINT>
 export let webAppSubVer = ''
 
+function normalizePromptRole(role: unknown): 'user'|'bot'|'system'|null {
+    if(role === 'user' || role === 'bot' || role === 'system'){
+        return role
+    }
+    if(role === 'assistant' || role === 'char'){
+        return 'bot'
+    }
+    return null
+}
+
+function normalizeCacheRole(role: unknown): 'user'|'assistant'|'system'|'all' {
+    if(role === 'user' || role === 'assistant' || role === 'system' || role === 'all'){
+        return role
+    }
+    if(role === 'bot' || role === 'char'){
+        return 'assistant'
+    }
+    return 'all'
+}
+
+function normalizePromptTemplate(template: PromptItem[]|null|undefined): PromptItem[]|null {
+    if(!Array.isArray(template)){
+        return null
+    }
+    const normalized = safeStructuredClone(template) as any[]
+    for(const item of normalized){
+        if(!item || typeof item !== 'object'){
+            continue
+        }
+        switch(item.type){
+            case 'plain':
+            case 'jailbreak':
+            case 'cot':{
+                item.role = normalizePromptRole(item.role) ?? 'system'
+                break
+            }
+            case 'persona':
+            case 'description':
+            case 'authornote':
+            case 'memory':{
+                if(item.role !== undefined && item.role !== null){
+                    item.role = normalizePromptRole(item.role) ?? 'system'
+                }
+                break
+            }
+            case 'cache':{
+                item.role = normalizeCacheRole(item.role)
+                break
+            }
+        }
+    }
+    return normalized as PromptItem[]
+}
+
 
 export function setDatabase(data:Database){
     if(checkNullish(data.characters)){
@@ -160,6 +214,9 @@ export function setDatabase(data:Database){
     }
     if(checkNullish(data.botPresetsId)){
         data.botPresetsId = 0
+    }
+    if(Array.isArray(data.promptTemplate)){
+        data.promptTemplate = normalizePromptTemplate(data.promptTemplate)
     }
     if(checkNullish(data.sdProvider)){
         data.sdProvider = ''
@@ -484,6 +541,9 @@ export function setDatabase(data:Database){
     }
     if (data.botPresets) {
         for (const preset of data.botPresets) {
+            if(Array.isArray(preset.promptTemplate)){
+                preset.promptTemplate = normalizePromptTemplate(preset.promptTemplate)
+            }
             preset.localNetworkMode ??= false
             preset.localNetworkTimeoutSec ??= 600
             if (typeof preset.localNetworkMode !== 'boolean') {
@@ -2051,7 +2111,7 @@ export function saveCurrentPreset(){
         proxyRequestModel: db.proxyRequestModel,
         openrouterRequestModel: db.openrouterRequestModel,
         NAISettings: safeStructuredClone(db.NAIsettings),
-        promptTemplate: db.promptTemplate ?? null,
+        promptTemplate: normalizePromptTemplate(db.promptTemplate) ?? null,
         NAIadventure: db.NAIadventure ?? false,
         NAIappendName: db.NAIappendName ?? false,
         localStopStrings: db.localStopStrings,
@@ -2166,7 +2226,7 @@ export function setPreset(db:Database, newPres: botPreset){
     db.autoSuggestPrompt = newPres.autoSuggestPrompt ?? db.autoSuggestPrompt
     db.autoSuggestPrefix = newPres.autoSuggestPrefix ?? db.autoSuggestPrefix
     db.autoSuggestClean = newPres.autoSuggestClean ?? db.autoSuggestClean
-    db.promptTemplate = newPres.promptTemplate
+    db.promptTemplate = normalizePromptTemplate(newPres.promptTemplate)
     db.NAIadventure = newPres.NAIadventure
     db.NAIappendName = newPres.NAIappendName
     db.NAIsettings.cfg_scale ??= 1
@@ -2344,6 +2404,9 @@ export async function importPreset(f:{
         pre = {...presetTemplate,...(JSON.parse(Buffer.from(f.data).toString('utf-8')))}
         console.log(pre)
     }
+    if(pre?.promptTemplate !== undefined){
+        pre.promptTemplate = normalizePromptTemplate(pre.promptTemplate)
+    }
     let db = DBState.db
     if(pre.presetVersion && pre.presetVersion >= 3){
         //NAI preset
@@ -2469,6 +2532,7 @@ export async function importPreset(f:{
                 role: 'bot'
             })
         }
+        pr.promptTemplate = normalizePromptTemplate(pr.promptTemplate)
         pr.name = "Imported ST Preset"
         db.botPresets.push(pr)
         return

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1308,6 +1308,7 @@ export interface loreBook{
     mode: 'multiple'|'constant'|'normal'|'child'|'folder',
     alwaysActive: boolean
     selective:boolean
+    role?: 'system'|'user'|'assistant'
     extentions?:{
         risu_case_sensitive:boolean
     }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds role selection for prompt template blocks that previously always emitted system-role prompts.

This covers persona, character description, author note, memory, and lorebook default roles. Existing prompts keep the previous system-role behavior when no role is set.

## Related Issues

None.

## Changes

**`src/lib/UI/PromptDataItem.svelte`**
- Added role selection for persona, description, author note, and memory prompt blocks
- Normalized invalid role values when changing prompt block types
- Fixed cache role selection to use the actual `assistant` role value for character messages

**`src/ts/process/index.svelte.ts`**
- Applies selected prompt block roles during both token calculation and final prompt assembly
- Applies description role only to the base character description block
- Preserves role handling for description-position lorebook entries
- Applies memory prompt block role to generated memory chunks

**`src/lib/SideBars/LoreBook/LoreBookData.svelte`**
- Added a default role selector to lorebook entries

**`src/ts/process/lorebook.svelte.ts`**
- Uses the lorebook entry role as the default role for activated entries
- Keeps `@@role` as the per-entry override
- Preserves parent lorebook role when locally activated child lore entries are used

**`src/ts/process/prompt.ts`**
- Normalized imported ST prompt roles when converting prompt presets

**`src/ts/storage/database.svelte.ts`**
- Added the optional lorebook entry role type
- Normalized prompt template role data when loading databases, importing presets, applying presets, and saving presets

## Impact

- Existing prompt templates without role settings keep the previous system-role behavior.
- Existing lorebooks without a role keep the previous system-role behavior.
- `@@role` inside lorebook content still overrides the entry default role.
- Imported or backed-up prompt templates with older or external role values are normalized instead of producing invalid runtime roles.
- Prompt block roles still pass through the existing model formatter path, so system prompt replacement, alternate-role merging, and provider-specific role mapping continue to work as before.
- No backup format, database schema migration, request provider implementation, or platform-specific storage path is changed.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

`pnpm build` passes with existing CSS `::highlight`, browser-externalized module, plugin timing, and chunk-size warnings.
