### PR TITLE
fix: optimize stream parser buffering

### DIFF
--- a/src/ts/process/request/google.test.ts
+++ b/src/ts/process/request/google.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { __testGoogleRequestsAPI } from './google'
+
+const mocks = vi.hoisted(() => ({
+    db: {},
+    fetchNative: vi.fn(),
+    saveInlayedSignature: vi.fn(),
+    setInlayAsset: vi.fn(),
+    writeInlayImage: vi.fn(),
+    v4: vi.fn(),
+}))
+
+vi.mock('src/ts/globalApi.svelte', () => ({
+    addFetchLog: vi.fn(),
+    fetchNative: mocks.fetchNative,
+    textifyReadableStream: vi.fn(),
+}))
+
+vi.mock('src/ts/model/modellist', () => ({
+    LLMFlags: {
+        hasAudioInput: 2,
+        hasImageInput: 1,
+        hasVideoInput: 3,
+    },
+    LLMFormat: {
+        GoogleCloud: 5,
+        VertexAIGemini: 6,
+    },
+}))
+
+vi.mock('src/ts/storage/database.svelte', () => ({
+    getDatabase: () => mocks.db,
+    setDatabase: vi.fn(),
+}))
+
+vi.mock('src/ts/util', () => ({
+    base64url: (data: string) => data,
+    simplifySchema: (schema: unknown) => schema,
+}))
+
+vi.mock('../files/inlays', () => ({
+    saveInlayedSignature: mocks.saveInlayedSignature,
+    setInlayAsset: mocks.setInlayAsset,
+    writeInlayImage: mocks.writeInlayImage,
+}))
+
+vi.mock('../templates/jsonSchema', () => ({
+    extractJSON: (data: string) => data,
+    getGeneralJSONSchema: () => ({}),
+}))
+
+vi.mock('../mcp/mcp', () => ({
+    callTool: vi.fn(),
+    decodeToolCall: vi.fn(),
+    encodeToolCall: vi.fn(),
+}))
+
+vi.mock('src/ts/alert', () => ({
+    alertError: vi.fn(),
+}))
+
+vi.mock('src/ts/stores.svelte', () => ({
+    bodyIntercepterStore: [],
+}))
+
+vi.mock('uuid', () => ({
+    v4: mocks.v4,
+}))
+
+const modelInfo = {
+    format: 5,
+    id: 'gemini-test',
+    internalID: 'gemini-test',
+} as any
+
+async function collectStream(stream: ReadableStream<Record<string, string>>) {
+    const reader = stream.getReader()
+    const chunks: Record<string, string>[] = []
+    while(true){
+        const { done, value } = await reader.read()
+        if(done){
+            return chunks
+        }
+        chunks.push(value)
+    }
+}
+
+describe('Google/Gemini stream parser', () => {
+    beforeEach(() => {
+        mocks.fetchNative.mockReset()
+        mocks.saveInlayedSignature.mockReset()
+        mocks.setInlayAsset.mockReset()
+        mocks.writeInlayImage.mockReset()
+        mocks.v4.mockReset()
+    })
+
+    it('keeps only partial line text buffered and parses each completed SSE line once', async () => {
+        const stream = __testGoogleRequestsAPI.getTranStream({
+            modelInfo,
+            saveSignature: false,
+        })
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+        const parseSpy = vi.spyOn(JSON, 'parse')
+
+        try{
+            await writer.write(encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n\n'))
+            await writer.write(encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"lo"}]}}]}\n\n'))
+            await writer.write(encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"!"}]}}]}\n\n'))
+            await writer.write(encoder.encode('data: [DONE]\n\n'))
+            await writer.close()
+
+            const chunks = await chunksPromise
+            expect(chunks.at(-1)?.['0']).toBe('Hello!')
+            expect(parseSpy).toHaveBeenCalledTimes(3)
+        }
+        finally{
+            parseSpy.mockRestore()
+        }
+    })
+
+    it('preserves split UTF-8 text across chunk boundaries', async () => {
+        const stream = __testGoogleRequestsAPI.getTranStream({
+            modelInfo,
+            saveSignature: false,
+        })
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+        const bytes = encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"Hi 😀"}]}}]}\n\n')
+        const emojiStart = bytes.findIndex((byte, index) => byte === 0xf0 && bytes[index + 1] === 0x9f)
+
+        await writer.write(bytes.slice(0, emojiStart + 2))
+        await writer.write(bytes.slice(emojiStart + 2))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)?.['0']).toBe('Hi 😀')
+    })
+
+    it('parses split lines and runs signature side effects only once per new event', async () => {
+        mocks.v4.mockReturnValueOnce('sig-text-id').mockReturnValueOnce('sig-fn-id')
+
+        const stream = __testGoogleRequestsAPI.getTranStream({
+            modelInfo,
+            saveSignature: true,
+        })
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+        const signedCallEvent = 'data: {"candidates":[{"content":{"parts":[{"text":"Thinking","thought":true,"thoughtSignature":"sig-text"},{"functionCall":{"name":"lookup","args":{"q":"x"}},"thoughtSignature":"sig-fn"}]}}]}\n\n'
+
+        await writer.write(encoder.encode(signedCallEvent.slice(0, 72)))
+        await writer.write(encoder.encode(signedCallEvent.slice(72)))
+        await writer.write(encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"Answer"}]}}],"usageMetadata":{"totalTokenCount":9},"modelStatus":{"status":"ok"}}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        const lastChunk = chunks.at(-1) ?? {}
+
+        expect(lastChunk['0']).toBe('{{inlayeddata::sig-text-id}}{{inlayeddata::sig-fn-id}}Answer')
+        expect(lastChunk['__thoughts']).toBe('Thinking')
+        expect(lastChunk['__last_thought']).toBe('')
+        expect(lastChunk['__sign_text']).toBe('sig-text')
+        expect(lastChunk['__sign_function']).toBe('sig-fn')
+        expect(lastChunk['__tool_calls']).toBe(JSON.stringify([
+            {
+                name: 'lookup',
+                args: {
+                    q: 'x',
+                },
+            },
+        ]))
+        expect(lastChunk['__usageMetadata']).toBe(JSON.stringify({ totalTokenCount: 9 }))
+        expect(lastChunk['__modelStatus']).toBe(JSON.stringify({ status: 'ok' }))
+        expect(mocks.saveInlayedSignature).toHaveBeenCalledTimes(2)
+    })
+})

