### PR TITLE
fix: prevent mobile swipe navigation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -36,6 +36,7 @@
     import IrisModal from './lib/Others/IrisModal.svelte';
     import Legal from './lib/Others/Legal.svelte';
     import CustomSidebarConfig from './lib/Others/CustomSidebarConfig.svelte';
+    import { isIOS } from './ts/platform';
 
 
   
@@ -44,11 +45,23 @@
     let aprilFools = $state(new Date().getMonth() === 3 && new Date().getDate() === 1)
     let aprilFoolsPage = $state(0)
     let keepingSessionAlive = $state(false)
+
+    function preventIOSHistorySwipe(event: TouchEvent) {
+        if (!isIOS() || event.touches.length !== 1) {
+            return
+        }
+
+        const edgeWidth = 24
+        const touchX = event.touches[0].clientX
+        if (touchX <= edgeWidth || touchX >= window.innerWidth - edgeWidth) {
+            event.preventDefault()
+        }
+    }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<main class="flex bg-bg w-full h-full max-w-100vw text-textcolor" ondragover={(e) => {
+<main class="flex bg-bg w-full h-full max-w-100vw text-textcolor" ontouchstart={preventIOSHistorySwipe} ondragover={(e) => {
     e.preventDefault()
     e.dataTransfer.dropEffect = 'link'
 }} ondrop={async (e) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -244,6 +244,7 @@ body {
 html,
 body {
   height: var(--risu-height-size);
+  overscroll-behavior-x: none;
 }
 
 .chattext p {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Prevent accidental browser history navigation when users swipe horizontally on mobile.

## Related Issues

None.

## Changes

The root document now blocks horizontal overscroll from being handed off to browser navigation. Because iOS Safari does not consistently honor that CSS behavior for history gestures, touches beginning within a narrow 24px strip at either screen edge are also prevented on iOS.

## Impact

Mobile users are less likely to leave Risuai accidentally while scrolling or swiping. Normal vertical scrolling and horizontal scrolling that begins away from the screen edges are unchanged.

## Additional Notes

Validated with `pnpm check` and `git diff --check`. No physical-device test was performed.
