### PR TITLE
fix: expand node storage write errors

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -1,5 +1,7 @@
 const express = require('express');
 const app = express();
+const requestBodyLimit = '100mb';
+const requestBodyLimitLabel = '100 MiB';
 if (process.env.TRUST_PROXY) {
     app.set('trust proxy', Number(process.env.TRUST_PROXY) || process.env.TRUST_PROXY);
 }
@@ -13,9 +15,24 @@ const crypto = require('crypto')
 const rateLimit = require('express-rate-limit');
 const { WebSocketServer } = require('ws');
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false}));
-app.use(express.json({ limit: '100mb' }));
-app.use(express.raw({ type: 'application/octet-stream', limit: '100mb' }));
-app.use(express.text({ limit: '100mb' }));
+app.use(express.json({ limit: requestBodyLimit }));
+app.use(express.raw({ type: 'application/octet-stream', limit: requestBodyLimit }));
+app.use(express.text({ limit: requestBodyLimit }));
+app.use((error, req, res, next) => {
+    if (error?.type === 'entity.too.large' && req.path === '/api/write' && req.is('application/octet-stream')) {
+        console.error('[Storage] Rejected oversized request:', {
+            size: error.length,
+            limit: error.limit,
+        });
+        res.status(413).send({
+            error: 'Storage payload is too large',
+            code: 'PAYLOAD_TOO_LARGE',
+            message: `Storage writes are limited to ${requestBodyLimitLabel}.`,
+        });
+        return;
+    }
+    next(error);
+});
 const {pipeline} = require('stream/promises')
 const https = require('https');
 const sslPath = path.join(process.cwd(), 'server/node/ssl/certificate');
