### PR TITLE
refactor: refine save area detection

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -14,10 +14,10 @@ import { appDataDir, join } from "@tauri-apps/api/path";
 import { get } from "svelte/store";
 import { open } from '@tauri-apps/plugin-shell'
 import streamSaver from 'streamsaver';
-import { setDatabase, type Database, defaultSdDataFunc, getDatabase, appVer, getCurrentCharacter, type character, type groupChat } from "./storage/database.svelte";
+import { setDatabase, type Database, defaultSdDataFunc, getDatabase, appVer, getCurrentCharacter, type character, type Chat, type groupChat } from "./storage/database.svelte";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { checkRisuUpdate } from "./update";
-import { MobileGUI, botMakerMode, selectedCharID, loadedStore, DBState, LoadingStatusState, selIdState, ReloadGUIPointer, bodyIntercepterStore } from "./stores.svelte";
+import { MobileGUI, botMakerMode, loadedStore, DBState, LoadingStatusState, selIdState, ReloadGUIPointer, bodyIntercepterStore } from "./stores.svelte";
 import { loadPlugins } from "./plugins/plugins.svelte";
 import { alertConfirm, alertError, alertMd, alertNormal, alertNormalWait, alertSelect, alertTOS, waitAlert } from "./alert";
 import { checkDriverInit, syncDrive } from "./drive/drive";
@@ -25,7 +25,7 @@ import { hasher } from "./parser/parser.svelte";
 import { characterURLImport, hubURL } from "./characterCards";
 import { defaultJailbreak, defaultMainPrompt, oldJailbreak, oldMainPrompt } from "./storage/defaultPrompts";
 import { loadRisuAccountData } from "./drive/accounter";
-import { decodeRisuSave, encodeRisuSaveLegacy, RisuSaveEncoder, type toSaveType } from "./storage/risuSave";
+import { decodeRisuSave, encodeRisuSaveLegacy, RisuSaveEncoder } from "./storage/risuSave";
 import { AutoStorage } from "./storage/autoStorage";
 import { updateAnimationSpeed } from "./gui/animation";
 import { updateColorScheme, updateTextThemeAndCSS } from "./gui/colorscheme";
@@ -45,6 +45,7 @@ import { isTauri, isNodeServer } from "./platform";
 import { isLocalNetworkUrl } from "./network/localNetwork";
 import { decodeProxyJobWsChunk, formatProxyStreamErrorMessage, parseProxyJobWsEvent } from "./network/proxyJobWs";
 import { getNodeServerProxyAuth } from "./storage/nodeStorage";
+import { expandChatSaveTargets, SaveAreaTracker, type SaveAreaFlag } from "./storage/saveAreaDetector";
 
 export const forageStorage = new AutoStorage()
 
@@ -312,31 +313,14 @@ export async function saveDb() {
         }
     }
 
-    const changeTracker: toSaveType = {
-        character: [],
-        chat: [],
-        botPreset: false,
-        modules: false,
-        loadouts: false,
-        plugins: false,
-        pluginCustomStorage: false
-    }
-
     let encoder = new RisuSaveEncoder()
