### PR TITLE
feat: add cbs parser API for Plugin V3

### DIFF
--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -1299,6 +1299,45 @@ interface RisuaiPluginAPI {
      * @returns Chat object or null if not found
      */
     getChatFromIndex(characterIndex: number, chatIndex: number): Promise<any|null>;
+
+    /**
+     * Parses Risu CBS macros in text with the selected/current character context.
+     * Set processRegex to also apply editprocess regex scripts after CBS parsing.
+     * @param text - Text containing CBS macros
+     * @param options - Parser context options
+     * @returns Parsed text
+     *
+     * @example
+     * ```typescript
+     * const text = await risuai.parseRisuChat('Hello, {{user}}', {
+     *   role: 'user',
+     *   processRegex: true,
+     * });
+     * ```
+     */
+    parseRisuChat(text: string, options?: {
+        /** Character index to use. Defaults to the selected character. */
+        characterIndex?: number;
+        /** Chat index to use as the current chat context. Defaults to the character's current chat. */
+        chatIndex?: number;
+        /** Message index used by chat-aware CBS macros. Defaults to -1. */
+        messageIndex?: number;
+        /** Message role used by role-aware CBS macros. */
+        role?: string;
+        /** Apply editprocess regex scripts after CBS parsing. */
+        processRegex?: boolean;
+        /** Enable chat variable writes from CBS macros. */
+        runVar?: boolean;
+        /** Remove unresolved variable macros. */
+        rmVar?: boolean;
+        /** Use tokenizer-accurate parsing behavior where supported. */
+        tokenizeAccurate?: boolean;
+        /** Additional CBS condition flags. */
+        cbsConditions?: {
+            firstmsg?: boolean;
+            chatRole?: string;
+        };
+    }): Promise<string>;
     
 
     /**

--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -1301,8 +1301,10 @@ interface RisuaiPluginAPI {
     getChatFromIndex(characterIndex: number, chatIndex: number): Promise<any|null>;
 
     /**
-     * Parses Risu CBS macros in text with the selected/current character context.
-     * Set processRegex to also apply editprocess regex scripts after CBS parsing.
+     * Parses Risu CBS macros using the currently selected character and active chat.
+     * Set processRegex to also run the editprocess script pipeline after CBS parsing.
+     * The editprocess pipeline can invoke plugin script handlers and action scripts,
+     * which may modify the active chat.
      * @param text - Text containing CBS macros
      * @param options - Parser context options
      * @returns Parsed text
@@ -1316,15 +1318,14 @@ interface RisuaiPluginAPI {
      * ```
      */
     parseRisuChat(text: string, options?: {
-        /** Character index to use. Defaults to the selected character. */
-        characterIndex?: number;
-        /** Chat index to use as the current chat context. Defaults to the character's current chat. */
-        chatIndex?: number;
-        /** Message index used by chat-aware CBS macros. Defaults to -1. */
+        /** Existing message index used by chat-aware CBS macros. Defaults to -1. */
         messageIndex?: number;
         /** Message role used by role-aware CBS macros. */
         role?: string;
-        /** Apply editprocess regex scripts after CBS parsing. */
+        /**
+         * Run the editprocess script pipeline after CBS parsing.
+         * This can invoke plugin handlers and action scripts that modify the active chat.
+         */
         processRegex?: boolean;
         /** Enable chat variable writes from CBS macros. */
         runVar?: boolean;

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -14,10 +14,11 @@ import { isNodeServer, isTauri } from "src/ts/platform";
 import { get } from "svelte/store";
 import { registerMCPModule, unregisterMCPModule } from "src/ts/process/mcp/pluginmcp";
 import { getLLMCache, searchLLMCache } from "src/ts/translator/translator";
-import { hasher } from "src/ts/parser/parser.svelte";
+import { hasher, risuChatParser, type CbsConditions } from "src/ts/parser/parser.svelte";
 import localforage from "localforage";
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, type LLMModel } from "src/ts/model/types";
 import { sendChat as processSendChat, doingChat } from "src/ts/process/index.svelte";
+import { processScriptFull } from "src/ts/process/scripts";
 import { getModelInfo } from "src/ts/model/modellist";
 import type { ModelModeExtended } from "src/ts/process/request/shared";
 import { requestChatDataMain } from "src/ts/process/request/request";
@@ -854,6 +855,51 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                 }
             }
             return null;