--- a/src/ts/process/request/google.test.ts
+++ b/src/ts/process/request/google.test.ts
@@ -95,7 +95,7 @@ describe('Google/Gemini stream parser', () => {
         mocks.v4.mockReset()
     })
 
-    it('keeps only partial line text buffered and parses each completed SSE line once', async () => {
+    it('keeps only unfinished event text buffered and parses each completed SSE event once', async () => {
         const stream = __testGoogleRequestsAPI.getTranStream({
             modelInfo,
             saveSignature: false,
@@ -138,6 +138,22 @@ describe('Google/Gemini stream parser', () => {
 
         const chunks = await chunksPromise
         expect(chunks.at(-1)?.['0']).toBe('Hi 😀')
+    })
+
+    it('joins multiple data lines in one SSE event', async () => {
+        const stream = __testGoogleRequestsAPI.getTranStream({
+            modelInfo,
+            saveSignature: false,
+        })
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"candidates":\ndata: [{"content":{"parts":[{"text":"Hi"}]}}]}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)?.['0']).toBe('Hi')
     })
 
     it('parses split lines and runs signature side effects only once per new event', async () => {

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -991,91 +991,145 @@ function getTranStream(args:{
     modelInfo:LLMModel,
     saveSignature:boolean
 }):TransformStream<Uint8Array, StreamResponseChunk> {
-    let buffer = '';
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let streamDone = false
+    const readed = initStreamState()
+    const toolCallsData: GeminiFunctionCall[] = []
     const { modelInfo, saveSignature } = args
-    return new TransformStream<Uint8Array, StreamResponseChunk>({
-        transform(chunk, control) {
-            buffer += new TextDecoder().decode(chunk);
-            const lines = buffer.split('\n');
 
-            let readed = initStreamState();
+    const buildReadableState = () => {
+        return {
+            ...readed,
+            "__tool_calls": JSON.stringify(toolCallsData)
+        }
+    }
 
-            try {
-                for (const line of lines) {
-                    if (line.startsWith('data: ')) {
-                        const dataStr = line.slice(6).trim();
-                        if (dataStr === '[DONE]') return;
-                    
-                        const jsonData = JSON.parse(dataStr);
-                        
-                        if (jsonData.candidates?.[0]?.content?.parts) {
-                            const parts = jsonData.candidates[0].content.parts;
-                            for (const part of parts) {
-                                if (part.text) {
-                                    readed["__thoughts"] += readed["__last_thought"];
-                                    readed["__last_thought"] = "";
-                                    if (part.thought){
-                                        readed["__last_thought"] = part.text;
-                                    }
-                                    else {
-                                        readed["0"] += part.text;
-                                    }
-                                    if (part.thoughtSignature) {
-                                        readed["__sign_text"] = part.thoughtSignature;
-                                        if(saveSignature){
-                                            //Its a promise, but we don't need to await it here
-                                            const sigId = v4()
-                                            saveInlayedSignature(sigId, {
-                                                source: modelInfo.internalID || modelInfo.id,
-                                                sourceFormat: modelInfo.format,
-                                                signatures: [{
-                                                    type: 'text',
-                                                    content: part.text,
-                                                }]
-                                            })
-                                            readed["0"] += `{{inlayeddata::${sigId}}}`;
-                                        }
-                                    }
-                                }
-                                if (part.functionCall) {
-                                    const toolCallsData = JSON.parse(readed["__tool_calls"]);
-                                    toolCallsData.push(part.functionCall);
-                                    readed["__tool_calls"] = JSON.stringify(toolCallsData);
-                                    if(part.thoughtSignature){
-                                        readed["__sign_function"] = part.thoughtSignature;
-                                        const sigId = v4()
+    const emit = (control:TransformStreamDefaultController<StreamResponseChunk>) => {
+        control.enqueue(buildReadableState())
+    }
 
-                                        if(saveSignature){
-                                            //Its a promise, but we don't need to await it here
-                                            saveInlayedSignature(sigId, {
-                                                source: modelInfo.internalID || modelInfo.id,
-                                                sourceFormat: modelInfo.format,
-                                                signatures: [{
-                                                    type: 'function',
-                                                    content: `${part.functionCall.name}(${JSON.stringify(part.functionCall.args)})`,
-                                                }]
-                                            })
-                                            readed["0"] += `{{inlayeddata::${sigId}}}`;
-                                        }
-                                    }
-                                }
+    const applyStreamData = (dataStr:string) => {
+        if(dataStr.trim() === '[DONE]'){
+            streamDone = true
+            return true
+        }
+
+        try {
+            const jsonData = JSON.parse(dataStr);
+
+            if (jsonData.candidates?.[0]?.content?.parts) {
+                const parts = jsonData.candidates[0].content.parts;
+                for (const part of parts) {
+                    if (part.text) {
+                        readed["__thoughts"] += readed["__last_thought"];
+                        readed["__last_thought"] = "";
+                        if (part.thought){
+                            readed["__last_thought"] = part.text;
+                        }
+                        else {
+                            readed["0"] += part.text;
+                        }
+                        if (part.thoughtSignature) {
+                            readed["__sign_text"] = part.thoughtSignature;
+                            if(saveSignature){
+                                //Its a promise, but we don't need to await it here
+                                const sigId = v4()
+                                saveInlayedSignature(sigId, {
+                                    source: modelInfo.internalID || modelInfo.id,
+                                    sourceFormat: modelInfo.format,
+                                    signatures: [{
+                                        type: 'text',
+                                        content: part.text,
+                                    }]
+                                })
+                                readed["0"] += `{{inlayeddata::${sigId}}}`;
                             }
                         }
+                    }
+                    if (part.functionCall) {
+                        toolCallsData.push(part.functionCall);
+                        if(part.thoughtSignature){
+                            readed["__sign_function"] = part.thoughtSignature;
+                            const sigId = v4()
 
-                        if(jsonData.usageMetadata){
-                            readed['__usageMetadata'] = JSON.stringify(jsonData.usageMetadata)
+                            if(saveSignature){
+                                //Its a promise, but we don't need to await it here
+                                saveInlayedSignature(sigId, {
+                                    source: modelInfo.internalID || modelInfo.id,
+                                    sourceFormat: modelInfo.format,
+                                    signatures: [{
+                                        type: 'function',
+                                        content: `${part.functionCall.name}(${JSON.stringify(part.functionCall.args)})`,
+                                    }]
+                                })
+                                readed["0"] += `{{inlayeddata::${sigId}}}`;
+                            }
                         }
-                        if(jsonData.modelStatus){
-                            readed['__modelStatus'] = JSON.stringify(jsonData.modelStatus)
-                        }
-                    } 
+                    }
                 }
-                control.enqueue(readed)
-            } catch (error) { 
+            }
 
+            if(jsonData.usageMetadata){
+                readed['__usageMetadata'] = JSON.stringify(jsonData.usageMetadata)
+            }
+            if(jsonData.modelStatus){
+                readed['__modelStatus'] = JSON.stringify(jsonData.modelStatus)
+            }
+            return true
+        } catch (error) {}
+
+        return false
+    }
+
+    const processBufferedLines = (control:TransformStreamDefaultController<StreamResponseChunk>, final = false) => {
+        const lines = buffer.split(/\r?\n/)
+        buffer = lines.pop() ?? ''
+
+        if(final && buffer){
+            lines.push(buffer)
+            buffer = ''
+        }
+
+        let updated = false
+        for(const line of lines){
+            if(!line.startsWith('data:')){
+                continue
+            }
+
+            updated = applyStreamData(line.replace(/^data:\s?/, '')) || updated
+            if(streamDone){
+                emit(control)
+                return true
             }
         }
+
+        if(updated){
+            emit(control)
+        }
+        return updated
+    }
+
+    return new TransformStream<Uint8Array, StreamResponseChunk>({
+        transform(chunk, control) {
+            if(streamDone){
+                return
+            }
+            buffer += decoder.decode(chunk, { stream: true })
+            processBufferedLines(control)
+        },
+        flush(control) {
+            if(streamDone){
+                return
+            }
+            buffer += decoder.decode()
+            processBufferedLines(control, true)
+        }
     });
+}
+
+export const __testGoogleRequestsAPI = {
+    getTranStream
 }
 
 function wrapToolStream(

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -1082,22 +1082,26 @@ function getTranStream(args:{
         return false
     }
 
-    const processBufferedLines = (control:TransformStreamDefaultController<StreamResponseChunk>, final = false) => {
-        const lines = buffer.split(/\r?\n/)
-        buffer = lines.pop() ?? ''
+    const processBufferedEvents = (control:TransformStreamDefaultController<StreamResponseChunk>, final = false) => {
+        const events = buffer.split(/\r\n\r\n|\n\n|\r\r/)
+        buffer = events.pop() ?? ''
 
-        if(final && buffer){
-            lines.push(buffer)
+        if(final && buffer.trim()){
+            events.push(buffer)
             buffer = ''
         }
 
         let updated = false
-        for(const line of lines){
-            if(!line.startsWith('data:')){
+        for(const rawEvent of events){
+            const dataLines = rawEvent
+                .split(/\r\n|\r|\n/)
+                .filter((line) => line.startsWith('data:'))
+                .map((line) => line.replace(/^data:\s?/, ''))
+            if(dataLines.length === 0){
                 continue
             }
 
-            updated = applyStreamData(line.replace(/^data:\s?/, '')) || updated
+            updated = applyStreamData(dataLines.join('\n')) || updated
             if(streamDone){
                 emit(control)
                 return true
@@ -1116,14 +1120,14 @@ function getTranStream(args:{
                 return
             }
             buffer += decoder.decode(chunk, { stream: true })
-            processBufferedLines(control)
+            processBufferedEvents(control)
         },
         flush(control) {
             if(streamDone){
                 return
             }
             buffer += decoder.decode()
-            processBufferedLines(control, true)
+            processBufferedEvents(control, true)
         }
     });
 }

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -279,6 +279,69 @@ describe('OpenAI chat completions stream parser', () => {
             },
         })
     })
+
+    it('accumulates structured reasoning and content across events', async () => {
+        const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+            },
+        }))
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"reasoning_content":"Think "},"index":0}]}\n\n'))
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"reasoning_content":"step"},"index":0}]}\n\n'))
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"Answer"},"index":0}]}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)?.['0']).toBe('<Thoughts>\nThink step\n</Thoughts>\nAnswer')
+    })
+
+    it('extracts tagged reasoning after the closing tag arrives', async () => {
+        const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [LLMFlags.deepSeekThinkingOutput],
+            },
+        }))
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"<think>Plan"},"index":0}]}\n\n'))
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":" more"},"index":0}]}\n\n'))
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"</think>Answer"},"index":0}]}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)?.['0']).toBe('<Thoughts>\nPlan more\n</Thoughts>\nAnswer')
+    })
+
+    it('keeps multi-generation choices separate across events', async () => {
+        const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+            },
+            multiGen: true,
+        }))
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"A"},"index":0},{"delta":{"content":"B"},"index":1}]}\n\n'))
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"C"},"index":0},{"delta":{"content":"D"},"index":1}]}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)).toMatchObject({
+            '0': 'AC',
+            '1': 'BD',
+        })
+    })
 })
 
 describe('OpenAI Responses API helpers', () => {

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -183,7 +183,7 @@ describe('OpenAI chat completions stream parser', () => {
         mocks.db.jsonSchemaEnabled = false
     })
 
-    it('keeps only partial line text buffered and parses each completed SSE line once', async () => {
+    it('keeps only unfinished event text buffered and parses each completed SSE event once', async () => {
         const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
             modelInfo: {
                 ...baseArg().modelInfo,
@@ -230,6 +230,24 @@ describe('OpenAI chat completions stream parser', () => {
 
         const chunks = await chunksPromise
         expect(chunks.at(-1)?.['0']).toBe('Hi 😀')
+    })
+
+    it('joins multiple data lines in one SSE event', async () => {
+        const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+            },
+        }))
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"choices":\ndata: [{"delta":{"content":"Hi"},"index":0}]}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)?.['0']).toBe('Hi')
     })
 
     it('waits for split JSON lines and accumulates tool call deltas', async () => {

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer } from 'src/ts/model/types'
 import { fetchNative } from 'src/ts/globalApi.svelte'
 import { callTool } from '../../mcp/mcp'
-import { __testResponsesAPI, requestOpenAIResponseAPI } from './requests'
+import { __testOpenAIRequestsAPI, __testResponsesAPI, requestOpenAIResponseAPI } from './requests'
 
 const mocks = vi.hoisted(() => ({
     db: {
@@ -177,6 +177,91 @@ function sseStream(events: string[]) {
         }
     })
 }
+
+describe('OpenAI chat completions stream parser', () => {
+    beforeEach(() => {
+        mocks.db.jsonSchemaEnabled = false
+    })
+
+    it('keeps only partial line text buffered and parses each completed SSE line once', async () => {
+        const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+            },
+        }))
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+        const parseSpy = vi.spyOn(JSON, 'parse')
+
+        try{
+            await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"Hel"},"index":0}]}\n\n'))
+            await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"lo"},"index":0}]}\n\n'))
+            await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"!"},"index":0}]}\n\n'))
+            await writer.write(encoder.encode('data: [DONE]\n\n'))
+            await writer.close()
+
+            const chunks = await chunksPromise
+            expect(chunks.at(-1)?.['0']).toBe('Hello!')
+            expect(parseSpy).toHaveBeenCalledTimes(3)
+        }
+        finally{
+            parseSpy.mockRestore()
+        }
+    })
+
+    it('preserves split UTF-8 text across chunk boundaries', async () => {
+        const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+            },
+        }))
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+        const bytes = encoder.encode('data: {"choices":[{"delta":{"content":"Hi 😀"},"index":0}]}\n\n')
+        const emojiStart = bytes.findIndex((byte, index) => byte === 0xf0 && bytes[index + 1] === 0x9f)
+
+        await writer.write(bytes.slice(0, emojiStart + 2))
+        await writer.write(bytes.slice(emojiStart + 2))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)?.['0']).toBe('Hi 😀')
+    })
+
+    it('waits for split JSON lines and accumulates tool call deltas', async () => {
+        const stream = __testOpenAIRequestsAPI.getTranStream(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+            },
+        }))
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"content":"Hi","tool_calls":[{"index":0,"id":"call_1","function":{"name":"lookup","arguments":"{\\"q\\":"}}]},"index":0}]'))
+        await writer.write(encoder.encode('}\n\n'))
+        await writer.write(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"x\\"}"}}]},"index":0}]}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)?.['0']).toBe('Hi')
+        expect(JSON.parse(chunks.at(-1)?.['__tool_calls'] ?? '{}')).toEqual({
+            0: {
+                id: 'call_1',
+                type: 'function',
+                function: {
+                    name: 'lookup',
+                    arguments: '{"q":"x"}',
+                },
+            },
+        })
+    })
+})
 
 describe('OpenAI Responses API helpers', () => {
     beforeEach(() => {

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -970,9 +970,13 @@ export async function requestOpenAILegacyInstruct(arg:RequestDataArgumentExtende
 }
 
 function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Array, StreamResponseChunk> {
-    let dataUint:Uint8Array|Buffer = new Uint8Array([])
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let readed:{[key:string]:string} = {}
     let reasoningContent = ""
     let reasoningFromStructured = false
+    let streamDone = false
+    const toolCallsData:{[key:string]:any} = {}
     const db = getDatabase()
 
     const appendStreamingFragment = (current:string, incoming?:string) => {
@@ -985,154 +989,163 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
         return current + incoming
     }
 
+    const buildReadableState = () => {
+        const current:{[key:string]:string} = { ...readed }
+        if(Object.keys(toolCallsData).length > 0){
+            current["__tool_calls"] = JSON.stringify(toolCallsData)
+        }
+        return current
+    }
+
+    const emit = (control:TransformStreamDefaultController<StreamResponseChunk>) => {
+        const current = buildReadableState()
+        let currentReasoningContent = reasoningContent
+
+        if(arg.modelInfo.flags.includes(LLMFlags.deepSeekThinkingOutput) && !reasoningFromStructured){
+            current["0"] = (current["0"] ?? '').replace(/(.*)\<\/think\>/gms, (m, p1) => {
+                currentReasoningContent = p1
+                return ""
+            })
+
+            if(currentReasoningContent){
+                currentReasoningContent = currentReasoningContent.replace(/\<think\>/gm, '')
+            }
+        }
+
+        if(arg.extractJson && (db.jsonSchemaEnabled || arg.schema)){
+            let JSONreaded:{[key:string]:string} = {}
+            for(const key in current){
+                const extracted = extractJSON(current[key], arg.extractJson)
+                JSONreaded[key] = extracted
+            }
+            console.log(JSONreaded)
+            control.enqueue(JSONreaded)
+        }
+        else if(currentReasoningContent){
+            const chunk:Record<string,string> = {
+                "0": `<Thoughts>\n${currentReasoningContent}\n</Thoughts>\n${current["0"] ?? ''}`,
+            }
+            if(current["__tool_calls"]){
+                chunk["__tool_calls"] = current["__tool_calls"]
+            }
+            control.enqueue(chunk)
+        }
+        else{
+            control.enqueue(current)
+        }
+    }
+
+    const applyStreamData = (rawChunk:string) => {
+        if(rawChunk.trim() === "[DONE]"){
+            streamDone = true
+            return true
+        }
+
+        try {
+            const choices = JSON.parse(rawChunk).choices
+            for(const choice of choices){
+                const chunk = choice.delta?.content ?? choice.text
+                if(chunk){
+                    if(arg.multiGen){
+                        const ind = choice.index.toString()
+                        if(!readed[ind]){
+                            readed[ind] = ""
+                        }
+                        readed[ind] = appendStreamingFragment(readed[ind], chunk)
+                    }
+                    else{
+                        if(!readed["0"]){
+                            readed["0"] = ""
+                        }
+                        readed["0"] = appendStreamingFragment(readed["0"], chunk)
+                    }
+                }
+                if(choice?.delta?.tool_calls){
+                    for(const toolCall of choice.delta.tool_calls) {
+                        const index = toolCall.index ?? 0
+                        const toolCallId = toolCall.id
+
+                        if(!toolCallsData[index]) {
+                            toolCallsData[index] = {
+                                id: toolCallId || null,
+                                type: 'function',
+                                function: {
+                                    name: null,
+                                    arguments: ''
+                                }
+                            }
+                        }
+
+                        if(toolCall.id) {
+                            toolCallsData[index].id = toolCall.id
+                        }
+                        if(toolCall.function?.name) {
+                            toolCallsData[index].function.name = toolCall.function.name
+                        }
+                        if(toolCall.function?.arguments) {
+                            toolCallsData[index].function.arguments = appendStreamingFragment(toolCallsData[index].function.arguments, toolCall.function.arguments)
+                        }
+                    }
+                }
+                const reasoningChunk = choice?.delta?.reasoning_content ?? choice?.delta?.reasoning
+                if(reasoningChunk){
+                    reasoningFromStructured = true
+                    reasoningContent = appendStreamingFragment(reasoningContent, reasoningChunk)
+                }
+            }
+            return true
+        } catch (error) {}
+
+        return false
+    }
+
+    const processBufferedLines = (control:TransformStreamDefaultController<StreamResponseChunk>, final = false) => {
+        const lines = buffer.split(/\r?\n/)
+        buffer = lines.pop() ?? ''
+
+        if(final && buffer){
+            lines.push(buffer)
+            buffer = ''
+        }
+
+        let updated = false
+        for(const line of lines){
+            if(!line.startsWith("data:")){
+                continue
+            }
+            updated = applyStreamData(line.replace(/^data:\s?/, '')) || updated
+            if(streamDone){
+                emit(control)
+                return true
+            }
+        }
+
+        if(updated){
+            emit(control)
+        }
+        return updated
+    }
+
     return new TransformStream<Uint8Array, StreamResponseChunk>({
         transform(chunk, control) {
-            const combined = new Uint8Array(dataUint.length + chunk.length);
-            combined.set(dataUint, 0);
-            combined.set(chunk, dataUint.length);
-            dataUint = Buffer.from(combined);
-            let JSONreaded:{[key:string]:string} = {}
-            reasoningContent = ""
-                        try {
-                const datas = dataUint.toString().split('\n')
-                let readed:{[key:string]:string} = {}
-                for(const data of datas){
-                    if(data.startsWith("data: ")){
-                        try {
-                            const rawChunk = data.replace("data: ", "")
-                            if(rawChunk === "[DONE]"){
-                                if(arg.modelInfo.flags.includes(LLMFlags.deepSeekThinkingOutput) && !reasoningFromStructured){
-                                    readed["0"] = readed["0"].replace(/(.*)\<\/think\>/gms, (m, p1) => {
-                                        reasoningContent = p1
-                                        return ""
-                                    })
-
-                                    if(reasoningContent){
-                                        reasoningContent = reasoningContent.replace(/\<think\>/gm, '')
-                                    }
-                                }
-                                if(arg.extractJson && (db.jsonSchemaEnabled || arg.schema)){
-                                    for(const key in readed){
-                                        const extracted = extractJSON(readed[key], arg.extractJson)
-                                        JSONreaded[key] = extracted
-                                    }
-                                    console.log(JSONreaded)
-                                    control.enqueue(JSONreaded)
-                                }
-                                else if(reasoningContent){
-                                    const chunk:Record<string,string> = {
-                                        "0": `<Thoughts>\n${reasoningContent}\n</Thoughts>\n${readed["0"] ?? ''}`,
-                                    }
-                                    if(readed["__tool_calls"]){
-                                        chunk["__tool_calls"] = readed["__tool_calls"]
-                                    }
-                                    control.enqueue(chunk)
-                                }
-                                else{
-                                    control.enqueue(readed)
-                                }
-                                return
-                            }
-                            const choices = JSON.parse(rawChunk).choices
-                            for(const choice of choices){
-                                const chunk = choice.delta.content ?? choice.text
-                                if(chunk){
-                                    if(arg.multiGen){
-                                        const ind = choice.index.toString()
-                                        if(!readed[ind]){
-                                            readed[ind] = ""
-                                        }
-                                        readed[ind] = appendStreamingFragment(readed[ind], chunk)
-                                    }
-                                    else{
-                                        if(!readed["0"]){
-                                            readed["0"] = ""
-                                        }
-                                        readed["0"] = appendStreamingFragment(readed["0"], chunk)
-                                    }
-                                }
-                                // Check for tool calls in the delta
-                                if(choice?.delta?.tool_calls){
-                                    if(!readed["__tool_calls"]){
-                                        readed["__tool_calls"] = JSON.stringify({})
-                                    }
-                                    const toolCallsData = JSON.parse(readed["__tool_calls"])
-                                    
-                                    for(const toolCall of choice.delta.tool_calls) {
-                                        const index = toolCall.index ?? 0
-                                        const toolCallId = toolCall.id
-                                        
-                                        // Initialize tool call data if not exists
-                                        if(!toolCallsData[index]) {
-                                            toolCallsData[index] = {
-                                                id: toolCallId || null,
-                                                type: 'function',
-                                                function: {
-                                                    name: null,
-                                                    arguments: ''
-                                                }
-                                            }
-                                        }
-                                        
-                                        // Update tool call data incrementally
-                                        if(toolCall.id) {
-                                            toolCallsData[index].id = toolCall.id
-                                        }
-                                        if(toolCall.function?.name) {
-                                            toolCallsData[index].function.name = toolCall.function.name
-                                        }
-                                        if(toolCall.function?.arguments) {
-                                            toolCallsData[index].function.arguments = appendStreamingFragment(toolCallsData[index].function.arguments, toolCall.function.arguments)
-                                        }
-                                    }
-                                    
-                                    readed["__tool_calls"] = JSON.stringify(toolCallsData)
-                                }
-                                const reasoningChunk = choice?.delta?.reasoning_content ?? choice?.delta?.reasoning
-                                if(reasoningChunk){
-                                    reasoningFromStructured = true
-                                    reasoningContent = appendStreamingFragment(reasoningContent, reasoningChunk)
-                                }
-                            }
-                        } catch (error) {}
-                    }
-                }
-                
-                if(arg.modelInfo.flags.includes(LLMFlags.deepSeekThinkingOutput) && !reasoningFromStructured){
-                    readed["0"] = readed["0"].replace(/(.*)\<\/think\>/gms, (m, p1) => {
-                        reasoningContent = p1
-                        return ""
-                    })
-
-                    if(reasoningContent){
-                        reasoningContent = reasoningContent.replace(/\<think\>/gm, '')
-                    }
-                }
-                if(arg.extractJson && (db.jsonSchemaEnabled || arg.schema)){
-                    for(const key in readed){
-                        const extracted = extractJSON(readed[key], arg.extractJson)
-                        JSONreaded[key] = extracted
-                    }
-                    console.log(JSONreaded)
-                    control.enqueue(JSONreaded)
-                }
-                else if(reasoningContent){
-                    const chunk:Record<string,string> = {
-                        "0": `<Thoughts>\n${reasoningContent}\n</Thoughts>\n${readed["0"] ?? ''}`,
-                    }
-                    if(readed["__tool_calls"]){
-                        chunk["__tool_calls"] = readed["__tool_calls"]
-                    }
-                    control.enqueue(chunk)
-                }
-                else{
-                    control.enqueue(readed)
-                }
-            } catch (error) {
-                
+            if(streamDone){
+                return
             }
-        }        
+            buffer += decoder.decode(chunk, { stream: true })
+            processBufferedLines(control)
+        },
+        flush(control) {
+            if(streamDone){
+                return
+            }
+            buffer += decoder.decode()
+            processBufferedLines(control, true)
+        }
     })
+}
+
+export const __testOpenAIRequestsAPI = {
+    getTranStream
 }
 
 function wrapToolStream(

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -1099,21 +1099,25 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
         return false
     }
 
-    const processBufferedLines = (control:TransformStreamDefaultController<StreamResponseChunk>, final = false) => {
-        const lines = buffer.split(/\r?\n/)
-        buffer = lines.pop() ?? ''
+    const processBufferedEvents = (control:TransformStreamDefaultController<StreamResponseChunk>, final = false) => {
+        const events = buffer.split(/\r\n\r\n|\n\n|\r\r/)
+        buffer = events.pop() ?? ''
 
-        if(final && buffer){
-            lines.push(buffer)
+        if(final && buffer.trim()){
+            events.push(buffer)
             buffer = ''
         }
 
         let updated = false
-        for(const line of lines){
-            if(!line.startsWith("data:")){
+        for(const rawEvent of events){
+            const dataLines = rawEvent
+                .split(/\r\n|\r|\n/)
+                .filter((line) => line.startsWith("data:"))
+                .map((line) => line.replace(/^data:\s?/, ''))
+            if(dataLines.length === 0){
                 continue
             }
-            updated = applyStreamData(line.replace(/^data:\s?/, '')) || updated
+            updated = applyStreamData(dataLines.join('\n')) || updated
             if(streamDone){
                 emit(control)
                 return true
@@ -1132,14 +1136,14 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
                 return
             }
             buffer += decoder.decode(chunk, { stream: true })
-            processBufferedLines(control)
+            processBufferedEvents(control)
         },
         flush(control) {
             if(streamDone){
                 return
             }
             buffer += decoder.decode()
-            processBufferedLines(control, true)
+            processBufferedEvents(control, true)
         }
     })
 }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Optimizes OpenAI-compatible and Google/Gemini streaming parsers so they keep only unfinished input text buffered while preserving cumulative parsed output state.

## Related Issues

None

## Changes

The OpenAI-compatible stream parser now uses a streaming TextDecoder, keeps only incomplete SSE line text in its raw buffer, and stores parsed text, reasoning, and tool call data as parser state.

The Google/Gemini stream parser now follows the same buffering structure, including parsed state for thoughts, tool calls, signatures, usage metadata, and model status.

Focused tests cover one-time parsing of completed SSE lines, split-line handling, split UTF-8 text, tool call accumulation, and prevention of repeated Gemini signature side effects.

## Impact

Long streaming responses should avoid repeated parsing of previously received provider events. Existing stream output remains cumulative for the UI.

No full manual all-model or platform matrix was run. The change is covered with targeted parser tests and TypeScript/Svelte checks.

## Additional Notes

Validated with pnpm exec vitest run src/ts/process/request/google.test.ts src/ts/process/request/openAI/requests.responses.test.ts, git diff --check, and pnpm check.