### PR TITLE
feat: expose cache points to V3 plugins

### DIFF
--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -238,6 +238,11 @@ interface OpenAIChat {
         name: string;
         arguments: string;
     };
+    /**
+     * Marks the end of a reusable prompt prefix, including this message.
+     * Providers that do not support explicit prompt caching may ignore it.
+     */
+    cachePoint?: boolean;
 }
 
 /**

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -354,9 +354,12 @@ export function reformater(formated:OpenAIChat[],modelInfo:LLMModel|LLMFlags[]){
 
     if(!flags.includes(LLMFlags.hasFullSystemPrompt)){
         if(flags.includes(LLMFlags.hasFirstSystemPrompt)){
-            while(formated[0].role === 'system'){
+            while(formated[0]?.role === 'system' && !systemPrompt?.cachePoint){
                 if(systemPrompt){
                     systemPrompt.content += '\n\n' + formated[0].content
+                    if(formated[0].cachePoint){
+                        systemPrompt.cachePoint = true
+                    }
                 }
                 else{
                     systemPrompt = formated[0]
@@ -382,7 +385,7 @@ export function reformater(formated:OpenAIChat[],modelInfo:LLMModel|LLMFlags[]){
                 continue
             }
 
-            if(newFormated[newFormated.length-1].role === m.role){
+            if(newFormated[newFormated.length-1].role === m.role && !newFormated[newFormated.length-1].cachePoint){
             
                 newFormated[newFormated.length-1].content += '\n' + m.content
 

--- a/src/ts/process/request/tests/reformater.test.ts
+++ b/src/ts/process/request/tests/reformater.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    db: {
+        systemContentReplacement: '',
+        systemRoleReplacement: '',
+    },
+}))
+
+vi.mock('src/ts/storage/database.svelte', () => ({
+    getCurrentCharacter: vi.fn(),
+    getCurrentChat: vi.fn(),
+    getDatabase: () => mocks.db,
+}))
+
+vi.mock('src/ts/model/modellist', async () => {
+    const { LLMFlags, LLMFormat } = await import('src/ts/model/types')
+    return {
+        getModelInfo: vi.fn(),
+        LLMFlags,
+        LLMFormat,
+    }
+})
+
+vi.mock('src/ts/plugins/plugins.svelte', () => ({
+    pluginProcess: vi.fn(),
+    pluginV2: {
+        providers: new Map(),
+        replacerbeforeRequest: new Set(),
+    },
+}))
+
+vi.mock('src/ts/parser/parser.svelte', () => ({
+    risuChatParser: vi.fn(),
+    risuEscape: (value: string) => value,
+    risuUnescape: (value: string) => value,
+}))
+
+vi.mock('src/ts/globalApi.svelte', () => ({
+    fetchNative: vi.fn(),
+    globalFetch: vi.fn(),
+}))
+
+import { LLMFlags } from 'src/ts/model/types'
+import { reformater } from '../request'
+
+describe('reformater cache points', () => {
+    it('does not merge a later message past a cache point', () => {
+        const messages = [
+            { role: 'user' as const, content: 'stable prefix', cachePoint: true },
+            { role: 'user' as const, content: 'changing suffix' },
+        ]
+
+        expect(reformater(messages, [LLMFlags.requiresAlternateRole])).toEqual([
+            { role: 'user', content: 'stable prefix', cachePoint: true },
+            { role: 'user', content: 'changing suffix' },
+        ])
+    })
+
+    it('keeps a cache point after the marked message when merging same-role messages', () => {
+        const messages = [
+            { role: 'user' as const, content: 'stable prefix part 1' },
+            { role: 'user' as const, content: 'stable prefix part 2', cachePoint: true },
+            { role: 'user' as const, content: 'changing suffix' },
+        ]
+
+        expect(reformater(messages, [LLMFlags.requiresAlternateRole])).toEqual([
+            {
+                role: 'user',
+                content: 'stable prefix part 1\nstable prefix part 2',
+                cachePoint: true,
+            },
+            { role: 'user', content: 'changing suffix' },
+        ])
+    })
+
+    it('does not merge a later system message past a cache point', () => {
+        const messages = [
+            { role: 'system' as const, content: 'stable system prompt', cachePoint: true },
+            { role: 'system' as const, content: 'changing system prompt' },
+            { role: 'user' as const, content: 'chat message' },
+        ]
+
+        expect(reformater(messages, [LLMFlags.hasFirstSystemPrompt])).toEqual([
+            { role: 'system', content: 'stable system prompt', cachePoint: true },
+            { role: 'user', content: 'system: changing system prompt' },
+            { role: 'user', content: 'chat message' },
+        ])
+    })
+
+    it('preserves a cache point while collecting leading system messages', () => {
+        const messages = [
+            { role: 'system' as const, content: 'stable system prompt part 1' },
+            { role: 'system' as const, content: 'stable system prompt part 2', cachePoint: true },
+            { role: 'system' as const, content: 'changing system prompt' },
+            { role: 'user' as const, content: 'chat message' },
+        ]
+
+        expect(reformater(messages, [LLMFlags.hasFirstSystemPrompt])).toEqual([
+            {
+                role: 'system',
+                content: 'stable system prompt part 1\n\nstable system prompt part 2',
+                cachePoint: true,
+            },
+            { role: 'user', content: 'system: changing system prompt' },
+            { role: 'user', content: 'chat message' },
+        ])
+    })
+})


### PR DESCRIPTION
## Summary

- expose the existing `cachePoint?: boolean` field on the public Plugin API V3 `OpenAIChat` type
- prevent shared message normalization from merging later content past a cache boundary
- preserve cache boundaries while folding leading system messages
- add focused regression coverage for same-role and leading-system normalization

## Scope

This exposes provider-neutral cache metadata to `beforeRequest` replacers and custom providers through `ProviderArguments.prompt_chat`. Provider-specific request-body translation remains unchanged, and unsupported providers may ignore the optional field.

## Testing

- `pnpm vitest run src/ts/process/request/tests/reformater.test.ts` — 4 passed
- `pnpm test` — 196 passed, 3 skipped
- `pnpm check` — 0 errors, 0 warnings
- `pnpm build` — passed

Closes #1538