+        },
+        parseRisuChat: async (text:string, options?:{
+            characterIndex?: number
+            chatIndex?: number
+            messageIndex?: number
+            role?: string
+            processRegex?: boolean
+            runVar?: boolean
+            rmVar?: boolean
+            tokenizeAccurate?: boolean
+            cbsConditions?: CbsConditions
+        }) => {
+            const db = DBState.db
+            const charIds = Object.keys(db.characters);
+            const selectedChar = get(selectedCharID) as string | number;
+            const charId = typeof options?.characterIndex === 'number'
+                ? charIds[options.characterIndex]
+                : db.characters[selectedChar as string]
+                    ? selectedChar as string
+                    : charIds[Number(selectedChar)];
+            const char = charId ? db.characters[charId] : null;
+            const parserChar = char && typeof options?.chatIndex === 'number' && char.chats?.[options.chatIndex]
+                ? { ...char, chatPage: options.chatIndex }
+                : char;
+            const chatID = options?.messageIndex ?? -1;
+            const role = options?.role;
+            const cbsConditions:CbsConditions = {
+                ...(role ? { chatRole: role } : {}),
+                ...(options?.cbsConditions ?? {}),
+            };
+            const parsed = risuChatParser(text ?? '', {
+                chara: parserChar ?? undefined,
+                chatID,
+                role,
+                runVar: options?.runVar,
+                rmVar: options?.rmVar,
+                tokenizeAccurate: options?.tokenizeAccurate,
+                cbsConditions,
+            });
+
+            if(!options?.processRegex || !char){
+                return parsed;
+            }
+
+            return (await processScriptFull(parserChar, parsed, 'editprocess', chatID, cbsConditions)).data;
         },
         setChatToIndex: (characterIndex:number, chatIndex:number, chat:any) => {
             const db = DBState.db

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -857,8 +857,6 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             return null;
         },
         parseRisuChat: async (text:string, options?:{
-            characterIndex?: number
-            chatIndex?: number
             messageIndex?: number
             role?: string
             processRegex?: boolean
@@ -868,25 +866,25 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             cbsConditions?: CbsConditions
         }) => {
             const db = DBState.db
-            const charIds = Object.keys(db.characters);
-            const selectedChar = get(selectedCharID) as string | number;
-            const charId = typeof options?.characterIndex === 'number'
-                ? charIds[options.characterIndex]
-                : db.characters[selectedChar as string]
-                    ? selectedChar as string
-                    : charIds[Number(selectedChar)];
-            const char = charId ? db.characters[charId] : null;
-            const parserChar = char && typeof options?.chatIndex === 'number' && char.chats?.[options.chatIndex]
-                ? { ...char, chatPage: options.chatIndex }
-                : char;
+            const char = db.characters[get(selectedCharID)];
+            if(!char){
+                throw new Error('No character selected');
+            }
+            const chat = char.chats?.[char.chatPage];
+            if(!chat){
+                throw new Error('No active chat found');
+            }
             const chatID = options?.messageIndex ?? -1;
+            if(!Number.isInteger(chatID) || chatID < -1 || chatID >= chat.message.length){
+                throw new Error(`Invalid messageIndex: ${chatID}`);
+            }
             const role = options?.role;
             const cbsConditions:CbsConditions = {
                 ...(role ? { chatRole: role } : {}),
                 ...(options?.cbsConditions ?? {}),
             };
             const parsed = risuChatParser(text ?? '', {
-                chara: parserChar ?? undefined,
+                chara: char,
                 chatID,
                 role,
                 runVar: options?.runVar,
@@ -895,11 +893,11 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                 cbsConditions,
             });
 
-            if(!options?.processRegex || !char){
+            if(!options?.processRegex){
                 return parsed;
             }
 
-            return (await processScriptFull(parserChar, parsed, 'editprocess', chatID, cbsConditions)).data;
+            return (await processScriptFull(char, parsed, 'editprocess', chatID, cbsConditions)).data;
         },
         setChatToIndex: (characterIndex:number, chatIndex:number, chat:any) => {
             const db = DBState.db


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add parseRisuChat API for parsing CBS text to Plugin V3 API

## Related Issues

None

## Changes

Receives text containing {{cbs}} from within the plugin, and returns the text with {{cbs}} parsing completed.  
It can be called in the form of risuai.parseRisuChat(text, options), and by passing characterIndex, chatIndex, messageIndex, etc., it minimizes errors during parsing.

By using the processRegex option, you can also apply new regex scripts (Request Modification).

## Impact

No modifications to existing APIs, no model calls, only returning CBS-parsed text.

## Additional Notes

None
