### PR TITLE
feat: add OpenAI GPT-5.6 models

### DIFF
--- a/src/lib/Others/AllSeperateParameters.svelte
+++ b/src/lib/Others/AllSeperateParameters.svelte
@@ -40,7 +40,8 @@
         modelInfo.parameters.includes('reasoning_effort') ||
         modelInfo.parameters.includes('reasoning_effort_min_medium') ||
         modelInfo.parameters.includes('reasoning_effort_none') ||
-        modelInfo.parameters.includes('reasoning_effort_xhigh')
+        modelInfo.parameters.includes('reasoning_effort_xhigh') ||
+        modelInfo.parameters.includes('reasoning_effort_max')
     )
     let hasVerbosity = $derived(modelInfo.parameters.includes('verbosity'))
     const verbosityOptions = [
@@ -57,9 +58,13 @@
         { value: 1, label: 'Medium' },
         { value: 2, label: 'High' },
         ...(modelInfo.parameters.includes('reasoning_effort_xhigh') ? [{ value: 3, label: 'XHigh' }] : []),
+        ...(modelInfo.parameters.includes('reasoning_effort_max') ? [{ value: 4, label: 'Max' }] : []),
     ])
 
     $effect(() => {
+        if (!modelInfo.parameters.includes('reasoning_effort_max') && value.reasoning_effort === 4) {
+            value.reasoning_effort = modelInfo.parameters.includes('reasoning_effort_xhigh') ? 3 : 2
+        }
         if (!modelInfo.parameters.includes('reasoning_effort_xhigh') && value.reasoning_effort === 3) {
             value.reasoning_effort = 2
         }

--- a/src/ts/model/providers/openai.ts
+++ b/src/ts/model/providers/openai.ts
@@ -1,6 +1,74 @@
-import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, GPT5Parameters, GPT5NoneParameters, GPT5XHighParameters, GPT5ProParameters, type LLMModel } from '../types'
+import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, OpenAIParameters, GPT5Parameters, GPT5NoneParameters, GPT5XHighParameters, GPT5MaxParameters, GPT5ProParameters, type LLMModel } from '../types'
 
 export const OpenAIModels: LLMModel[] = [
+    // GPT-5.6
+    {
+        id: 'gpt-5.6',
+        internalID: 'gpt-5.6',
+        name: 'GPT 5.6',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5MaxParameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base,
+        recommended: true
+    },
+    {
+        id: 'gpt-5.6-sol',
+        internalID: 'gpt-5.6-sol',
+        name: 'GPT 5.6 Sol',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5MaxParameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base
+    },
+    {
+        id: 'gpt-5.6-terra',
+        internalID: 'gpt-5.6-terra',
+        name: 'GPT 5.6 Terra',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5MaxParameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base,
+        recommended: true
+    },
+    {
+        id: 'gpt-5.6-luna',
+        internalID: 'gpt-5.6-luna',
+        name: 'GPT 5.6 Luna',
+        provider: LLMProvider.OpenAI,
+        format: LLMFormat.OpenAICompatible,
+        flags: [
+            LLMFlags.hasStreaming,
+            LLMFlags.OAICompletionTokens,
+            LLMFlags.hasFullSystemPrompt,
+            LLMFlags.hasImageInput,
+            LLMFlags.DeveloperRole
+        ],
+        parameters: GPT5MaxParameters,
+        tokenizer: LLMTokenizer.tiktokenO200Base,
+        recommended: true
+    },
     // GPT-5.5 (April 2026)
     {
         id: 'gpt-5.5',

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -141,5 +141,6 @@ const GPT5BaseParameters:LLMParameter[] = ['temperature', 'top_p', 'frequency_pe
 export const GPT5Parameters:LLMParameter[] = [...GPT5BaseParameters]
 export const GPT5NoneParameters:LLMParameter[] = [...GPT5BaseParameters, 'reasoning_effort_none']
 export const GPT5XHighParameters:LLMParameter[] = [...GPT5NoneParameters, 'reasoning_effort_xhigh']
+export const GPT5MaxParameters:LLMParameter[] = [...GPT5XHighParameters, 'reasoning_effort_max']
 export const GPT5ProParameters:LLMParameter[] = [...GPT5BaseParameters, 'reasoning_effort_min_medium', 'reasoning_effort_xhigh']
 export const ClaudeParameters:LLMParameter[] = ['temperature', 'top_k', 'top_p']

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -14,6 +14,7 @@ export type LLMParameter =
     | 'reasoning_effort_min_medium'
     | 'reasoning_effort_none'
     | 'reasoning_effort_xhigh'
+    | 'reasoning_effort_max'
     | 'thinking_tokens'
     | 'verbosity'
 
@@ -23,6 +24,7 @@ const reasoningCapabilityParameters: LLMParameter[] = [
     'reasoning_effort_min_medium',
     'reasoning_effort_none',
     'reasoning_effort_xhigh',
+    'reasoning_effort_max',
 ]
 
 function isReasoningCapabilityParameter(parameter: LLMParameter): boolean {
@@ -148,8 +150,9 @@ export function applyParameters(
     const reasoningDisabledEffort = parameters.includes('reasoning_effort_none') ? 'none' : 'minimal'
     const reasoningMinEffort = parameters.includes('reasoning_effort_min_medium') ? 'medium' : 'low'
     const supportsXHighReasoning = parameters.includes('reasoning_effort_xhigh')
+    const supportsMaxReasoning = parameters.includes('reasoning_effort_max')
 
-    function getEffort(effort: number, disabledEffort: 'minimal' | 'none' = 'minimal', supportsXHigh = false, minEffort: 'low' | 'medium' = 'low') {
+    function getEffort(effort: number, disabledEffort: 'minimal' | 'none' = 'minimal', supportsXHigh = false, supportsMax = false, minEffort: 'low' | 'medium' = 'low') {
         switch (effort) {
             case -1: {
                 return disabledEffort
@@ -165,6 +168,9 @@ export function applyParameters(
             }
             case 3: {
                 return supportsXHigh ? 'xhigh' : 'high'
+            }
+            case 4: {
+                return supportsMax ? 'max' : supportsXHigh ? 'xhigh' : 'high'
             }
             default: {
                 return 'medium'
@@ -249,6 +255,7 @@ export function applyParameters(
                         sepParams.reasoning_effort,
                         reasoningDisabledEffort,
                         supportsXHighReasoning,
+                        supportsMaxReasoning,
                         reasoningMinEffort
                     )
                     break
@@ -311,6 +318,7 @@ export function applyParameters(
                     db.reasoningEffort,
                     reasoningDisabledEffort,
                     supportsXHighReasoning,
+                    supportsMaxReasoning,
                     reasoningMinEffort
                 )
                 break

--- a/src/ts/process/request/tests/shared.test.ts
+++ b/src/ts/process/request/tests/shared.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockDatabase = vi.hoisted(() => ({
+    seperateParametersEnabled: false,
+    seperateParametersByModel: false,
+    reasoningEffort: 0,
+}))
+
+vi.mock('src/ts/storage/database.svelte', () => ({
+    getDatabase: () => mockDatabase,
+}))
+
+import { applyParameters, type LLMParameter } from '../shared'
+
+const baseArgs = {
+    modelId: 'gpt-5.6',
+}
+
+describe('applyParameters reasoning effort capabilities', () => {
+    beforeEach(() => {
+        mockDatabase.reasoningEffort = 0
+    })
+
+    it('maps GPT-5.6 max effort for Responses API requests', () => {
+        mockDatabase.reasoningEffort = 4
+        const parameters: LLMParameter[] = [
+            'reasoning_effort',
+            'reasoning_effort_none',
+            'reasoning_effort_xhigh',
+            'reasoning_effort_max',
+        ]
+
+        expect(applyParameters({}, parameters, {
+            reasoning_effort: 'reasoning.effort',
+        }, 'model', baseArgs)).toEqual({
+            reasoning: {
+                effort: 'max',
+            },
+        })
+    })
+
+    it('falls back to xhigh when the selected model does not support max', () => {
+        mockDatabase.reasoningEffort = 4
+        const parameters: LLMParameter[] = [
+            'reasoning_effort',
+            'reasoning_effort_none',
+            'reasoning_effort_xhigh',
+        ]
+
+        expect(applyParameters({}, parameters, {}, 'model', baseArgs)).toEqual({
+            reasoning_effort: 'xhigh',
+        })
+    })
+})

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -274,7 +274,8 @@ export const modelSpecificParameterItems: SettingItem[] = [
             ctx.modelInfo.parameters.includes('reasoning_effort') ||
             ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') ||
             ctx.modelInfo.parameters.includes('reasoning_effort_none') ||
-            ctx.modelInfo.parameters.includes('reasoning_effort_xhigh'),
+            ctx.modelInfo.parameters.includes('reasoning_effort_xhigh') ||
+            ctx.modelInfo.parameters.includes('reasoning_effort_max'),
         options: {
             segmentOptions: [
                 { value: -1, label: 'Minimal', condition: (ctx) => !ctx.modelInfo.parameters.includes('reasoning_effort_none') && !ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') },
@@ -283,9 +284,10 @@ export const modelSpecificParameterItems: SettingItem[] = [
                 { value: 1, label: 'Medium' },
                 { value: 2, label: 'High' },
                 { value: 3, label: 'XHigh', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_xhigh') },
+                { value: 4, label: 'Max', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_max') },
             ]
         },
-        keywords: ['reasoning', 'effort', 'xhigh'],
+        keywords: ['reasoning', 'effort', 'xhigh', 'max'],
     },
     {
         id: 'params.verbosity',


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This adds the OpenAI GPT-5.6 family to the model selector, including the `gpt-5.6` alias and the Sol, Terra, and Luna tiers. It also exposes GPT-5.6's `max` reasoning effort in both the standard and separate-parameter settings.

## Related Issues

None.

## Changes

The new model entries reuse the existing OpenAI request paths, capability flags, tokenizer, and automatically generated Responses API variants. Reasoning parameter handling now maps the new `max` setting to the correct Chat Completions and Responses API request shapes, while safely falling back to `xhigh` when switching to a model that does not support `max`. Focused tests cover the Responses API mapping and the fallback behavior.

## Impact

Users can select the GPT-5.6 alias or a specific GPT-5.6 tier without defining a custom model. Existing OpenAI models keep their current reasoning controls and request behavior.

## Additional Notes

Validated with `pnpm exec vitest run src/ts/process/request/tests/shared.test.ts`, `pnpm check`, and `git diff --check`.
