### PR TITLE
fix: restore SafeMutationObserver payloads across the iframe bridge

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -1462,13 +1462,13 @@ Add clear comments and metadata:
 
     // Monitor DOM changes
     let changeCount = 0;
-    const observer = Risuai.createMutationObserver(async (mutations) => {
-      changeCount += mutations.length;
+    const observer = await Risuai.createMutationObserver(async (mutations) => {
+      changeCount += await mutations.length();
       await indicator.setTextContent(`Changes: ${changeCount}`);
     });
 
     if (body) {
-      observer.observe(body, {
+      await observer.observe(body, {
         childList: true,
         subtree: true,
         attributes: false

--- a/plugins.md
+++ b/plugins.md
@@ -512,7 +512,7 @@ await observer.observe(body, {
 });
 ```
 
-Note: `getAddedNodes()`/`getRemovedNodes()` contain HTML element nodes only.
+Note: `getAddedNodes()`/`getRemovedNodes()` contain HTML element nodes only; text nodes and SVG elements are excluded.
 
 ### SafeClassArray
 

--- a/plugins.md
+++ b/plugins.md
@@ -493,6 +493,12 @@ const observer = await Risuai.createMutationObserver(async (mutations) => {
     for (const node of addedNodes) {
       console.log(`Node added: ${await node.nodeName()}`);
     }
+
+    // getRemovedNodes() returns SafeClassArray<SafeElement>
+    const removedNodes = await Risuai.unwarpSafeArray(await mutation.getRemovedNodes());
+    for (const node of removedNodes) {
+      console.log(`Node removed: ${await node.nodeName()}`);
+    }
   }
 });
 
@@ -505,6 +511,8 @@ await observer.observe(body, {
   attributes: true
 });
 ```
+
+Note: `getAddedNodes()`/`getRemovedNodes()` contain HTML element nodes only.
 
 ### SafeClassArray
 

--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -455,6 +455,7 @@ export class SandboxHost {
     private csp = `connect-src 'none'; script-src 'nonce-${this.nonce}' 'wasm-unsafe-eval'; frame-src 'none'; object-src 'none'; style-src * 'unsafe-inline'; default-src 'none'; img-src * data: blob:; font-src * data: blob:; media-src * data: blob:; base-uri 'none';`;
 
     private instanceRegistry = new Map<string, any>();
+    private refIdCounter = 0;
     private abortControllers = new Map<string, AbortController>();
     private messageHandlerRef: ((event: MessageEvent) => void) | null = null;
     private callbackWrapperCache = new Map<string, Function>();
@@ -533,7 +534,7 @@ export class SandboxHost {
             if (Array.isArray(val)) return val;
 
 
-            const id = 'ref_' + Math.random().toString(36).substring(2);
+            const id = 'ref_' + (++this.refIdCounter);
             this.instanceRegistry.set(id, val);
             return { __type: 'REMOTE_REF', id } as RemoteRef;
         }

--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -333,7 +333,7 @@ await (async function() {
                         if (a.aborted) { controller.abort(); }
                         return controller.signal;
                     }
-                    return a;
+                    return deserializeResult(a);
                 });
                 const result = await fn(...deserializedArgs);
                 response.result = result;
@@ -584,7 +584,7 @@ export class SandboxHost {
                                 }
                                 return ref;
                             }
-                            return arg;
+                            return this.serialize(arg);
                         });
 
                         const message = {

--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -40,7 +40,14 @@ await (async function() {
     const pendingRequests = new Map();
     const callbackRegistry = new Map();
     const callbackIdByFunction = new WeakMap();
-    const proxyRefRegistry = new Map();
+    const proxyRefRegistry = new WeakMap();
+    const releaseRegistry = new FinalizationRegistry((id) => {
+        try {
+            send({ type: 'RELEASE_INSTANCE', id: id });
+        } catch (_) {
+            // Frame is tearing down; host clears its registry anyway
+        }
+    });
     const abortControllers = new Map();
 
     function serializeArg(arg) {
@@ -89,15 +96,25 @@ await (async function() {
                     if (prop === 'release') {
                         return () => send({ type: 'RELEASE_INSTANCE', id: val.id });
                     }
-                    return (...args) => sendRequest('CALL_INSTANCE', {
-                        id: val.id,
-                        method: prop,
-                        args: args
-                    });
+                    return (...args) => {
+                        // Extracted methods must pin their owning proxy:
+                        // without this reference the proxy could be
+                        // collected (and auto-released) while this
+                        // function is still callable.
+                        void proxy;
+                        return sendRequest('CALL_INSTANCE', {
+                            id: val.id,
+                            method: prop,
+                            args: args
+                        });
+                    };
                 }
             });
             // Store the mapping so we can serialize it back
             proxyRefRegistry.set(proxy, val.id);
+            // Held value must be the id string, never the proxy itself:
+            // the registry holds it strongly until cleanup fires.
+            releaseRegistry.register(proxy, val.id);
             return proxy;
         }
         if (val && typeof val === 'object' && val.__type === 'CALLBACK_STREAMS') {

--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -624,6 +624,7 @@ export class SandboxHost {
                 if (instance) {
                     return instance;
                 }
+                throw new Error("Instance not found or released");
             }
             if (arg && typeof arg === 'object' && arg.constructor === Object) {
                 let out: any = null;

--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -11,6 +11,7 @@ interface RpcMessage {
     type: MsgType;
     reqId?: string;
     id?: string;
+    ids?: string[];
     method?: string;
     args?: any[];
     result?: any;
@@ -41,12 +42,20 @@ await (async function() {
     const callbackRegistry = new Map();
     const callbackIdByFunction = new WeakMap();
     const proxyRefRegistry = new WeakMap();
-    const releaseRegistry = new FinalizationRegistry((id) => {
+    const releaseBuffer = [];
+    const flushReleases = () => {
+        if (releaseBuffer.length === 0) return;
+        const ids = releaseBuffer.splice(0);
         try {
-            send({ type: 'RELEASE_INSTANCE', id: id });
+            send({ type: 'RELEASE_INSTANCE', ids: ids });
         } catch (_) {
             // Frame is tearing down; host clears its registry anyway
         }
+    };
+    const releaseRegistry = new FinalizationRegistry((id) => {
+        // Schedule one flush per burst: first push arms the microtask.
+        if (releaseBuffer.length === 0) queueMicrotask(flushReleases);
+        releaseBuffer.push(id);
     });
     const abortControllers = new Map();
 
@@ -838,7 +847,8 @@ export class SandboxHost {
 
 
             if (data.type === 'RELEASE_INSTANCE') {
-                this.instanceRegistry.delete(data.id!);
+                if (data.id) this.instanceRegistry.delete(data.id!);
+                if (Array.isArray(data.ids)) for (const id of data.ids) this.instanceRegistry.delete(id);
                 return;
             }
 

--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -965,6 +965,8 @@ interface SafeMutationRecord {
     getTarget(): Promise<SafeElement>;
     /** Added nodes in mutation */
     getAddedNodes(): Promise<SafeClassArray<SafeElement>>;
+    /** Removed nodes in mutation */
+    getRemovedNodes(): Promise<SafeClassArray<SafeElement>>;
 }
 
 /**

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -391,6 +391,7 @@ type SafeMutationRecordObject = {
     type: string;
     target: SafeElement;
     addedNodes: SafeElement[];
+    removedNodes: SafeElement[];
 }
 
 class SafeClassArray<T> {
@@ -415,10 +416,12 @@ class SafeMutationRecord{
     #type: string;
     #target: SafeElement;
     #addedNodes: SafeClassArray<SafeElement>;
-    constructor(type: string, target: SafeElement, addedNodes: SafeElement[]) {
+    #removedNodes: SafeClassArray<SafeElement>;
+    constructor(type: string, target: SafeElement, addedNodes: SafeElement[], removedNodes: SafeElement[]) {
         this.#type = type;
         this.#target = target;
         this.#addedNodes = new SafeClassArray<SafeElement>(addedNodes);
+        this.#removedNodes = new SafeClassArray<SafeElement>(removedNodes);
     }
     getType(): string {
         return this.#type;
@@ -428,6 +431,9 @@ class SafeMutationRecord{
     }
     getAddedNodes(): SafeClassArray<SafeElement> {
         return this.#addedNodes;
+    }
+    getRemovedNodes(): SafeClassArray<SafeElement> {
+        return this.#removedNodes;
     }
 }
 
@@ -464,7 +470,8 @@ class SafeMutationObserver {
                 safeClassed.push(new SafeMutationRecord(
                     record.type,
                     record.target,
-                    record.addedNodes
+                    record.addedNodes,
+                    record.removedNodes,
                 ));
             }
             callback(safeClassed);

--- a/src/ts/plugins/migrationGuide.md
+++ b/src/ts/plugins/migrationGuide.md
@@ -391,26 +391,35 @@ Monitor DOM changes safely:
 
 ```javascript
 // Create mutation observer
-const observer = risuai.createMutationObserver((mutations) => {
-  mutations.forEach(mutation => {
-    console.log('Type:', mutation.type)
-    console.log('Target:', mutation.target)
-    console.log('Added nodes:', mutation.addedNodes)
-  })
+// The callback receives a SafeClassArray<SafeMutationRecord>
+const observer = await risuai.createMutationObserver(async (mutations) => {
+  const records = await risuai.unwarpSafeArray(mutations)
+  for (const mutation of records) {
+    // Records are RPC proxies: read them with async getter methods
+    console.log('Type:', await mutation.getType())
+    console.log('Target:', await mutation.getTarget())
+
+    const addedNodes = await risuai.unwarpSafeArray(await mutation.getAddedNodes())
+    const removedNodes = await risuai.unwarpSafeArray(await mutation.getRemovedNodes())
+    console.log('Added:', addedNodes.length, 'Removed:', removedNodes.length)
+  }
 })
 
 // Start observing
-observer.observe(element, {
+await observer.observe(element, {
   childList: true,
   subtree: true,
   attributes: true
 })
 ```
 
-**Mutation Record Properties:**
-- `type`: Type of mutation ('attributes', 'childList', etc.)
-- `target`: SafeElement that was modified
-- `addedNodes`: Array of added SafeElement nodes
+**Mutation Record Methods:**
+- `getType()`: Type of mutation ('attributes', 'childList', etc.)
+- `getTarget()`: SafeElement that was modified
+- `getAddedNodes()`: `SafeClassArray<SafeElement>` of added nodes
+- `getRemovedNodes()`: `SafeClassArray<SafeElement>` of removed nodes
+
+Note: `getAddedNodes()`/`getRemovedNodes()` contain HTML element nodes only.
 
 #### UI Registration
 

--- a/src/ts/plugins/migrationGuide.md
+++ b/src/ts/plugins/migrationGuide.md
@@ -419,7 +419,7 @@ await observer.observe(element, {
 - `getAddedNodes()`: `SafeClassArray<SafeElement>` of added nodes
 - `getRemovedNodes()`: `SafeClassArray<SafeElement>` of removed nodes
 
-Note: `getAddedNodes()`/`getRemovedNodes()` contain HTML element nodes only.
+Note: `getAddedNodes()`/`getRemovedNodes()` contain HTML element nodes only; text nodes and SVG elements are excluded.
 
 #### UI Registration
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

---

## Summary

The callback passed to `createMutationObserver` receives a bare `{__classType: 'REMOTE_REQUIRED'}` shell instead of the documented `SafeClassArray<SafeMutationRecord>`, so the example in plugins.md fails with `length is not a function`. Cause: the `INVOKE_CALLBACK` path was missing the REMOTE_REF conversion (both directions) that the request/response path already has.

Also wires up `removedNodes`: the observer already computes it (`removedNodes: elementMapHelper(mutation.removedNodes)`) but never passes it into `SafeMutationRecord`, so the value was silently dropped.


## Related Issues

None.

## Changes

- `factory.ts`: serialize `INVOKE_CALLBACK` args on the host side, deserialize in the guest bridge (2 lines)
- `v3.svelte.ts`, `risuai.d.ts`: add `getRemovedNodes()`, symmetric with `getAddedNodes()`
- `plugins.md`, `migrationGuide.md`: document `getRemovedNodes()`; the migration guide example still used the old plain-object API (updated to the current async-getter API)

## Impact

- Verified with a test plugin: all four getters return correct payloads across childList add/remove, attribute, and text mutations.
- The bug lives in the argument path shared by all plugin callbacks, so the fix applies to all of them, not just mutation observers. `serialize()` passes previously-working args (plain data, `AbortSignal`) through unchanged; verified with a published v3 provider plugin: generation and mid-generation abort still work.

## Additional Notes

Out of scope, noted while working on this:

- `attributeName` / `oldValue` not exposed; `disconnect()` is pending in #1307
~~- `instanceRegistry` entries are freed only by `release()` or iframe teardown, so a busy observer accumulates them. Will address in a separate PR.~~ **Update:** per review discussion, registry lifetime
  management now lands in this PR: guest-side `WeakMap` +
  `FinalizationRegistry` auto-release with batched messages, monotonic ids,
  and fail-closed handling of released refs. Details and measurements in the
  review thread below.