### PR TITLE
fix: support explicit cache points for OpenAI GPT-5.6

### DIFF
--- a/src/ts/process/request/openAI/promptCache.test.ts
+++ b/src/ts/process/request/openAI/promptCache.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { addPromptCacheBreakpoint, applyGPT56ChatCachePoints, responsesCacheableContentTypes } from './promptCache'
+
+describe('OpenAI GPT-5.6 explicit prompt caching', () => {
+    it('converts a GPT-5.6 chat cache point into a text content breakpoint', () => {
+        expect(applyGPT56ChatCachePoints([
+            { role: 'system', content: 'Stable instructions', cachePoint: true },
+            { role: 'user', content: 'Changing request' },
+        ], 'gpt-5.6-sol')).toEqual([
+            {
+                role: 'system',
+                content: [{
+                    type: 'text',
+                    text: 'Stable instructions',
+                    prompt_cache_breakpoint: { mode: 'explicit' },
+                }],
+            },
+            { role: 'user', content: 'Changing request' },
+        ])
+    })
+
+    it('places a multimodal chat breakpoint on the final cacheable block', () => {
+        expect(applyGPT56ChatCachePoints([{
+            role: 'user',
+            cachePoint: true,
+            content: [
+                { type: 'image_url', image_url: { url: 'image', detail: 'auto' } },
+                { type: 'text', text: 'Stable caption' },
+            ],
+        }], 'gpt-5.6')[0].content).toEqual([
+            { type: 'image_url', image_url: { url: 'image', detail: 'auto' } },
+            {
+                type: 'text',
+                text: 'Stable caption',
+                prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+        ])
+    })
+
+    it('strips internal cache points from models before GPT-5.6', () => {
+        expect(applyGPT56ChatCachePoints([
+            { role: 'system', content: 'Stable instructions', cachePoint: true },
+        ], 'gpt-5.5')).toEqual([
+            { role: 'system', content: 'Stable instructions' },
+        ])
+    })
+
+    it('supports OpenAI-compatible custom models using a GPT-5.6 request model', () => {
+        expect(applyGPT56ChatCachePoints([
+            { role: 'system', content: 'Stable instructions', cachePoint: true },
+        ], 'gpt-5.6-luna')).toEqual([
+            {
+                role: 'system',
+                content: [{
+                    type: 'text',
+                    text: 'Stable instructions',
+                    prompt_cache_breakpoint: { mode: 'explicit' },
+                }],
+            },
+        ])
+    })
+
+    it('places a Responses breakpoint on the final supported input block', () => {
+        expect(addPromptCacheBreakpoint([
+            { type: 'input_text', text: 'Stable instructions' },
+            { type: 'input_file', file_data: 'file' },
+        ], responsesCacheableContentTypes)).toEqual([
+            { type: 'input_text', text: 'Stable instructions' },
+            {
+                type: 'input_file',
+                file_data: 'file',
+                prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+        ])
+    })
+})

--- a/src/ts/process/request/openAI/promptCache.ts
+++ b/src/ts/process/request/openAI/promptCache.ts
@@ -1,0 +1,76 @@
+const explicitCacheBreakpoint = {
+    mode: 'explicit',
+} as const
+
+export function isGPT56Model(model:string):boolean{
+    return model === 'gpt-5.6' || model.startsWith('gpt-5.6-')
+}
+
+export function addPromptCacheBreakpoint<T extends { type?: string }>(
+    content:T[],
+    supportedTypes:ReadonlySet<string>
+):T[]{
+    let breakpointIndex = -1
+    for(let index = content.length - 1; index >= 0; index--){
+        const type = content[index].type
+        if(type && supportedTypes.has(type)){
+            breakpointIndex = index
+            break
+        }
+    }
+    if(breakpointIndex === -1){
+        return content
+    }
+
+    return content.map((block, index) => index === breakpointIndex
+        ? {
+            ...block,
+            prompt_cache_breakpoint: explicitCacheBreakpoint,
+        }
+        : block
+    )
+}
+
+const chatCacheableContentTypes = new Set([
+    'text',
+    'image_url',
+    'input_audio',
+    'file',
+    'refusal',
+])
+
+export function applyGPT56ChatCachePoints<T extends {
+    cachePoint?: boolean
+    content?: unknown
+}>(messages:T[], model:string):Omit<T, 'cachePoint'>[]{
+    return messages.map((message) => {
+        const { cachePoint, ...requestMessage } = message
+        if(!isGPT56Model(model) || !cachePoint){
+            return requestMessage
+        }
+
+        if(typeof requestMessage.content === 'string'){
+            return {
+                ...requestMessage,
+                content: [{
+                    type: 'text',
+                    text: requestMessage.content,
+                    prompt_cache_breakpoint: explicitCacheBreakpoint,
+                }],
+            }
+        }
+        if(Array.isArray(requestMessage.content)){
+            return {
+                ...requestMessage,
+                content: addPromptCacheBreakpoint(requestMessage.content, chatCacheableContentTypes),
+            }
+        }
+        return requestMessage
+    })
+}
+
+export const responsesCacheableContentTypes = new Set([
+    'input_text',
+    'input_image',
+    'input_file',
+])

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -241,6 +241,35 @@ describe('OpenAI Responses API helpers', () => {
         expect(sourceMessages[1]).toMatchObject({ role: 'user', content: 'Describe this.', multimodals: [{ type: 'image', base64: 'data:image/png;base64,abc' }] })
     })
 
+    it('converts GPT-5.6 cache points into Responses input block breakpoints', async () => {
+        const body = await __testResponsesAPI.buildResponsesBody(baseArg({
+            formated: [
+                { role: 'system', content: 'Stable instructions', cachePoint: true },
+                { role: 'user', content: 'Changing request' },
+            ],
+            modelInfo: {
+                ...baseArg().modelInfo,
+                id: 'gpt-5.6-response-api',
+                internalID: 'gpt-5.6',
+            },
+        }))
+
+        expect(body.input).toEqual([
+            {
+                role: 'developer',
+                content: [{
+                    type: 'input_text',
+                    text: 'Stable instructions',
+                    prompt_cache_breakpoint: { mode: 'explicit' },
+                }],
+            },
+            {
+                role: 'user',
+                content: [{ type: 'input_text', text: 'Changing request' }],
+            },
+        ])
+    })
+
     it('requests reasoning summaries for Responses reasoning models', async () => {
         const body = await __testResponsesAPI.buildResponsesBody(baseArg())
 

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -16,6 +16,7 @@ import type { RequestDataArgumentExtended, requestDataResponse, StreamResponseCh
 import { applyAdditionalParameters, applyParameters, getAdditionalParameters } from '../shared'
 
 import type { Contents, OpenAIChatExtra, OpenAIChatFull, ToolCall } from './types'
+import { applyGPT56ChatCachePoints } from './promptCache'
 
 import { getLocalNetworkRequestOptions, type LocalNetworkRequestOptions } from './shared'
 export { requestOpenAIResponseAPI, __testResponsesAPI } from './responses'
@@ -157,7 +158,6 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
             delete formatedChat[i].attr
             delete formatedChat[i].multimodals
             delete formatedChat[i].thoughts
-            delete formatedChat[i].cachePoint
         }
         if(aiModel === 'reverse_proxy' && db.reverseProxyOobaMode && formatedChat[i].role === 'system'){
             const cont = formatedChat[i].content
@@ -387,6 +387,11 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         stream: false,
 
     })
+
+    body.messages = applyGPT56ChatCachePoints(
+        body.messages,
+        body.model
+    )
 
 
     if(Object.keys(body.logit_bias).length === 0){

--- a/src/ts/process/request/openAI/responses.ts
+++ b/src/ts/process/request/openAI/responses.ts
@@ -13,6 +13,7 @@ import { applyAdditionalParameters, applyParameters, getAdditionalParameters } f
 
 import type { OpenAIChatExtra, ResponseFunctionCallItem, ResponseInputItem, ResponseItem, ResponseOutputItem } from './types'
 import { getLocalNetworkRequestOptions, type LocalNetworkRequestOptions } from './shared'
+import { addPromptCacheBreakpoint, isGPT56Model, responsesCacheableContentTypes } from './promptCache'
 
 function responseTextContentToString(content:any):string{
     if(typeof content === 'string'){
@@ -79,6 +80,7 @@ async function buildResponseInputItems(arg:RequestDataArgumentExtended):Promise<
     const items:ResponseItem[] = []
     const developerRole = arg.modelInfo.flags.includes(LLMFlags.DeveloperRole)
     const db = getDatabase()
+    const supportsExplicitPromptCaching = isGPT56Model(getResponsesRequestModel(arg))
 
     for(const content of arg.formated as OpenAIChatExtra[]){
         switch(content.role){
@@ -152,6 +154,9 @@ async function buildResponseInputItems(arg:RequestDataArgumentExtended):Promise<
                 }
 
                 if(item.content.length > 0){
+                    if(content.cachePoint && supportsExplicitPromptCaching){
+                        item.content = addPromptCacheBreakpoint(item.content, responsesCacheableContentTypes)
+                    }
                     items.push(item)
                 }
                 break

--- a/src/ts/process/request/openAI/types.ts
+++ b/src/ts/process/request/openAI/types.ts
@@ -5,16 +5,25 @@ export interface ResponseInputItem {
         | {
               type: 'input_text'
               text: string
+              prompt_cache_breakpoint?: {
+                  mode: 'explicit'
+              }
           }
         | {
               detail: 'high' | 'low' | 'auto'
               type: 'input_image'
               image_url: string
+              prompt_cache_breakpoint?: {
+                  mode: 'explicit'
+              }
           }
         | {
               type: 'input_file'
               file_data: string
               filename?: string
+              prompt_cache_breakpoint?: {
+                  mode: 'explicit'
+              }
           }
     )[]
     role: 'user' | 'system' | 'developer'
@@ -70,6 +79,9 @@ export type ResponseItem = ResponseInputItem | ResponseOutputItem | ResponseFunc
 interface TextContents {
     type: 'text'
     text: string
+    prompt_cache_breakpoint?: {
+        mode: 'explicit'
+    }
 }
 
 interface ImageContents {
@@ -77,6 +89,9 @@ interface ImageContents {
     image_url: {
         url: string
         detail: string
+    }
+    prompt_cache_breakpoint?: {
+        mode: 'explicit'
     }
 }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds explicit prompt cache breakpoint support for OpenAI GPT-5.6 models.

## Related Issues

Related to #1533 and #1543.

## Changes

- Converts prompt preset cache points into OpenAI `prompt_cache_breakpoint` content blocks.
- Supports both Chat Completions and Responses API request formats.
- Supports built-in and OpenAI-compatible custom GPT-5.6 models.
- Keeps cache point fields out of requests for earlier models.
- Adds type definitions and focused regression tests.

## Impact

Prompt preset cache points now use GPT-5.6 explicit prompt caching. Existing behavior for earlier models remains unchanged.

## Additional Notes

Manually tested Responses API GPT-5.6 Sol, Terra, and Luna twice each using the node-hosted version. Local builds were not tested because I do not currently have a local build environment configured.