### PR TITLE
feat: add createInlay plugin API (v3)

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -895,6 +895,9 @@ const imageData = await Risuai.readImage('asset-id');
 
 // Save assets
 const savedPath = await Risuai.saveAsset(assetData);
+
+// Create an inlay from image data; renders in chat via {{inlay::<id>}}
+const inlayId = await Risuai.createInlay(imageBytes, { name: 'generated.png' });
 ```
 
 ### Theming

--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -1849,6 +1849,30 @@ interface RisuaiPluginAPI {
      */
     saveAsset(data: any): Promise<string>;
 
+    /**
+     * Creates an inlay from image data, embeddable in chat messages via the
+     * `{{inlay::id}}` syntax. Unlike `saveAsset`, inlays live in inlay storage
+     * rather than the character card, so generating many images does not grow
+     * the card. The image is re-encoded as PNG (animated GIF/WEBP keep only the
+     * first frame) and downscaled to fit 1024x1024 total pixels, matching the
+     * built-in image generation inlays.
+     *
+     * @param data - Image bytes (JPEG, PNG, GIF, WEBP, ...) as a Uint8Array, or
+     * an image data URI string. Remote URLs are rejected — fetch them with
+     * `nativeFetch` and pass the bytes. The Uint8Array's buffer is transferred
+     * to the host and detached after the call; pass a copy if you still need it.
+     * @param options - `name` sets the display name in the inlay explorer; defaults to the id.
+     * @returns The inlay id; insert `{{inlay::<id>}}` into a message to render it.
+     * @throws Error if the data is not decodable image data, or the string is not a data URI.
+     *
+     * @example
+     * ```typescript
+     * const id = await risuai.createInlay(imageBytes, { name: 'generated.png' });
+     * // then insert `{{inlay::${id}}}` into a chat message
+     * ```
+     */
+    createInlay(data: Uint8Array | string, options?: { name?: string }): Promise<string>;
+
     // ========== Plugin Management ==========
 
     /**

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -22,6 +22,7 @@ import { getModelInfo } from "src/ts/model/modellist";
 import type { ModelModeExtended } from "src/ts/process/request/shared";
 import { requestChatDataMain } from "src/ts/process/request/request";
 import { getModuleLorebooks } from "src/ts/process/modules";
+import { createInlayFromData } from "src/ts/process/files/inlays";
 import {
     registerTTSPreprocessor,
     unregisterTTSPreprocessor,
@@ -825,6 +826,12 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                     p.realArg[key] = value;
                 }
             }
+        },
+        createInlay: async (data: Uint8Array | string, options?: { name?: string }) => {
+            if(typeof data !== 'string' && !(data instanceof Uint8Array)){
+                throw new Error('data must be a Uint8Array or an image data URI string')
+            }
+            return await createInlayFromData(data, options?.name)
         },
         getCharacterFromIndex: (index:number) => {
             const db = DBState.db

--- a/src/ts/process/files/inlays.ts
+++ b/src/ts/process/files/inlays.ts
@@ -124,6 +124,40 @@ export async function writeInlayImage(imgObj:HTMLImageElement, arg:{name?:string
     return `${imgid}`
 }
 
+export async function createInlayFromData(data: Uint8Array | string, name?: string) {
+    if(typeof data === 'string'){
+        //reject remote URLs so plugins can't bypass nativeFetch's URL restrictions
+        if(!data.startsWith('data:')){
+            throw new Error('String input must be an image data URI')
+        }
+        return await writeInlayImageFromSrc(data, name)
+    }
+
+    //mime is only a hint; undecodable bytes reject via onerror in writeInlayImageFromSrc
+    const imageType = getImageType(data)
+    const mimeType = imageType === 'Unknown' ? 'application/octet-stream' : `image/${imageType.toLowerCase()}`
+
+    const src = URL.createObjectURL(new Blob([asBuffer(data)], {type: mimeType}))
+    try {
+        return await writeInlayImageFromSrc(src, name)
+    } finally {
+        URL.revokeObjectURL(src)
+    }
+}
+
+function writeInlayImageFromSrc(src: string, name?: string): Promise<string> {
+    const imgObj = new Image()
+
+    return new Promise((resolve, reject) => {
+        //writeInlayImage only waits for onload; reject undecodable input via onerror
+        imgObj.onerror = () => {
+            reject(new Error('Failed to decode inlay image data'))
+        }
+        imgObj.src = src
+        writeInlayImage(imgObj, { name }).then(resolve, reject)
+    })
+}
+
 export type InlaySignature = {
     signatures: {
         type: 'function'|'text'

--- a/src/ts/process/files/tests/inlays.test.ts
+++ b/src/ts/process/files/tests/inlays.test.ts
@@ -1,7 +1,9 @@
 import fc from 'fast-check'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { getImageType } from 'src/ts/media'
 import type { InlayAsset } from '../inlays'
 import {
+    createInlayFromData,
     getInlayAsset,
     getInlayAssetBlob,
     listInlayAssets,
@@ -435,6 +437,93 @@ describe('writeInlayImage', () => {
                 })
             }),
         )
+    })
+})
+
+describe('createInlayFromData', () => {
+    // happy-dom does not load images, so onload/onerror never fire naturally
+    class FakeImage {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        width = 200
+        height = 100
+        #src = ''
+        get src() {
+            return this.#src
+        }
+        set src(value: string) {
+            this.#src = value
+            queueMicrotask(() => {
+                if (value.includes('bad-image')) this.onerror?.()
+                else this.onload?.()
+            })
+        }
+    }
+
+    const origCreateObjectURL = URL.createObjectURL
+    const origRevokeObjectURL = URL.revokeObjectURL
+
+    beforeEach(() => {
+        vi.stubGlobal('Image', FakeImage)
+        URL.createObjectURL = vi.fn(() => 'blob:fake-url')
+        URL.revokeObjectURL = vi.fn()
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        URL.createObjectURL = origCreateObjectURL
+        URL.revokeObjectURL = origRevokeObjectURL
+    })
+
+    test('creates an image inlay from a data URI string', async () => {
+        const result = await createInlayFromData('data:image/png;base64,aGVsbG8=')
+
+        expect(result).toBe('test-uuid-1234')
+        const stored = store.get('test-uuid-1234') as InlayAsset
+        expect(stored).toMatchObject({
+            data: expect.any(Blob),
+            ext: 'png',
+            name: 'test-uuid-1234',
+            type: 'image',
+        })
+    })
+
+    test('creates an image inlay from raw bytes and revokes the object URL', async () => {
+        vi.mocked(getImageType).mockReturnValue('PNG')
+
+        const result = await createInlayFromData(new Uint8Array([0x89, 0x50]), 'gen.png')
+
+        expect(result).toBe('test-uuid-1234')
+        expect(URL.createObjectURL).toHaveBeenCalledOnce()
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:fake-url')
+        const stored = store.get('test-uuid-1234') as InlayAsset
+        expect(stored).toMatchObject({
+            name: 'gen.png',
+            type: 'image',
+        })
+    })
+
+    test('rejects and revokes the object URL when raw bytes cannot be decoded', async () => {
+        vi.mocked(getImageType).mockReturnValue('Unknown')
+        vi.mocked(URL.createObjectURL).mockReturnValue('blob:bad-image')
+
+        await expect(createInlayFromData(new Uint8Array([0x00, 0x01]))).rejects.toThrow(
+            /Failed to decode/,
+        )
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:bad-image')
+        expect(store.size).toBe(0)
+    })
+
+    test('rejects instead of hanging when the image cannot be decoded', async () => {
+        await expect(createInlayFromData('data:bad-image')).rejects.toThrow(/Failed to decode/)
+        expect(store.size).toBe(0)
+    })
+
+    test('rejects strings that are not data URIs', async () => {
+        await expect(createInlayFromData('https://example.com/x.png')).rejects.toThrow(
+            /must be an image data URI/,
+        )
+        expect(store.size).toBe(0)
     })
 })
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

> Note on the model checklist: this PR does not touch prompting/request/response handling, so the "uses models" section is left unchecked (N/A).
> Note on AI generation: the implementation was AI-assisted, then manually reviewed and trimmed. The diff is intentionally small (+158 / -1, 5 files) and is a thin binding over existing internals.

## Summary

V3 plugins can generate images (`nativeFetch`), insert chat tokens, and trigger re-renders, but they cannot create **inlays** — the inlay machinery (`writeInlayImage` / `postInlayAsset`) is internal and, until now, only reachable from Luatriggers (the Lua `generateImage` trigger already calls `writeInlayImage` and returns `{{inlay::}}`).

This PR exposes a single, additive V3 API:

```ts
risuai.createInlay(data: Uint8Array | string, options?: { name?: string }): Promise<string>
```

It takes image **data** (raw bytes or an image data URI — not an `HTMLImageElement`, since plugins run in a sandboxed iframe and can't pass DOM nodes over postMessage), stores it as an inlay, and returns the id, so a plugin can insert `{{inlay::<id>}}` into a message.

This closes the gap where a plugin that generates an image (e.g. NovelAI) had only two poor workarounds:
1. `saveAsset` → permanently bloats the character card with one asset per generated image.
2. Inline a full-res `data:` URI in the message → a ~780k-char base64 string stalls the markdown/CBS/DOMPurify render pipeline and freezes the chat.

`createInlay` is chat-scoped (inlay storage, no card bloat) and renders natively at full resolution with a small token — the same path RisuAI's own image generation already uses.

## Related Issues

#1511

This also complements the open read-only PR #1454 (`readInlay`): that adds the read path, this adds the create path.

## Changes

- **`src/ts/process/files/inlays.ts`** — new `createInlayFromData(data, name?)`:
  - String branch reuses the existing Lua `generateImage` pattern (`new Image()` → `src = dataURI` → `writeInlayImage`). Rejects non-`data:` strings so a plugin can't use an image load to reach a URL that `nativeFetch` blocks.
  - `Uint8Array` branch sniffs a mime hint via the existing `getImageType()` and hands the bytes to `writeInlayImage` through an object URL, which is revoked in a `finally` so bulk callers don't leak blobs.
  - A small `writeInlayImageFromSrc` helper adds an `onerror` rejection, because `writeInlayImage` only awaits `onload` and would otherwise hang forever on undecodable input.
- **`src/ts/plugins/apiV3/v3.svelte.ts`** — expose `createInlay` on the V3 API object (validates the argument type, then delegates). No sandbox-bridge changes: `Uint8Array` already crosses the postMessage bridge intact as a transferable, exactly like `saveAsset`.
- **`src/ts/plugins/apiV3/risuai.d.ts`** — typed `createInlay(...)` under Asset Management with JSDoc (`@param` / `@returns` / `@throws` / `@example`).
- **`plugins.md`** — usage snippet in the Asset Management section.
- **`src/ts/process/files/tests/inlays.test.ts`** — new `createInlayFromData` cases (data URI, raw bytes, object-URL revoke, `onerror` rejection, non-data-URI rejection), reusing the file's existing mocks.

## Impact

- **Additive and backward-compatible.** No existing function is modified; existing plugin APIs are unchanged.
- **No UI / render / prompt / request changes.**
- **No new permission gate**, consistent with the existing ungated `saveAsset`. Adding one would drag in i18n strings across all 7 languages for no security gain over `saveAsset` / the Lua `generateImage` path, both of which already write inlay/asset storage from plugin-adjacent code.
- **Write-safety** (the concern raised on #1454's review): the returned id is always a fresh uuid — a plugin cannot pass or alias an `id`, so it can't overwrite an existing inlay. The stored blob is always canvas-re-encoded to PNG, so no input MIME/polyglot survives storage, and the plugin-supplied `name` is only ever rendered through Svelte's auto-escaped bindings in the inlay explorer.
- **Documented behaviors:** images are re-encoded to PNG (animated GIF/WEBP flatten to the first frame) and downscaled to ≤1024×1024 total pixels — identical to the built-in image-generation inlays; and, per the existing transferable bridge, the passed `Uint8Array`'s buffer is detached after the call.

## Additional Notes

Verified locally on this branch:

- `pnpm check` → `svelte-check found 0 errors and 0 warnings`
- `pnpm test` → `Test Files 20 passed (20)`, `Tests 197 passed | 3 skipped` (includes the 5 new `createInlayFromData` cases)
- `pnpm build` → `✓ built`

Manual end-to-end in the running web app (`pnpm dev`) with a small test plugin calling the new API in the real sandboxed iframe:

```
[createinlay-demo] inlay from data URI: e8e2b55b-cf22-435d-a845-ea78143c848d
[createinlay-demo] inlay from Uint8Array: a0528d35-855d-4052-b8aa-0da0b5c54f77
[createinlay-demo] invalid bytes correctly rejected: Failed to decode inlay image data
```

The created inlays were confirmed in inlay storage as valid PNGs and rendered correctly (320×180, decoded 320×180). Inserting `{{inlay::<id>}}` into a chat renders them inline via the existing `parseInlayAssets` path (no renderer changes needed).

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.