-    await encoder.init(getDatabase(), {
-        compression: forageStorage.isAccount
-    })
+    const saveAreaTracker = new SaveAreaTracker()
+    let needsInitialSave = true
 
     $effect.root(() => {
-
-        let selIdState = $state(0)
-
         const debounceTime = 500; // 500 milliseconds
         let saveTimeout: ReturnType<typeof setTimeout> | null = null;
-
-        selectedCharID.subscribe((v) => {
-            selIdState = v
-        })
+        const characterEffects = new Map<object, { chaId: string, dispose: () => void }>()
 
         function saveTimeoutExecute() {
             if (saveTimeout) {
@@ -347,32 +331,149 @@ export async function saveDb() {
             }, debounceTime);
         }
 
-        $effect(() => {
-            DBState.db.botPresetsId
-            DBState.db.botPresets.length
-            changeTracker.botPreset = true
-            saveTimeoutExecute()
+        function queueCharacter(chaId?: string) {
+            if (saveAreaTracker.markCharacter(chaId)) {
+                saveTimeoutExecute()
+            }
+        }
+
+        function queueChat(chaId?: string, chatId?: string) {
+            if (saveAreaTracker.markChat(chaId, chatId)) {
+                saveTimeoutExecute()
+            }
+            else {
+                queueCharacter(chaId)
+            }
+        }
+
+        function watchFlag(flag: SaveAreaFlag, read: () => void) {
+            let initialized = false
+            $effect(() => {
+                read()
+                if (initialized) {
+                    saveAreaTracker.markFlag(flag)
+                    saveTimeoutExecute()
+                }
+                initialized = true
+            })
+        }
+
+        function watchChat(character: character | groupChat, chat: Chat, markOnInitial: boolean) {
+            let initialized = false
+            return $effect.root(() => {
+                $effect(() => {
+                    $state.snapshot(chat)
+                    if (initialized || markOnInitial) {
+                        queueChat(character.chaId, chat.id)
+                    }
+                    initialized = true
+                })
+            })
+        }
+
+        function watchCharacter(character: character | groupChat, markOnInitial: boolean) {
+            return $effect.root(() => {
+                const chatEffects = new Map<object, { chatId: string, dispose: () => void }>()
+                let metadataInitialized = false
+                let chatListInitialized = false
+
+                $effect(() => {
+                    const characterData = character as unknown as Record<string, unknown>
+                    for (const key of Object.keys(characterData)) {
+                        if (key !== 'chats') {
+                            $state.snapshot(characterData[key])
+                        }
+                    }
+                    if (metadataInitialized || markOnInitial) {
+                        queueCharacter(character.chaId)
+                    }
+                    metadataInitialized = true
+                })
+
+                $effect(() => {
+                    const activeChats = new Set<object>()
+                    for (const chat of character.chats ?? []) {
+                        chat.id
+                        activeChats.add(chat)
+                        const existing = chatEffects.get(chat)
+                        if (!existing) {
+                            chatEffects.set(chat, {
+                                chatId: chat.id,
+                                dispose: watchChat(character, chat, chatListInitialized || markOnInitial)
+                            })
+                        }
+                        else if (existing.chatId !== chat.id) {
+                            queueChat(character.chaId, existing.chatId)
+                            queueChat(character.chaId, chat.id)
+                            existing.chatId = chat.id
+                        }
+                    }
+                    for (const [chat, effectState] of chatEffects) {
+                        if (!activeChats.has(chat)) {
+                            queueChat(character.chaId, effectState.chatId)
+                            effectState.dispose()
+                            chatEffects.delete(chat)
+                        }
+                    }
+                    if (chatListInitialized) {
+                        queueCharacter(character.chaId)
+                    }
+                    chatListInitialized = true
+                })
+
+                return () => {
+                    for (const effectState of chatEffects.values()) {
+                        effectState.dispose()
+                    }
+                    chatEffects.clear()
+                }
+            })
+        }
+
+        watchFlag('botPreset', () => {
+            $state.snapshot(DBState.db.botPresets)
         })
-        $effect(() => {
+        watchFlag('modules', () => {
             $state.snapshot(DBState.db.modules)
-            changeTracker.modules = true
-            saveTimeoutExecute()
         })
-        $effect(() => {
+        watchFlag('loadouts', () => {
             $state.snapshot(DBState.db.loadouts)
-            changeTracker.loadouts = true
-            saveTimeoutExecute()
         })
-        $effect(() => {
+        watchFlag('plugins', () => {
             $state.snapshot(DBState.db.plugins)
-            changeTracker.plugins = true
-            saveTimeoutExecute()
         })
-        $effect(() => {
+        watchFlag('pluginCustomStorage', () => {
             $state.snapshot(DBState.db.pluginCustomStorage)
-            changeTracker.pluginCustomStorage = true
-            saveTimeoutExecute()
         })
+        let characterListInitialized = false
+        $effect(() => {
+            const activeCharacters = new Set<object>()
+            for (const character of DBState.db.characters ?? []) {
+                character.chaId
+                activeCharacters.add(character)
+                const existing = characterEffects.get(character)
+                if (!existing) {
+                    characterEffects.set(character, {
+                        chaId: character.chaId,
+                        dispose: watchCharacter(character, characterListInitialized)
+                    })
+                }
+                else if (existing.chaId !== character.chaId) {
+                    queueCharacter(existing.chaId)
+                    queueCharacter(character.chaId)
+                    existing.chaId = character.chaId
+                }
+            }
+            for (const [character, effectState] of characterEffects) {
+                if (!activeCharacters.has(character)) {
+                    queueCharacter(effectState.chaId)
+                    effectState.dispose()
+                    characterEffects.delete(character)
+                }
+            }
+            characterListInitialized = true
+        })
+        let rootInitialized = false
         $effect(() => {
             for (const key in DBState.db) {
                 if (
@@ -382,25 +483,29 @@ export async function saveDb() {
                     $state.snapshot(DBState.db[key])
                 }
             }
-            if (DBState?.db?.characters?.[selIdState]) {
-                for (const key in DBState.db.characters[selIdState]) {
-                    if (key !== 'chats') {
-                        $state.snapshot(DBState.db.characters[selIdState][key])
-                    }
-                }
-                $state.snapshot(DBState.db.characters[selIdState].chats)
-                if (changeTracker.character[0] !== DBState.db.characters[selIdState]?.chaId) {
-                    changeTracker.character.unshift(DBState.db.characters[selIdState]?.chaId)
-                }
-                if (
-                    changeTracker.chat[0]?.[0] !== DBState.db.characters[selIdState]?.chaId ||
-                    changeTracker.chat[0]?.[1] !== DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id
-                ) {
-                    changeTracker.chat.unshift([DBState.db.characters[selIdState]?.chaId, DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id])
-                }
+            if (rootInitialized) {
+                saveAreaTracker.markRoot()
+                saveTimeoutExecute()
             }
-            saveTimeoutExecute()
+            rootInitialized = true
         })
+        $effect(() => {
+            if (requiresFullEncoderReload.state) {
+                saveTimeoutExecute()
+            }
+        })
+
+        saveTimeoutExecute()
+
+        return () => {
+            if (saveTimeout) {
+                clearTimeout(saveTimeout)
+            }
+            for (const effectState of characterEffects.values()) {
+                effectState.dispose()
+            }
+            characterEffects.clear()
+        }
     })
 
     let savetrys = 0
@@ -412,24 +517,8 @@ export async function saveDb() {
             continue
         }
 
-        saving.state = true
         changed = false
         try {
-
-            if (requiresFullEncoderReload.state) {
-                encoder = new RisuSaveEncoder()
-                await encoder.init(getDatabase(), {
-                    compression: forageStorage.isAccount,
-                    skipRemoteSavingOnCharacters: false
-                })
-                requiresFullEncoderReload.state = false
-            }
-
-            let toSave = safeStructuredClone(changeTracker)
-            changeTracker.character = changeTracker.character.length === 0 ? [] : [changeTracker.character[0]]
-            changeTracker.chat = changeTracker.chat.length === 0 ? [] : [changeTracker.chat[0]]
-            changeTracker.botPreset = false
-            changeTracker.modules = false
             if (gotChannel) {
                 //Data is saved in other tab
                 await sleep(1000)
@@ -444,6 +533,27 @@ export async function saveDb() {
                 continue
             }
 
+            const saveAreaBatch = saveAreaTracker.snapshot()
+            const needsFullEncoderReload = requiresFullEncoderReload.state
+            if (!needsInitialSave && !needsFullEncoderReload && !saveAreaTracker.hasChanges()) {
+                continue
+            }
+
+            saving.state = true
+            if (needsInitialSave || needsFullEncoderReload) {
+                encoder = new RisuSaveEncoder()
+                await encoder.init(db, {
+                    compression: forageStorage.isAccount,
+                    skipRemoteSavingOnCharacters: !needsFullEncoderReload
+                })
+                if (needsFullEncoderReload) {
+                    requiresFullEncoderReload.state = false
+                }
+            }
+
+            // Chats are detected independently, but the current save format still stores them
+            // inside their parent character block.
+            const toSave = expandChatSaveTargets(saveAreaBatch.toSave)
             await encoder.set(db, toSave)
             const encoded = encoder.encode()
             if (!encoded) {
@@ -470,8 +580,11 @@ export async function saveDb() {
             }
             savetrys = 0
             await saveDbKei()
+            saveAreaTracker.ack(saveAreaBatch)
+            needsInitialSave = false
             await sleep(500)
         } catch (error) {
+            changed = true
             savetrys += 1
             if (savetrys > 4) {
                 alertError(error)
@@ -479,6 +592,7 @@ export async function saveDb() {
             else {
                 console.error(error)
             }
+            await sleep(500)
         }
 
         saving.state = false

--- a/src/ts/storage/saveAreaDetector.test.ts
+++ b/src/ts/storage/saveAreaDetector.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { expandChatSaveTargets, SaveAreaTracker } from './saveAreaDetector'
+
+describe('SaveAreaTracker', () => {
+    it('tracks root, character, chat, and dedicated save areas independently', () => {
+        const tracker = new SaveAreaTracker()
+        tracker.markRoot()
+        tracker.markCharacter('char-1')
+        tracker.markChat('char-1', 'chat-1')
+        tracker.markFlag('modules')
+
+        const batch = tracker.snapshot()
+        expect(batch.rootVersion).toBeDefined()
+        expect(batch.toSave.character).toEqual(['char-1'])
+        expect(batch.toSave.chat).toEqual([['char-1', 'chat-1']])
+        expect(batch.toSave.modules).toBe(true)
+        expect(batch.toSave.plugins).toBe(false)
+    })
+
+    it('maps chat targets to parent character blocks for the current encoder', () => {
+        const tracker = new SaveAreaTracker()
+        tracker.markChat('char-1', 'chat-1')
+        tracker.markChat('char-2', 'chat-2')
+        tracker.markCharacter('char-2')
+
+        const original = tracker.snapshot().toSave
+        const expanded = expandChatSaveTargets(original)
+
+        expect(expanded.character).toEqual(['char-2', 'char-1'])
+        expect(expanded.chat).toEqual([
+            ['char-1', 'chat-1'],
+            ['char-2', 'chat-2'],
+        ])
+        expect(original.character).toEqual(['char-2'])
+    })
+
+    it('keeps an unacknowledged batch pending after a failed save', () => {
+        const tracker = new SaveAreaTracker()
+        tracker.markFlag('plugins')
+        const failedBatch = tracker.snapshot()
+
+        expect(failedBatch.toSave.plugins).toBe(true)
+        expect(tracker.snapshot().toSave.plugins).toBe(true)
+        expect(tracker.hasChanges()).toBe(true)
+    })
+
+    it('clears only the areas acknowledged after a successful save', () => {
+        const tracker = new SaveAreaTracker()
+        tracker.markRoot()
+        tracker.markCharacter('char-1')
+        tracker.markChat('char-1', 'chat-1')
+        tracker.markFlag('pluginCustomStorage')
+
+        const batch = tracker.snapshot()
+        tracker.ack(batch)
+
+        expect(tracker.hasChanges()).toBe(false)
+    })
+
+    it('preserves changes made while a save is in flight', () => {
+        const tracker = new SaveAreaTracker()
+        tracker.markCharacter('char-1')
+        tracker.markChat('char-1', 'chat-1')
+        const inFlight = tracker.snapshot()
+
+        tracker.markChat('char-1', 'chat-1')
+        tracker.markChat('char-1', 'chat-2')
+        tracker.markFlag('loadouts')
+        tracker.ack(inFlight)
+
+        const nextBatch = tracker.snapshot()
+        expect(nextBatch.toSave.character).toEqual([])
+        expect(nextBatch.toSave.chat).toEqual([
+            ['char-1', 'chat-1'],
+            ['char-1', 'chat-2'],
+        ])
+        expect(nextBatch.toSave.loadouts).toBe(true)
+    })
+
+    it('falls back cleanly when an entity has no stable id', () => {
+        const tracker = new SaveAreaTracker()
+
+        expect(tracker.markCharacter()).toBe(false)
+        expect(tracker.markChat('char-1')).toBe(false)
+        expect(tracker.hasChanges()).toBe(false)
+    })
+})

--- a/src/ts/storage/saveAreaDetector.ts
+++ b/src/ts/storage/saveAreaDetector.ts
@@ -1,0 +1,147 @@
+import type { toSaveType } from './risuSave'
+
+export type SaveAreaFlag = Exclude<keyof toSaveType, 'character' | 'chat'>
+type VersionedFlags = Partial<Record<SaveAreaFlag, number>>
+
+export type SaveAreaBatch = {
+    toSave: toSaveType
+    rootVersion?: number
+    characterVersions: Map<string, number>
+    chatVersions: Map<string, number>
+    flagVersions: VersionedFlags
+}
+
+const saveAreaFlags: SaveAreaFlag[] = [
+    'botPreset',
+    'modules',
+    'loadouts',
+    'plugins',
+    'pluginCustomStorage',
+]
+
+function createEmptySaveTargets(): toSaveType {
+    return {
+        character: [],
+        chat: [],
+        botPreset: false,
+        modules: false,
+        loadouts: false,
+        plugins: false,
+        pluginCustomStorage: false,
+    }
+}
+
+function createChatKey(chaId: string, chatId: string) {
+    return `${chaId}\0${chatId}`
+}
+
+function parseChatKey(key: string): [string, string] {
+    const separator = key.indexOf('\0')
+    return [key.slice(0, separator), key.slice(separator + 1)]
+}
+
+export function expandChatSaveTargets(toSave: toSaveType): toSaveType {
+    const character = [...toSave.character]
+    for (const [chaId] of toSave.chat) {
+        if (!character.includes(chaId)) {
+            character.push(chaId)
+        }
+    }
+    return {
+        ...toSave,
+        character,
+        chat: toSave.chat.map(([chaId, chatId]) => [chaId, chatId]),
+    }
+}
+
+export class SaveAreaTracker {
+    private version = 0
+    private rootVersion: number | undefined
+    private characterVersions = new Map<string, number>()
+    private chatVersions = new Map<string, number>()
+    private flagVersions: VersionedFlags = {}
+
+    markRoot() {
+        this.rootVersion = ++this.version
+    }
+
+    markCharacter(chaId?: string) {
+        if (!chaId) {
+            return false
+        }
+        this.characterVersions.set(chaId, ++this.version)
+        return true
+    }
+
+    markChat(chaId?: string, chatId?: string) {
+        if (!chaId || !chatId) {
+            return false
+        }
+        this.chatVersions.set(createChatKey(chaId, chatId), ++this.version)
+        return true
+    }
+
+    markFlag(flag: SaveAreaFlag) {
+        this.flagVersions[flag] = ++this.version
+    }
+
+    hasChanges() {
+        return (
+            this.rootVersion !== undefined ||
+            this.characterVersions.size > 0 ||
+            this.chatVersions.size > 0 ||
+            saveAreaFlags.some((flag) => this.flagVersions[flag] !== undefined)
+        )
+    }
+
+    snapshot(): SaveAreaBatch {
+        const toSave = createEmptySaveTargets()
+        const characterVersions = new Map(this.characterVersions)
+        const chatVersions = new Map(this.chatVersions)
+        const flagVersions: VersionedFlags = {}
+
+        toSave.character = [...characterVersions.entries()]
+            .sort((left, right) => left[1] - right[1])
+            .map(([chaId]) => chaId)
+        toSave.chat = [...chatVersions.entries()]
+            .sort((left, right) => left[1] - right[1])
+            .map(([key]) => parseChatKey(key))
+
+        for (const flag of saveAreaFlags) {
+            if (this.flagVersions[flag] !== undefined) {
+                toSave[flag] = true
+                flagVersions[flag] = this.flagVersions[flag]
+            }
+        }
+
+        return {
+            toSave,
+            rootVersion: this.rootVersion,
+            characterVersions,
+            chatVersions,
+            flagVersions,
+        }
+    }
+
+    ack(batch: SaveAreaBatch) {
+        if (batch.rootVersion !== undefined && (this.rootVersion ?? -1) <= batch.rootVersion) {
+            this.rootVersion = undefined
+        }
+        for (const [chaId, version] of batch.characterVersions) {
+            if ((this.characterVersions.get(chaId) ?? -1) <= version) {
+                this.characterVersions.delete(chaId)
+            }
+        }
+        for (const [key, version] of batch.chatVersions) {
+            if ((this.chatVersions.get(key) ?? -1) <= version) {
+                this.chatVersions.delete(key)
+            }
+        }
+        for (const flag of saveAreaFlags) {
+            const version = batch.flagVersions[flag]
+            if (version !== undefined && (this.flagVersions[flag] ?? -1) <= version) {
+                delete this.flagVersions[flag]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This refines save-area detection without changing the RisuSave format or splitting chat data into new storage blocks. The save loop can now distinguish root data, character metadata, individual chats, presets, modules, loadouts, plugins, and plugin custom storage before selecting which existing blocks need to be refreshed.

## Related Issues

None.

## Changes

The previous watcher combined root changes with the currently selected character and treated that character's chat collection as one broad area. The new tracker watches every character and chat independently, including additions, removals, replacements, and identifier changes. It also watches nested bot preset changes instead of only the selected preset and array length.

Dirty entries are versioned and remain pending until a successful save acknowledges the captured batch. If another edit arrives while a save is running, that newer version stays pending for the next pass. Failed saves are retried without clearing their targets.

Chats are still stored inside their parent character block by the current encoder. Before calling `RisuSaveEncoder.set()`, chat targets are expanded to the corresponding character targets. The existing full save encoding and database write remain unchanged.

## Impact

This makes save targeting more accurate, including changes to non-selected characters and chats, while preserving the current file layout, remote payload behavior, decoder, recovery paths, and cleanup policy. There is no save migration. Per-character and per-chat effects avoid taking a full database snapshot on every reactive update.

## Additional Notes

Validated with `pnpm exec vitest run src/ts/storage/saveAreaDetector.test.ts`, `pnpm check`, and `git diff --check`. The focused tracker suite contains six passing tests covering area separation, current-encoder target expansion, failed saves, successful acknowledgement, and edits made during an in-flight save.
