### PR TITLE
feat: add UnoRouter provider

### DIFF
--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -502,6 +502,75 @@ export const LLMModels: LLMModel[] = [
         endpoint: 'https://api.deepseek.com/beta/chat/completions',
         keyIdentifier: 'deepseek'
     },
+    // UnoRouter
+    {
+        id: 'deepseek-v4-flash:free',
+        name: 'DeepSeek V4 Flash (free)',
+        provider: LLMProvider.UnoRouter,
+        format: LLMFormat.OpenAICompatible,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasStreaming],
+        parameters: OpenAIParameters,
+        tokenizer: LLMTokenizer.Unknown,
+        endpoint: 'https://api.unorouter.com/v1/chat/completions',
+        keyIdentifier: 'unorouter',
+        recommended: true
+    },
+    {
+        id: 'claude-sonnet-5',
+        name: 'Claude Sonnet 5',
+        provider: LLMProvider.UnoRouter,
+        format: LLMFormat.OpenAICompatible,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasImageInput, LLMFlags.hasPrefill, LLMFlags.hasStreaming],
+        parameters: OpenAIParameters,
+        tokenizer: LLMTokenizer.Unknown,
+        endpoint: 'https://api.unorouter.com/v1/chat/completions',
+        keyIdentifier: 'unorouter',
+        recommended: true
+    },
+    {
+        id: 'nemotron-3-ultra-550b-a55b:free',
+        name: 'Nemotron 3 Ultra (free)',
+        provider: LLMProvider.UnoRouter,
+        format: LLMFormat.OpenAICompatible,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasStreaming],
+        parameters: OpenAIParameters,
+        tokenizer: LLMTokenizer.Unknown,
+        endpoint: 'https://api.unorouter.com/v1/chat/completions',
+        keyIdentifier: 'unorouter'
+    },
+    {
+        id: 'glm-5.2:free',
+        name: 'GLM 5.2 (free)',
+        provider: LLMProvider.UnoRouter,
+        format: LLMFormat.OpenAICompatible,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasStreaming],
+        parameters: OpenAIParameters,
+        tokenizer: LLMTokenizer.Unknown,
+        endpoint: 'https://api.unorouter.com/v1/chat/completions',
+        keyIdentifier: 'unorouter'
+    },
+    {
+        id: 'qwen3.5-397b-a17b:free',
+        name: 'Qwen 3.5 397B (free)',
+        provider: LLMProvider.UnoRouter,
+        format: LLMFormat.OpenAICompatible,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasStreaming],
+        parameters: OpenAIParameters,
+        tokenizer: LLMTokenizer.Unknown,
+        endpoint: 'https://api.unorouter.com/v1/chat/completions',
+        keyIdentifier: 'unorouter'
+    },
+    {
+        id: 'kimi-k2.6',
+        name: 'Kimi K2.6',
+        provider: LLMProvider.UnoRouter,
+        format: LLMFormat.OpenAICompatible,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasImageInput, LLMFlags.hasStreaming],
+        parameters: OpenAIParameters,
+        tokenizer: LLMTokenizer.Unknown,
+        endpoint: 'https://api.unorouter.com/v1/chat/completions',
+        keyIdentifier: 'unorouter'
+    },
     // DeepInfra
     ...makeDeepInfraModels([
         'deepseek-ai/DeepSeek-R1',

--- a/src/ts/model/types.UnoRouter.test.ts
+++ b/src/ts/model/types.UnoRouter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, ProviderNames, type LLMModel } from 'src/ts/model/types'
+
+describe('UnoRouter provider', () => {
+    it('is registered as an LLMProvider with a display name', () => {
+        expect(typeof LLMProvider.UnoRouter).toBe('number')
+        expect(ProviderNames.get(LLMProvider.UnoRouter)).toBe('UnoRouter')
+    })
+
+    it('describes the free DeepSeek V4 Flash model as an OpenAI-compatible endpoint', () => {
+        const model: LLMModel = {
+            id: 'deepseek-v4-flash:free',
+            name: 'DeepSeek V4 Flash (free)',
+            provider: LLMProvider.UnoRouter,
+            format: LLMFormat.OpenAICompatible,
+            flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasStreaming],
+            parameters: OpenAIParameters,
+            tokenizer: LLMTokenizer.Unknown,
+            endpoint: 'https://api.unorouter.com/v1/chat/completions',
+            keyIdentifier: 'unorouter',
+        }
+
+        expect(model.format).toBe(LLMFormat.OpenAICompatible)
+        expect(model.endpoint).toBe('https://api.unorouter.com/v1/chat/completions')
+        expect(model.keyIdentifier).toBe('unorouter')
+        expect(model.flags).toContain(LLMFlags.hasStreaming)
+    })
+})

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -47,7 +47,8 @@ export const LLMProvider = {
     DeepInfra: 13,
     Echo: 14,
     NanoGPT: 15,
-    Ollama: 16
+    Ollama: 16,
+    UnoRouter: 17
 } as const;
 export type LLMProvider = (typeof LLMProvider)[keyof typeof LLMProvider];
 
@@ -133,7 +134,8 @@ export const ProviderNames = new Map<LLMProvider, string>([
     [LLMProvider.DeepInfra, 'DeepInfra'],
     [LLMProvider.Echo, 'For Developer'],
     [LLMProvider.NanoGPT, 'NanoGPT'],
-    [LLMProvider.Ollama, 'Ollama']
+    [LLMProvider.Ollama, 'Ollama'],
+    [LLMProvider.UnoRouter, 'UnoRouter']
 ])
 
 export const OpenAIParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty']


### PR DESCRIPTION
## Summary

Add UnoRouter as a new LLM provider, compatible with the existing OpenAI-compatible provider architecture.

UnoRouter (unorouter.com) is an open-source gateway serving 200+ models through one API key; models with a `:free` suffix cost nothing, which makes it a practical default for RP users without a paid API. Full catalog: https://unorouter.com/models

## Changes

- Add `UnoRouter` to `LLMProvider` and `ProviderNames` in `types.ts`
- Add six model entries in `modellist.ts` (`OpenAICompatible` format, endpoint + `keyIdentifier`), following the existing DeepSeek entries: `deepseek-v4-flash:free`, `claude-sonnet-5`, `nemotron-3-ultra-550b-a55b:free`, `glm-5.2:free`, `qwen3.5-397b-a17b:free`, `kimi-k2.6`
- Add unit tests for the provider registration and model shape (`types.UnoRouter.test.ts`)

## Testing

- `vitest run src/ts/model/types.UnoRouter.test.ts` passes (2/2)
- `svelte-check` clean (0 errors, 0 warnings)