@@ -1280,8 +1297,9 @@ app.post('/api/write', authenticatedRouteLimiter, async (req, res) => {
         return;
     }
 
+    const storageFilePath = path.join(savePath, filePath);
     try {
-        await fs.writeFile(path.join(savePath, filePath), fileContent);
+        await fs.writeFile(storageFilePath, fileContent);
         res.send({
             success: true
         });
@@ -1289,6 +1307,8 @@ app.post('/api/write', authenticatedRouteLimiter, async (req, res) => {
         const storageKey = Buffer.from(filePath, 'hex').toString('utf-8');
         const errorCode = typeof error?.code === 'string' ? error.code : 'WRITE_FAILED';
         const errorMessage = error instanceof Error ? error.message : String(error);
+        const relativeStoragePath = path.relative(process.cwd(), storageFilePath) || path.basename(storageFilePath);
+        const clientErrorMessage = errorMessage.split(storageFilePath).join(`.${path.sep}${relativeStoragePath}`);
         const status = errorCode === 'ENOSPC' || errorCode === 'EDQUOT' ? 507 : 500;
 
         console.error('[Storage] Failed to write item:', {
@@ -1300,7 +1320,7 @@ app.post('/api/write', authenticatedRouteLimiter, async (req, res) => {
         res.status(status).send({
             error: 'Failed to write storage item',
             code: errorCode,
-            message: errorMessage,
+            message: clientErrorMessage,
         });
     }
 });

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -1261,7 +1261,7 @@ app.get('/api/list', authenticatedRouteLimiter, async (req, res, next) => {
     }
 });
 
-app.post('/api/write', authenticatedRouteLimiter, async (req, res, next) => {
+app.post('/api/write', authenticatedRouteLimiter, async (req, res) => {
     if(!await checkAuth(req, res)){
         return;
     }
@@ -1286,7 +1286,22 @@ app.post('/api/write', authenticatedRouteLimiter, async (req, res, next) => {
             success: true
         });
     } catch (error) {
-        next(error);
+        const storageKey = Buffer.from(filePath, 'hex').toString('utf-8');
+        const errorCode = typeof error?.code === 'string' ? error.code : 'WRITE_FAILED';
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const status = errorCode === 'ENOSPC' || errorCode === 'EDQUOT' ? 507 : 500;
+
+        console.error('[Storage] Failed to write item:', {
+            key: storageKey,
+            size: fileContent.byteLength,
+            code: errorCode,
+            message: errorMessage,
+        });
+        res.status(status).send({
+            error: 'Failed to write storage item',
+            code: errorCode,
+            message: errorMessage,
+        });
     }
 });
 

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -1290,21 +1290,30 @@ app.post('/api/write', authenticatedRouteLimiter, async (req, res) => {
         });
         return;
     }
-    if(!isHex(filePath)){
+    const normalizedFilePath = filePath.trim();
+    if(!isHex(normalizedFilePath)){
         res.status(400).send({
             error:'Invaild Path'
         });
         return;
     }
 
-    const storageFilePath = path.join(savePath, filePath);
+    const normalizedSavePath = path.resolve(savePath);
+    const storageFilePath = path.resolve(normalizedSavePath, normalizedFilePath);
+    if (!storageFilePath.startsWith(`${normalizedSavePath}${path.sep}`)) {
+        res.status(400).send({
+            error:'Invaild Path'
+        });
+        return;
+    }
+
     try {
         await fs.writeFile(storageFilePath, fileContent);
         res.send({
             success: true
         });
     } catch (error) {
-        const storageKey = Buffer.from(filePath, 'hex').toString('utf-8');
+        const storageKey = Buffer.from(normalizedFilePath, 'hex').toString('utf-8');
         const errorCode = typeof error?.code === 'string' ? error.code : 'WRITE_FAILED';
         const errorMessage = error instanceof Error ? error.message : String(error);
         const relativeStoragePath = path.relative(process.cwd(), storageFilePath) || path.basename(storageFilePath);

--- a/src/ts/storage/nodeStorage.test.ts
+++ b/src/ts/storage/nodeStorage.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('src/lang', () => ({
+    language: {}
+}))
+
+vi.mock('../alert', () => ({
+    alertError: vi.fn(),
+    alertInput: vi.fn(),
+    waitAlert: vi.fn()
+}))
+
+vi.mock('../util', () => ({
+    base64url: vi.fn(),
+    getKeypairStore: vi.fn(),
+    saveKeypairStore: vi.fn()
+}))
+
+import { NodeStorage } from './nodeStorage'
+
+describe('NodeStorage.setItem', () => {
+    const fetchMock = vi.fn()
+    let storage:NodeStorage
+
+    beforeEach(() => {
+        fetchMock.mockReset()
+        vi.stubGlobal('fetch', fetchMock)
+        storage = new NodeStorage()
+        vi.spyOn(storage as any, 'checkAuth').mockResolvedValue(undefined)
+        vi.spyOn(storage, 'createAuth').mockResolvedValue('test-auth')
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.restoreAllMocks()
+    })
+
+    it('includes storage context and JSON server details for HTTP errors', async () => {
+        fetchMock.mockResolvedValue(new Response(JSON.stringify({
+            error: 'Failed to write storage item',
+            code: 'ENOSPC',
+            message: 'no space left on device'
+        }), {
+            status: 507,
+            statusText: 'Insufficient Storage',
+            headers: {
+                'content-type': 'application/json'
+            }
+        }))
+
+        await expect(storage.setItem('database/database.bin', new Uint8Array(2048))).rejects.toThrow(
+            'Node storage setItem failed.\n' +
+            'Key: database/database.bin\n' +
+            'Size: 2048 bytes (2.00 KiB)\n' +
+            'HTTP: 507 Insufficient Storage\n' +
+            'Server: Failed to write storage item | ENOSPC | no space left on device'
+        )
+    })
+
+    it('extracts useful text from an HTML error response', async () => {
+        fetchMock.mockResolvedValue(new Response(
+            '<!DOCTYPE html><html><body><pre>PayloadTooLargeError: request entity too large<br>at parser</pre></body></html>',
+            {
+                status: 413,
+                statusText: 'Payload Too Large',
+                headers: {
+                    'content-type': 'text/html'
+                }
+            }
+        ))
+
+        await expect(storage.setItem('assets/example', new Uint8Array(3))).rejects.toThrow(
+            'HTTP: 413 Payload Too Large\nServer: PayloadTooLargeError: request entity too large\nat parser'
+        )
+    })
+
+    it('distinguishes network failures from HTTP failures', async () => {
+        fetchMock.mockRejectedValue(new TypeError('Failed to fetch'))
+
+        await expect(storage.setItem('database/database.bin', new Uint8Array(3))).rejects.toThrow(
+            'Node storage setItem request failed.\n' +
+            'Key: database/database.bin\n' +
+            'Size: 3 bytes\n' +
+            'Cause: Failed to fetch'
+        )
+    })
+})

--- a/src/ts/storage/nodeStorage.test.ts
+++ b/src/ts/storage/nodeStorage.test.ts
@@ -39,7 +39,7 @@ describe('NodeStorage.setItem', () => {
         fetchMock.mockResolvedValue(new Response(JSON.stringify({
             error: 'Failed to write storage item',
             code: 'ENOSPC',
-            message: 'no space left on device'
+            message: "ENOSPC: no space left on device, open './save/64617461626173652f64617461626173652e62696e'"
         }), {
             status: 507,
             statusText: 'Insufficient Storage',
@@ -53,7 +53,27 @@ describe('NodeStorage.setItem', () => {
             'Key: database/database.bin\n' +
             'Size: 2048 bytes (2.00 KiB)\n' +
             'HTTP: 507 Insufficient Storage\n' +
-            'Server: Failed to write storage item | ENOSPC | no space left on device'
+            'Server: Failed to write storage item | ENOSPC | ' +
+            "ENOSPC: no space left on device, open './save/64617461626173652f64617461626173652e62696e'"
+        )
+    })
+
+    it('includes structured server details for payload limit errors', async () => {
+        fetchMock.mockResolvedValue(new Response(JSON.stringify({
+            error: 'Storage payload is too large',
+            code: 'PAYLOAD_TOO_LARGE',
+            message: 'Storage writes are limited to 100 MiB.'
+        }), {
+            status: 413,
+            statusText: 'Payload Too Large',
+            headers: {
+                'content-type': 'application/json'
+            }
+        }))
+
+        await expect(storage.setItem('assets/example', new Uint8Array(3))).rejects.toThrow(
+            'HTTP: 413 Payload Too Large\n' +
+            'Server: Storage payload is too large | PAYLOAD_TOO_LARGE | Storage writes are limited to 100 MiB.'
         )
     })
 

--- a/src/ts/storage/nodeStorage.ts
+++ b/src/ts/storage/nodeStorage.ts
@@ -2,6 +2,88 @@ import { language } from "src/lang"
 import { alertError, alertInput, waitAlert } from "../alert"
 import { base64url, getKeypairStore, saveKeypairStore } from "../util"
 
+const MAX_STORAGE_ERROR_DETAIL_LENGTH = 2000
+
+function formatStorageValueSize(byteLength:number) {
+    if(byteLength < 1024){
+        return `${byteLength} bytes`
+    }
+
+    const units = ['KiB', 'MiB', 'GiB']
+    let size = byteLength
+    let unitIndex = -1
+    do {
+        size /= 1024
+        unitIndex += 1
+    } while(size >= 1024 && unitIndex < units.length - 1)
+
+    return `${byteLength} bytes (${size.toFixed(2)} ${units[unitIndex]})`
+}
+
+function formatUnknownError(error:unknown) {
+    if(error instanceof Error){
+        return error.message
+    }
+    if(typeof error === 'string'){
+        return error
+    }
+    try {
+        return JSON.stringify(error) ?? `${error}`
+    } catch {
+        return `${error}`
+    }
+}
+
+function normalizeStorageErrorDetail(detail:string) {
+    const normalized = detail
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&')
+        .replace(/[ \t]+/g, ' ')
+        .replace(/\n\s+/g, '\n')
+        .trim()
+
+    if(normalized.length <= MAX_STORAGE_ERROR_DETAIL_LENGTH){
+        return normalized
+    }
+    return normalized.slice(0, MAX_STORAGE_ERROR_DETAIL_LENGTH) + '...'
+}
+
+async function getStorageResponseErrorDetail(response:Response) {
+    let responseText = ''
+    try {
+        responseText = await response.text()
+    } catch (error) {
+        return `Could not read the server response: ${formatUnknownError(error)}`
+    }
+
+    if(!responseText.trim()){
+        return ''
+    }
+
+    try {
+        const body = JSON.parse(responseText)
+        if(body && typeof body === 'object'){
+            const details = [body.error, body.code, body.message, body.details]
+                .filter((value, index, values) => value != null && value !== '' && values.indexOf(value) === index)
+                .map((value) => formatUnknownError(value))
+            if(details.length > 0){
+                return normalizeStorageErrorDetail(details.join(' | '))
+            }
+        }
+    } catch {}
+
+    return normalizeStorageErrorDetail(responseText)
+}
+
+function getSetItemContext(key:string, byteLength:number) {
+    return `Key: ${key}\nSize: ${formatStorageValueSize(byteLength)}`
+}
+
 
 export class NodeStorage{
 
@@ -71,21 +153,39 @@ export class NodeStorage{
 
     async setItem(key:string, value:Uint8Array) {
         await this.checkAuth()
-        const da = await fetch('/api/write', {
-            method: "POST",
-            body: value as any,
-            headers: {
-                'content-type': 'application/octet-stream',
-                'file-path': Buffer.from(key, 'utf-8').toString('hex'),
-                'risu-auth': await this.createAuth()
-            }
-        })
-        if(da.status < 200 || da.status >= 300){
-            throw "setItem Error"
+        const context = getSetItemContext(key, value.byteLength)
+        let response:Response
+        try {
+            response = await fetch('/api/write', {
+                method: "POST",
+                body: value as any,
+                headers: {
+                    'content-type': 'application/octet-stream',
+                    'file-path': Buffer.from(key, 'utf-8').toString('hex'),
+                    'risu-auth': await this.createAuth()
+                }
+            })
+        } catch (error) {
+            throw new Error(`Node storage setItem request failed.\n${context}\nCause: ${formatUnknownError(error)}`)
         }
-        const data = await da.json()
+
+        if(!response.ok){
+            const responseDetail = await getStorageResponseErrorDetail(response)
+            const httpStatus = `${response.status}${response.statusText ? ` ${response.statusText}` : ''}`
+            throw new Error(
+                `Node storage setItem failed.\n${context}\nHTTP: ${httpStatus}` +
+                (responseDetail ? `\nServer: ${responseDetail}` : '')
+            )
+        }
+
+        let data:any
+        try {
+            data = await response.json()
+        } catch (error) {
+            throw new Error(`Node storage setItem received an invalid response.\n${context}\nCause: ${formatUnknownError(error)}`)
+        }
         if(data.error){
-            throw data.error
+            throw new Error(`Node storage setItem failed.\n${context}\nServer: ${formatUnknownError(data.error)}`)
         }
     }
     async getItem(key:string):Promise<Buffer> {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Improve Node storage write diagnostics so failed `setItem` calls expose actionable context instead of always reporting only `setItem Error`.

## Related Issues

None.

## Changes

The Node storage client now reports the logical storage key, payload size, HTTP status, and a sanitized, length-limited server response. It parses structured JSON errors, extracts useful text from HTML responses as a fallback, and distinguishes transport failures from HTTP failures.

The Node server now returns structured write errors with the filesystem error code and message. It logs the affected logical key, payload size, and full server-side error, while paths returned to the client are converted from absolute filesystem paths to relative `./save/...` paths.

Disk-full and quota errors return HTTP 507. Oversized `/api/write` payloads now return a structured HTTP 413 response with the `PAYLOAD_TOO_LARGE` code and the 100 MiB storage limit instead of relying on Express's HTML error page. Other write failures return HTTP 500.

Focused tests cover structured disk errors with relative paths, structured payload-limit errors, HTML error fallback behavior, and network failures.

## Impact

Successful writes and the existing save retry behavior are unchanged. When a write fails, users and server operators can distinguish request-size limits, network failures, insufficient disk space, quota exhaustion, and file permission errors without logging stored payload contents or authentication tokens. Absolute server filesystem paths are no longer exposed in client-facing write errors.

## Additional Notes

Validated with:

- `pnpm exec vitest run src/ts/storage/nodeStorage.test.ts` (4 tests)
- `pnpm check`
- `node --check server/node/server.cjs`
- `git diff --check`
- A live Node-server request exceeding 100 MiB, which returned the expected structured HTTP 413 response
