### PR TITLE
fix: preserve reasoning effort options with Responses API

### DIFF
--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -190,6 +190,7 @@ describe('OpenAI Responses API helpers', () => {
         mocks.db.nanogptProvider = ''
         mocks.db.nanogptRequestModel = 'nanogpt-model'
         mocks.db.nanogptUseSubscriptionEndpoint = false
+        mocks.db.reasoningEffort = 2
         mocks.db.simplifiedToolUse = false
         mocks.db.autofillRequestUrl = false
     })
@@ -245,6 +246,45 @@ describe('OpenAI Responses API helpers', () => {
         const body = await __testResponsesAPI.buildResponsesBody(baseArg())
 
         expect(body.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+    })
+
+    it('maps Responses reasoning effort none when the model supports it', async () => {
+        mocks.db.reasoningEffort = -1
+
+        const body = await __testResponsesAPI.buildResponsesBody(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                parameters: ['reasoning_effort', 'reasoning_effort_none'],
+            },
+        }))
+
+        expect(body.reasoning).toEqual({ effort: 'none', summary: 'auto' })
+    })
+
+    it('maps Responses reasoning low to medium for min-medium models', async () => {
+        mocks.db.reasoningEffort = 0
+
+        const body = await __testResponsesAPI.buildResponsesBody(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                parameters: ['reasoning_effort', 'reasoning_effort_min_medium'],
+            },
+        }))
+
+        expect(body.reasoning).toEqual({ effort: 'medium', summary: 'auto' })
+    })
+
+    it('maps Responses reasoning effort xhigh when the model supports it', async () => {
+        mocks.db.reasoningEffort = 3
+
+        const body = await __testResponsesAPI.buildResponsesBody(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                parameters: ['reasoning_effort', 'reasoning_effort_xhigh'],
+            },
+        }))
+
+        expect(body.reasoning).toEqual({ effort: 'xhigh', summary: 'auto' })
     })
 
     it('does not request reasoning summaries for Responses non-reasoning models', async () => {

--- a/src/ts/process/request/openAI/responses.ts
+++ b/src/ts/process/request/openAI/responses.ts
@@ -333,13 +333,23 @@ async function buildResponsesBody(arg:RequestDataArgumentExtended):Promise<Recor
         tools.push({ type: 'web_search_preview' })
     }
 
+    const responseParameters = arg.modelInfo.parameters.filter((p) => [
+        'temperature',
+        'top_p',
+        'reasoning_effort',
+        'reasoning_effort_none',
+        'reasoning_effort_min_medium',
+        'reasoning_effort_xhigh',
+        'verbosity'
+    ].includes(p))
+
     let body = applyParameters({
         model: getResponsesRequestModel(arg),
         input: await buildResponseInputItems(arg),
         max_output_tokens: arg.maxTokens,
         tools: tools,
         store: false
-    }, ['temperature', 'top_p', 'reasoning_effort', 'verbosity'].filter((p) => arg.modelInfo.parameters.includes(p as any)) as any, {
+    }, responseParameters, {
         reasoning_effort: 'reasoning.effort',
         verbosity: 'text.verbosity'
     }, arg.mode, {

--- a/src/ts/process/request/openAI/responses.ts
+++ b/src/ts/process/request/openAI/responses.ts
@@ -9,7 +9,7 @@ import { NANOGPT_RESPONSES_ENDPOINT, NANOGPT_SUBSCRIPTION_RESPONSES_ENDPOINT } f
 import { extractJSON, getOpenAIJSONSchema } from "../../templates/jsonSchema"
 import { callTool, decodeToolCall, encodeToolCall } from "../../mcp/mcp"
 import type { RequestDataArgumentExtended, requestDataResponse, StreamResponseChunk } from '../request'
-import { applyAdditionalParameters, applyParameters, getAdditionalParameters } from '../shared'
+import { applyAdditionalParameters, applyParameters, getAdditionalParameters, isReasoningCapabilityParameter } from '../shared'
 
 import type { OpenAIChatExtra, ResponseFunctionCallItem, ResponseInputItem, ResponseItem, ResponseOutputItem } from './types'
 import { getLocalNetworkRequestOptions, type LocalNetworkRequestOptions } from './shared'
@@ -333,15 +333,9 @@ async function buildResponsesBody(arg:RequestDataArgumentExtended):Promise<Recor
         tools.push({ type: 'web_search_preview' })
     }
 
-    const responseParameters = arg.modelInfo.parameters.filter((p) => [
-        'temperature',
-        'top_p',
-        'reasoning_effort',
-        'reasoning_effort_none',
-        'reasoning_effort_min_medium',
-        'reasoning_effort_xhigh',
-        'verbosity'
-    ].includes(p))
+    const responseParameters = arg.modelInfo.parameters.filter((p) =>
+        ['temperature', 'top_p', 'reasoning_effort', 'verbosity'].includes(p) || isReasoningCapabilityParameter(p)
+    )
 
     let body = applyParameters({
         model: getResponsesRequestModel(arg),

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -25,7 +25,7 @@ const reasoningCapabilityParameters: LLMParameter[] = [
     'reasoning_effort_xhigh',
 ]
 
-function isReasoningCapabilityParameter(parameter: LLMParameter): boolean {
+export function isReasoningCapabilityParameter(parameter: LLMParameter): boolean {
     return reasoningCapabilityParameters.includes(parameter)
 }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Type definitions were not needed
    - [x] Have you tested your changes?
    - [x] Have you checked that it will not break any existing features?
- [x] If your PR uses models, check the following:
    - [x] Request body generation is covered for supported Responses reasoning markers
    - [x] This only changes OpenAI Responses API request construction and is platform-independent
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Preserve OpenAI Responses API reasoning capability markers when building request parameters.

## Related Issues

https://arca.live/b/characterai/175449760

<img width="755" height="181" alt="image" src="https://github.com/user-attachments/assets/974c1d3d-a55b-4b57-9125-949410896be7" />

For some models that supports `none` reasoning effort, mapping is not getting applied correctly in response API.
It resulted in the error above.

Similar bug happened for `xhigh` reasoning effort, result in downgrade to `high` effort.

## Changes

- Keep `reasoning_effort_none`, `reasoning_effort_min_medium`, and `reasoning_effort_xhigh` markers when mapping Responses API parameters.
- Add regression tests for `none`, min-medium, and `xhigh` reasoning effort mapping.

## Impact

Responses API requests now send the selected supported reasoning effort instead of falling back to default mappings such as `minimal` or `high`.