### PR TITLE
fix: evaluate CBS in postEndInnerFormat before sending

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -697,7 +697,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     if(usingPromptTemplate && DBState.db.promptSettings.postEndInnerFormat){
                         await tokenizeChatArray([{
                             role: 'system',
-                            content: DBState.db.promptSettings.postEndInnerFormat
+                            content: risuChatParser(DBState.db.promptSettings.postEndInnerFormat, {chara: currentChar})
                         }])
                     }
                     break
@@ -1297,7 +1297,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     if(usingPromptTemplate && DBState.db.promptSettings.postEndInnerFormat){
                         pushPrompts([{
                             role: 'system',
-                            content: DBState.db.promptSettings.postEndInnerFormat
+                            content: risuChatParser(DBState.db.promptSettings.postEndInnerFormat, {chara: currentChar})
                         }])
                     }
                     break


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`promptSettings.postEndInnerFormat` ("Post End" in prompt settings) was the only innerFormat-style field sent to the model **without CBS evaluation**. CBS such as `{{char}}`, `{{user}}`, `{{bot}}`, `{{persona}}`, `{{description}}`, `{{getvar}}` and `{{#if}}` blocks reached the model as literal text instead of being substituted/evaluated.

Every sibling field is parsed — the persona/description/authornote card `innerFormat`s go through `risuChatParser` in both the token-counting pass and the output pass — so this looks like an omission rather than a design decision: the field was added raw in a3b90e8b (Dec 2023) and never changed since. This PR applies `risuChatParser` to it, following the same principle as #1490 (evaluate CBS before counting; `runVar` stays at its default `false`, so no side effects run).

## Related Issues

None. (Follows up on the "let's implement it in more areas" direction from the #1490 review.)

## Changes

- `src/ts/process/index.svelte.ts`: wrap `DBState.db.promptSettings.postEndInnerFormat` with `risuChatParser(..., {chara: currentChar})` in
  - the token-counting pass (`case 'postEverything'`), and
  - the output pass (`case 'postEverything'`).

Both call sites are kept identical so the token estimate used for cutoff matches the text that is actually sent — the same count/output consistency #1490 established for lorebooks.

## Impact

For presets that use Post End as plain text or with substitution macros, this is a pure fix: `{{char}}`, `{{user}}`, `{{bot}}`, `{{persona}}`, `{{description}}`, `{{scenario}}`, `{{personality}}` etc. now resolve, and `{{#if}}` blocks are evaluated, consistent with every other innerFormat field.

**Behavior change for presets that relied on the field being sent verbatim.** Since this field sits at the very end of the prompt, it may be used for output-format instructions that intentionally contain literal CBS the model is supposed to reproduce. After this change:

- **Now substituted/evaluated (breaks literal usage):**
  - Dice/random macros — `{{roll}}`, `{{rollp}}`, `{{dice}}`, `{{random}}`, `{{pick}}`, `{{randint}}` — evaluate at prompt-build time instead of reaching the model as text (e.g. an instruction like "include `{{roll::d20}}` in your reply" would pre-roll).
  - Asset/media macros — `{{img}}`, `{{image}}`, `{{asset}}`, `{{emotion}}`, `{{audio}}`, `{{bg}}`, `{{bgm}}`, `{{video}}`, `{{inlay}}` — resolve against character assets at build time (e.g. "output `{{img::happy}}` when happy" would resolve/strip the tag).
  - Value macros — `{{getvar}}`, `{{time}}`, `{{date}}`, `{{calc}}`, `{{lastmessage}}` etc. — replaced with their current values (e.g. a format example like "show `{{getvar::hp}}` in the status line" becomes the current value).
  - `{{#if}} ... {{/}}` blocks — evaluated; inactive branches are removed.
- **Not affected:**
  - Unregistered macros (e.g. `{{status_window}}`) pass through unchanged — the parser leaves unknown CBS as-is.
  - `{{setvar}}` / `{{addvar}}` / `{{settempvar}}` / `{{setdefaultvar}}` — with `runVar: false` these return `null` (no match) and stay literal, and no variable writes happen. Presets that instruct the model to emit `{{setvar::...}}` for trigger/regex post-processing keep working.
  - No CBS side effects run at any point (`runVar` is left `false`, matching the rest of the prompt-building path).
- **Escape hatch:** authors who need literal braces for a now-evaluated macro can use the existing escape macros (`{{bo}}`/`{{bc}}`, `{{decbo}}`/`{{decbc}}`).

Token accounting is unaffected in the aggregate: the counting pass and the output pass apply the same transformation, so the cutoff estimate stays consistent with the sent text.

## Additional Notes

- Verified with `vitest run` (all tests pass) and `svelte-check` (0 errors, 0 warnings).
- If sending this field verbatim was intentional, feel free to close — but in that case it may be worth documenting, since it is the only CBS-dead field among the innerFormat-style settings.
