### PR TITLE
Fix searchMatch key mutation in regex lorebook

### DIFF
--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -143,28 +143,33 @@ export async function loadLoreBookV3Prompt(){
             }))    
 
         if(arg.regex){
+            const regexes: { regex: RegExp, source: string }[] = []
+            for(const regexString of arg.keys){
+                const parsed = regexString.match(/^\/([\s\S]*)\/([dgimsuvy]*)$/)
+                if(!parsed){
+                    return false
+                }
+                const [, pattern, flags] = parsed
+
+                try {
+                    regexes.push({
+                        regex: new RegExp(pattern, flags),
+                        source: regexString
+                    })
+                } catch (error) {
+                    return false
+                }
+            }
             for(const mText of mList){
-                for(const regexString of arg.keys){
-                    if(!regexString.startsWith('/')){
-                        return false
-                    }
-                    const regexFlag = regexString.split('/').pop()
-                    if(regexFlag){
-                        arg.keys[0] = regexString.replace('/'+regexFlag,'')
-                        try {
-                            const regex = new RegExp(arg.keys[0],regexFlag)
-                            const d = regex.test(mText.data)
-                            if(d){
-                                matchLog.push({
-                                    prompt: mText.prompt,
-                                    source: mText.source,
-                                    activated: regexString
-                                })
-                                return true
-                            }
-                        } catch (error) {
-                            return false
-                        }
+                for(const {regex, source} of regexes){
+                    regex.lastIndex = 0
+                    if(regex.test(mText.data)){
+                        matchLog.push({
+                            prompt: mText.prompt,
+                            source: mText.source,
+                            activated: source
+                        })
+                        return true
                     }
                 }
             }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions? (N/A, no new types introduced; the change only uses locals inferred from existing types)
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes the `arg.keys[0]` mutation bug in regex lorebook key matching, which caused regex lorebook entries to silently fail on all messages after the first non-matching one.

## Related Issues

Fixes #1530

## Changes

- Removed the mutation of `arg.keys[0]` during regex key iteration in `searchMatch` (`src/ts/process/lorebook.svelte.ts`).
- Each key is now parsed into local `pattern` and `flags` variables using `^\/([\s\S]*)\/([dgimsuvy]*)$`.
- _**Updated**_: Keys are parsed and compiled once into a `{ regex, source }[]` array before the message scan instead of being re-parsed and re-compiled for each message; `lastIndex` is reset before each `.test()` call for `g`/`y` flagged regexes.
- This fixes all four reported defects:
  - matches in later scanned messages failing;
  - the opening `/` being retained as part of the pattern;
  - flagless regexes never being evaluated;
  - multiple regex keys overwriting `arg.keys[0]`.

## Impact

- Regex lorebook entries now activate correctly regardless of which scanned message contains the match.
- ~~Error behavior is preserved: keys that fail to parse or compile still return false, same as before.~~
  _**Updated**_: regex keys are validated up front, so any malformed key makes the entry inactive. See the verification comment below for details.
- Pure string/regex parsing change — model-agnostic, no platform-specific code, so behavior is identical across web, local, and node-hosted versions.

## Additional Notes

Manual verification on a local node-hosted build, with a test lorebook covering each reported defect:

- a match in the first scanned message (`/studio/i` — also covers the leading-slash defect);
- a match only in the last scanned message (the mutation defect);
- a flagless regex (`/flagless/`);
- multiple comma-separated regex keys where only the second key matches.

All four entries activate correctly on the fixed build (verified via the lore monitor and the actual prompt sent).

Minor edge case: an empty pattern key (`//`) previously was silently skipped and now compiles to an empty regex (matches everything). This follows the parsing approach proposed and approved in #1530.

<details>
<summary>Verification screenshots (lore monitor + actual request body)</summary>

All four test entries activate — TEST1 (match only in the last scanned message), TEST2 (`/studio/i`, the leading-slash case from the issue), TEST3 (flagless `/flagless/`), TEST4 (second of two comma-separated keys):

<img width="2558" height="1280" alt="1" src="https://github.com/user-attachments/assets/d11c751c-3cd2-4652-a694-2856668209e6" />
<img width="2558" height="1283" alt="2" src="https://github.com/user-attachments/assets/e8d401c5-da65-4a63-958f-e3d518f09c8c" />
<img width="1357" height="1285" alt="3" src="https://github.com/user-attachments/assets/e03d313c-49ad-4ded-a7c1-b3796c4fd3cd" />

</details>