### PR TITLE
fix: propagate Tauri stream cancellation to Rust

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,8 @@ tauri-plugin-process = "2.3.1"
 tauri-plugin-shell = "2.3.3"
 tauri-plugin-http = "2.5.5"
 oauth2 = "5.0.0"
-tokio = { version = "1.47.1", features = ["time"] }
+tokio = { version = "1.47.1", features = ["macros", "sync", "time"] }
+tokio-util = "0.7"
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
 tauri-plugin-deep-link = "2.4.6"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,15 +21,33 @@ use oauth2::{
     TokenUrl
 };
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::Method;
 use serde_json::json;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::io::Write;
 use std::{path::Path, time::Duration};
 use std::sync::{Arc, Mutex};
+use tauri::ipc::{Channel, InvokeResponseBody};
 use tauri::path::BaseDirectory;
 use tauri::{Listener, Manager};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, State};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+struct NativeHttpState {
+    client: reqwest::Client,
+    active_streams: Arc<Mutex<HashMap<String, CancellationToken>>>,
+}
+
+impl Default for NativeHttpState {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            active_streams: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
 
 #[tauri::command]
 async fn native_request(url: String, body: String, header: String, method: String) -> String {
@@ -429,140 +447,156 @@ fn run_py_server(handle: tauri::AppHandle, py_path: String) {
     return;
 }
 
-#[tauri::command]
-async fn streamed_fetch(
-    id: String,
-    url: String,
-    headers: String,
-    body: String,
-    app: AppHandle,
-    method: String,
-    timeout_secs: Option<u64>,
-) -> String {
-    //parse headers
-    let headers_json: Value = match serde_json::from_str(&headers) {
-        Ok(h) => h,
-        Err(e) => return format!(r#"{{"success":false, body:{}}}"#, e.to_string()),
-    };
-
-    let mut headers = HeaderMap::new();
-    if let Some(obj) = headers_json.as_object() {
-        for (key, value) in obj {
-            let header_name = match HeaderName::from_bytes(key.as_bytes()) {
-                Ok(name) => name,
-                Err(e) => return format!(r#"{{"success":false, body:{}}}"#, e.to_string()),
-            };
-            let header_value = match HeaderValue::from_str(value.as_str().unwrap_or("")) {
-                Ok(value) => value,
-                Err(e) => return format!(r#"{{"success":false, body:{}}}"#, e.to_string()),
-            };
-            headers.insert(header_name, header_value);
-        }
-    } else {
-        return format!(r#"{{"success":false,"body":"Invalid header JSON"}}"#);
-    }
-
-    let client = reqwest::Client::new();
-    let timeout_secs = timeout_secs.unwrap_or(240);
-    let builder: reqwest::RequestBuilder;
-    if method == "POST" {
-
-        let body_decoded = general_purpose::STANDARD.decode(body.as_bytes()).unwrap();
-
-        builder = client
-        .post(&url)
-        .headers(headers)
-        .timeout(Duration::from_secs(timeout_secs))
-        .body(body_decoded)
-    }
-    else if method == "GET" {
-        builder = client
-        .get(&url)
-        .headers(headers)
-        .timeout(Duration::from_secs(timeout_secs));
-    }
-    else if method == "PUT" {
-
-        let body_decoded = general_purpose::STANDARD.decode(body.as_bytes()).unwrap();
-
-        builder = client
-        .put(&url)
-        .headers(headers)
-        .timeout(Duration::from_secs(timeout_secs))
-        .body(body_decoded)
-    }
-    else if method == "DELETE" {
-
-        let body_decoded = general_purpose::STANDARD.decode(body.as_bytes()).unwrap();
-
-        builder = client
-        .delete(&url)
-        .headers(headers)
-        .timeout(Duration::from_secs(timeout_secs))
-        .body(body_decoded)
-    }
-    else {
-        return format!(r#"{{"success":false, body:"Invalid method"}}"#);
-    }
-
-
-
-    let response = builder
-        .send()
-        .await;
-
-    match response {
-        Ok(mut resp) => {
-            let headers = resp.headers();
-            let header_json = header_map_to_json(headers);
-            app.emit(
-                "streamed_fetch",
-                &format!(
-                    r#"{{"type": "headers", "body": {}, "id": "{}", "status": {}}}"#,
-                    header_json,
-                    id,
-                    resp.status().as_u16()
-                ),
-            )
-            .unwrap();
-            loop {
-                let byt = resp.chunk().await;
-                match byt {
-                    Ok(chunk) => {
-                        if chunk.is_none() {
-                            break;
-                        }
-                        let chunk = chunk.unwrap();
-                        let encoded = general_purpose::STANDARD.encode(chunk);
-                        let emited = app.emit(
-                            "streamed_fetch",
-                            &format!(
-                                r#"{{"type": "chunk", "body": "{}", "id": "{}"}}"#,
-                                encoded, id
-                            ),
-                        );
-
-                        match emited {
-                            Ok(_) => {}
-                            Err(e) => {
-                                return format!(r#"{{"success":false, body:{}}}"#, e.to_string())
-                            }
-                        }
-                    }
-                    Err(e) => return format!(r#"{{"success":false, body:{}}}"#, e.to_string()),
-                }
-            }
-            app.emit(
-                "streamed_fetch",
-                &format!(r#"{{"type": "end", "id": "{}"}}"#, id),
-            )
-            .unwrap();
-            return "{\"success\":true}".to_string();
-        }
-        Err(e) => return format!(r#"{{"success":false, body:{}}}"#, e.to_string()),
-    }
+enum StreamOutcome {
+    Completed,
+    Cancelled,
 }
 
+fn send_stream_event(channel: &Channel<InvokeResponseBody>, event: Value) -> Result<(), String> {
+    channel
+        .send(InvokeResponseBody::Json(event.to_string()))
+        .map_err(|error| error.to_string())
+}
+
+async fn run_streamed_fetch(
+    client: reqwest::Client,
+    url: String,
+    headers: HeaderMap,
+    body: Vec<u8>,
+    method: Method,
+    timeout_secs: u64,
+    channel: &Channel<InvokeResponseBody>,
+    cancel_token: CancellationToken,
+) -> Result<StreamOutcome, String> {
+    let mut builder = client
+        .request(method.clone(), &url)
+        .headers(headers)
+        .timeout(Duration::from_secs(timeout_secs));
+
+    if method != Method::GET && !body.is_empty() {
+        builder = builder.body(body);
+    }
+
+    let mut response = tokio::select! {
+        _ = cancel_token.cancelled() => return Ok(StreamOutcome::Cancelled),
+        response = builder.send() => response.map_err(|error| error.to_string())?,
+    };
+
+    send_stream_event(
+        channel,
+        json!({
+            "type": "headers",
+            "headers": header_map_to_json(response.headers()),
+            "status": response.status().as_u16(),
+        }),
+    )?;
+
+    loop {
+        let chunk = tokio::select! {
+            _ = cancel_token.cancelled() => return Ok(StreamOutcome::Cancelled),
+            chunk = response.chunk() => chunk.map_err(|error| error.to_string())?,
+        };
+
+        let Some(chunk) = chunk else {
+            break;
+        };
+
+        channel
+            .send(InvokeResponseBody::Raw(chunk.to_vec()))
+            .map_err(|error| error.to_string())?;
+    }
+
+    Ok(StreamOutcome::Completed)
+}
+
+#[tauri::command]
+fn streamed_fetch(
+    id: String,
+    url: String,
+    headers: HashMap<String, String>,
+    body: String,
+    method: String,
+    timeout_secs: Option<u64>,
+    channel: Channel<InvokeResponseBody>,
+    state: State<'_, NativeHttpState>,
+) -> Result<(), String> {
+    let method = Method::from_bytes(method.as_bytes()).map_err(|error| error.to_string())?;
+    let body = general_purpose::STANDARD
+        .decode(body.as_bytes())
+        .map_err(|error| error.to_string())?;
+
+    let mut request_headers = HeaderMap::new();
+    for (key, value) in headers {
+        let header_name =
+            HeaderName::from_bytes(key.as_bytes()).map_err(|error| error.to_string())?;
+        let header_value = HeaderValue::from_str(&value).map_err(|error| error.to_string())?;
+        request_headers.insert(header_name, header_value);
+    }
+
+    let cancel_token = CancellationToken::new();
+    {
+        let mut active_streams = state
+            .active_streams
+            .lock()
+            .map_err(|_| "Native stream registry lock poisoned".to_string())?;
+        if active_streams.contains_key(&id) {
+            return Err("Duplicate native stream id".to_string());
+        }
+        active_streams.insert(id.clone(), cancel_token.clone());
+    }
+
+    let task_state = state.inner().clone();
+    tauri::async_runtime::spawn(async move {
+        let result = run_streamed_fetch(
+            task_state.client.clone(),
+            url,
+            request_headers,
+            body,
+            method,
+            timeout_secs.unwrap_or(240),
+            &channel,
+            cancel_token,
+        )
+        .await;
+
+        if let Ok(mut active_streams) = task_state.active_streams.lock() {
+            active_streams.remove(&id);
+        }
+
+        match result {
+            Ok(StreamOutcome::Completed) => {
+                let _ = send_stream_event(&channel, json!({ "type": "end" }));
+            }
+            Ok(StreamOutcome::Cancelled) => {}
+            Err(message) => {
+                let _ = send_stream_event(
+                    &channel,
+                    json!({
+                        "type": "error",
+                        "message": message,
+                    }),
+                );
+            }
+        }
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+fn cancel_streamed_fetch(id: String, state: State<'_, NativeHttpState>) -> Result<(), String> {
+    let cancel_token = state
+        .active_streams
+        .lock()
+        .map_err(|_| "Native stream registry lock poisoned".to_string())?
+        .remove(&id);
+
+    if let Some(cancel_token) = cancel_token {
+        cancel_token.cancel();
+    }
+
+    Ok(())
+}
 
 fn main() {
     let mut builder = tauri::Builder::default();
@@ -578,6 +612,7 @@ fn main() {
     }
 
     builder
+        .manage(NativeHttpState::default())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_shell::init())
@@ -597,6 +632,7 @@ fn main() {
             run_py_server,
             install_py_dependencies,
             streamed_fetch,
+            cancel_streamed_fetch,
             oauth_login
         ])
         .run(tauri::generate_context!())
@@ -608,7 +644,7 @@ fn header_map_to_json(header_map: &HeaderMap) -> serde_json::Value {
     for (key, value) in header_map {
         map.insert(
             key.as_str().to_string(),
-            value.to_str().unwrap().to_string(),
+            String::from_utf8_lossy(value.as_bytes()).into_owned(),
         );
     }
     json!(map)

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -8,7 +8,7 @@ import {
     remove
 } from "@tauri-apps/plugin-fs"
 import { changeFullscreen, checkNullish, sleep } from "./util"
-import { convertFileSrc, invoke } from "@tauri-apps/api/core"
+import { Channel, convertFileSrc, invoke } from "@tauri-apps/api/core"
 import { v4 as uuidv4, v4 } from 'uuid';
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { get } from "svelte/store";
@@ -31,7 +31,6 @@ import { updateAnimationSpeed } from "./gui/animation";
 import { updateColorScheme, updateTextThemeAndCSS } from "./gui/colorscheme";
 import { autoServerBackup, saveDbKei } from "./kei/backup";
 import { save } from "@tauri-apps/plugin-dialog";
-import { listen } from '@tauri-apps/api/event'
 import { language } from "src/lang";
 import { startObserveDom } from "./observer.svelte";
 import { updateGuisize } from "./gui/guisize";
@@ -44,6 +43,7 @@ import { getColdStorageItem, makeColdData } from "./process/coldstorage.svelte";
 import { isTauri, isNodeServer } from "./platform";
 import { isLocalNetworkUrl } from "./network/localNetwork";
 import { decodeProxyJobWsChunk, formatProxyStreamErrorMessage, parseProxyJobWsEvent } from "./network/proxyJobWs";
+import { pipeStreamWithTextLog } from "./network/streamFetchLog";
 import { getNodeServerProxyAuth } from "./storage/nodeStorage";
 
 export const forageStorage = new AutoStorage()
@@ -1365,103 +1365,22 @@ export class VirtualWriter {
     }
 }
 
-/**
- * Index for fetch operations.
- * @type {number}
- */
-let fetchIndex = 0
-
-/**
- * Stores native fetch data.
- * @type {{ [key: string]: StreamedFetchChunk[] }}
- */
-let nativeFetchData: { [key: string]: StreamedFetchChunk[] } = {}
-
-/**
- * Interface representing a streamed fetch chunk data.
- * @interface
- */
-interface StreamedFetchChunkData {
-    type: 'chunk',
-    body: string,
-    id: string
-}
-
-/**
- * Interface representing a streamed fetch header data.
- * @interface
- */
 interface StreamedFetchHeaderData {
     type: 'headers',
-    body: { [key: string]: string },
-    id: string,
+    headers: { [key: string]: string },
     status: number
 }
 
-/**
- * Interface representing a streamed fetch end data.
- * @interface
- */
 interface StreamedFetchEndData {
-    type: 'end',
-    id: string
+    type: 'end'
 }
 
-/**
- * Type representing a streamed fetch chunk.
- * @typedef {StreamedFetchChunkData | StreamedFetchHeaderData | StreamedFetchEndData} StreamedFetchChunk
- */
-type StreamedFetchChunk = StreamedFetchChunkData | StreamedFetchHeaderData | StreamedFetchEndData
-
-/**
- * Interface representing a streamed fetch plugin.
- * @interface
- */
-interface StreamedFetchPlugin {
-    /**
-     * Performs a streamed fetch operation.
-     * @param {Object} options - The options for the fetch operation.
-     * @param {string} options.id - The ID of the fetch operation.
-     * @param {string} options.url - The URL to fetch.
-     * @param {string} options.body - The body of the fetch request.
-     * @param {{ [key: string]: string }} options.headers - The headers of the fetch request.
-     * @returns {Promise<{ error: string, success: boolean }>} - The result of the fetch operation.
-     */
-    streamedFetch(options: { id: string, url: string, body: string, headers: { [key: string]: string } }): Promise<{ "error": string, "success": boolean }>;
-
-    /**
-     * Adds a listener for the specified event.
-     * @param {string} eventName - The name of the event.
-     * @param {(data: StreamedFetchChunk) => void} listenerFunc - The function to call when the event is triggered.
-     */
-    addListener(eventName: 'streamed_fetch', listenerFunc: (data: StreamedFetchChunk) => void): void;
+interface StreamedFetchErrorData {
+    type: 'error',
+    message: string
 }
 
-/**
- * Indicates whether streamed fetch listening is active.
- * @type {boolean}
- */
-let streamedFetchListening = false
-
-/**
- * The streamed fetch plugin instance.
- * @type {StreamedFetchPlugin | undefined}
- */
-let capStreamedFetch: StreamedFetchPlugin | undefined
-
-if (isTauri) {
-    listen('streamed_fetch', (event) => {
-        try {
-            const parsed = JSON.parse(event.payload as string)
-            const id = parsed.id
-            nativeFetchData[id]?.push(parsed)
-        } catch (error) {
-            console.error(error)
-        }
-    }).then((v) => {
-        streamedFetchListening = true
-    })
-}
+type StreamedFetchEvent = StreamedFetchHeaderData | StreamedFetchEndData | StreamedFetchErrorData
 
 /**
  * A class to manage a buffer that can be appended to and deappended from.
@@ -1547,15 +1466,164 @@ export class AppendableBuffer {
  * @returns {ReadableStream<Uint8Array>} - The new readable stream.
  */
 const pipeFetchLog = (fetchLogIndex: number, readableStream: ReadableStream<Uint8Array>) => {
-    
-    const splited = readableStream.tee();
-    
-    (async () => {
-        const text = await (new Response(splited[0])).text()
-        fetchLog[fetchLogIndex].response = text
-    })()
-    
-    return splited[1]
+    const logEntry = fetchLog[fetchLogIndex]
+    return pipeStreamWithTextLog(readableStream, (responseText) => {
+        if (logEntry) {
+            logEntry.response = responseText
+        }
+    })
+}
+
+function toNativeFetchError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error))
+}
+
+async function fetchViaTauriStream(url: string, arg: {
+    body: Uint8Array,
+    headers: { [key: string]: string },
+    method: "POST" | "GET" | "PUT" | "DELETE",
+    signal?: AbortSignal,
+    requestTimeoutMs?: number,
+}): Promise<Response> {
+    if (arg.signal?.aborted) {
+        throw new DOMException('The operation was aborted.', 'AbortError')
+    }
+
+    const fetchId = uuidv4()
+    let responseHeaders: { [key: string]: string } = {}
+    let responseStatus = 400
+    let headersSettled = false
+    let settled = false
+    let registered = false
+    let cancelRequested = false
+    let cancelSent = false
+    let streamController: ReadableStreamDefaultController<Uint8Array>
+    let resolveHeaders: () => void = () => {}
+    let rejectHeaders: (error: Error) => void = () => {}
+
+    const headersReady = new Promise<void>((resolve, reject) => {
+        resolveHeaders = resolve
+        rejectHeaders = reject
+    })
+
+    const cleanup = () => {
+        arg.signal?.removeEventListener('abort', abortHandler)
+    }
+
+    const cancelNative = async () => {
+        cancelRequested = true
+        if (!registered || cancelSent) {
+            return
+        }
+        cancelSent = true
+        try {
+            await invoke('cancel_streamed_fetch', { id: fetchId })
+        } catch (error) {
+            console.error('Failed to cancel native stream', error)
+        }
+    }
+
+    const fail = (error: Error) => {
+        if (settled) {
+            return
+        }
+        settled = true
+        cleanup()
+        if (!headersSettled) {
+            headersSettled = true
+            rejectHeaders(error)
+            return
+        }
+        streamController.error(error)
+    }
+
+    const abortHandler = () => {
+        fail(new DOMException('The operation was aborted.', 'AbortError'))
+        void cancelNative()
+    }
+
+    const channel = new Channel<StreamedFetchEvent | ArrayBuffer>()
+    channel.onmessage = (message) => {
+        if (settled) {
+            return
+        }
+
+        if (message instanceof ArrayBuffer) {
+            streamController.enqueue(new Uint8Array(message))
+            return
+        }
+
+        if (ArrayBuffer.isView(message)) {
+            streamController.enqueue(new Uint8Array(message.buffer, message.byteOffset, message.byteLength))
+            return
+        }
+
+        if (message.type === 'headers') {
+            if (!headersSettled) {
+                responseHeaders = message.headers
+                responseStatus = message.status
+                headersSettled = true
+                resolveHeaders()
+            }
+            return
+        }
+
+        if (message.type === 'error') {
+            fail(new Error(message.message))
+            return
+        }
+
+        if (!headersSettled) {
+            fail(new Error('Native stream ended before response headers were received'))
+            return
+        }
+
+        settled = true
+        cleanup()
+        streamController.close()
+    }
+
+    const readableStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            streamController = controller
+        },
+        async cancel() {
+            if (!settled) {
+                settled = true
+                cleanup()
+            }
+            await cancelNative()
+        }
+    })
+
+    arg.signal?.addEventListener('abort', abortHandler, { once: true })
+    if (arg.signal?.aborted) {
+        abortHandler()
+    }
+
+    const startRequest = invoke('streamed_fetch', {
+        id: fetchId,
+        url,
+        headers: arg.headers,
+        body: arg.body ? Buffer.from(arg.body).toString('base64') : '',
+        method: arg.method,
+        timeout_secs: arg.requestTimeoutMs ? Math.max(1, Math.ceil(arg.requestTimeoutMs / 1000)) : undefined,
+        channel,
+    }).then(async () => {
+        registered = true
+        if (cancelRequested) {
+            await cancelNative()
+        }
+    }).catch((error) => {
+        fail(toNativeFetchError(error))
+    })
+
+    await Promise.all([startRequest, headersReady])
+
+    return new Response(readableStream, {
+        headers: new Headers(responseHeaders),
+        status: responseStatus,
+    })
 }
 
 async function fetchViaProxyJobWs(url: string, arg: {
@@ -1846,110 +1914,23 @@ export async function fetchNative(url: string, arg: {
         })
         }
         else if (isTauri) {
-        fetchIndex++
-        if (requestSignal && requestSignal.aborted) {
-            throw new Error('aborted')
-        }
-        if (fetchIndex >= 100000) {
-            fetchIndex = 0
-        }
-        let fetchId = fetchIndex.toString().padStart(5, '0')
-        nativeFetchData[fetchId] = []
-        let resolved = false
-
-        let error = ''
-        while (!streamedFetchListening) {
-            await sleep(100)
-        }
-        if (isTauri) {
-            invoke('streamed_fetch', {
-                id: fetchId,
-                url: url,
-                headers: JSON.stringify(headers),
-                body: realBody ? Buffer.from(realBody).toString('base64') : '',
+            const response = await fetchViaTauriStream(url, {
+                body: realBody,
+                headers,
                 method: arg.method,
-                timeout_secs: arg.requestTimeoutMs ? Math.max(1, Math.ceil(arg.requestTimeoutMs / 1000)) : undefined
-            }).then((res) => {
-                try {
-                    const parsedRes = JSON.parse(res as string)
-                    if (!parsedRes.success) {
-                        error = parsedRes.body
-                        resolved = true
-                    }
-                } catch (e) {
-                    // Error properties (message/name/stack) are non-enumerable, so
-                    // JSON.stringify(e) returns "{}" and discards the real cause.
-                    error = e instanceof Error
-                        ? (e.message || e.name || 'streamed_fetch parse failed')
-                        : String(e)
-                    resolved = true
-                }
+                signal: arg.signal,
+                requestTimeoutMs: arg.requestTimeoutMs,
             })
-        }
-        else if (capStreamedFetch) {
-            capStreamedFetch.streamedFetch({
-                id: fetchId,
-                url: url,
-                headers: headers,
-                body: realBody ? Buffer.from(realBody).toString('base64') : '',
-            }).then((res) => {
-                if (!res.success) {
-                    error = res.error
-                    resolved = true
-                }
-            })
-        }
 
-        let resHeaders: { [key: string]: string } = null
-        let status = 400
-
-        const tauriReadableStream = new ReadableStream<Uint8Array>({
-            async start(controller) {
-                while (!resolved || nativeFetchData[fetchId].length > 0) {
-                    if (nativeFetchData[fetchId].length > 0) {
-                        const data = nativeFetchData[fetchId].shift()
-                        if (data.type === 'chunk') {
-                            const chunk = Buffer.from(data.body, 'base64')
-                            controller.enqueue(chunk as unknown as Uint8Array)
-                        }
-                        if (data.type === 'headers') {
-                            resHeaders = data.body
-                            status = data.status
-                        }
-                        if (data.type === 'end') {
-                            resolved = true
-                        }
-                    }
-                    await sleep(10)
-                }
-                controller.close()
+            if (shouldLogFetch && fetchLogIndex !== null && response.body) {
+                return new Response(pipeFetchLog(fetchLogIndex, response.body), {
+                    headers: response.headers,
+                    status: response.status,
+                })
             }
-        })
 
-        let readableStream = tauriReadableStream
-        if (shouldLogFetch && fetchLogIndex !== null) {
-            readableStream = pipeFetchLog(fetchLogIndex, tauriReadableStream)
+            return response
         }
-
-        while (resHeaders === null && !resolved) {
-            await sleep(10)
-        }
-
-        if (resHeaders === null) {
-            resHeaders = {}
-        }
-
-        if (error !== '') {
-            throw new Error(error)
-        }
-
-        return new Response(readableStream, {
-            headers: new Headers(resHeaders),
-            status: status
-        })
-
-
-    }
     else if (throughProxy) {
         const useProxyJobWs = isNodeServer
             && arg.interceptor === 'openai_streaming'

--- a/src/ts/network/streamFetchLog.test.ts
+++ b/src/ts/network/streamFetchLog.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { pipeStreamWithTextLog } from './streamFetchLog'
+
+describe('pipeStreamWithTextLog', () => {
+    it('forwards the complete stream and records its text', async () => {
+        const encoder = new TextEncoder()
+        const onFinalize = vi.fn()
+        const source = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(encoder.encode('hel'))
+                controller.enqueue(encoder.encode('lo'))
+                controller.close()
+            },
+        })
+
+        const response = new Response(pipeStreamWithTextLog(source, onFinalize))
+
+        await expect(response.text()).resolves.toBe('hello')
+        expect(onFinalize).toHaveBeenCalledOnce()
+        expect(onFinalize).toHaveBeenCalledWith('hello')
+    })
+
+    it('propagates cancellation and records only consumed data', async () => {
+        const encoder = new TextEncoder()
+        const onCancel = vi.fn()
+        const onFinalize = vi.fn()
+        const source = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(encoder.encode('first'))
+            },
+            cancel: onCancel,
+        })
+        const reader = pipeStreamWithTextLog(source, onFinalize).getReader()
+
+        await expect(reader.read()).resolves.toMatchObject({ done: false })
+        await reader.cancel('stopped')
+
+        expect(onCancel).toHaveBeenCalledWith('stopped')
+        expect(onFinalize).toHaveBeenCalledOnce()
+        expect(onFinalize).toHaveBeenCalledWith('first')
+    })
+})

--- a/src/ts/network/streamFetchLog.ts
+++ b/src/ts/network/streamFetchLog.ts
@@ -1,0 +1,40 @@
+export function pipeStreamWithTextLog(
+    readableStream: ReadableStream<Uint8Array>,
+    onFinalize: (responseText: string) => void,
+): ReadableStream<Uint8Array> {
+    const reader = readableStream.getReader()
+    const decoder = new TextDecoder()
+    let responseText = ''
+    let finalized = false
+
+    const finalizeLog = () => {
+        if (finalized) {
+            return
+        }
+        finalized = true
+        responseText += decoder.decode()
+        onFinalize(responseText)
+    }
+
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            try {
+                const result = await reader.read()
+                if (result.done) {
+                    finalizeLog()
+                    controller.close()
+                    return
+                }
+                responseText += decoder.decode(result.value, { stream: true })
+                controller.enqueue(result.value)
+            } catch (error) {
+                finalizeLog()
+                controller.error(error)
+            }
+        },
+        async cancel(reason) {
+            finalizeLog()
+            await reader.cancel(reason)
+        },
+    })
+}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Propagate Tauri streaming cancellation to the Rust HTTP request and replace the global event polling bridge with request-scoped IPC channels.

## Related Issues

None

## Changes

- stream response chunks through a per-request Tauri `Channel` instead of global JSON events, Base64 response chunks, and 10 ms polling
- register each Rust request with a cancellation token and cancel both the initial send and response chunk loop
- reuse a managed `reqwest::Client` so connections can be pooled across streaming requests
- serialize stream headers and errors through `serde_json` values rather than manually assembled JSON strings
- remove the persistent `nativeFetchData` request map
- replace fetch-log `ReadableStream.tee()` usage with a cancellation-propagating stream wrapper
- add focused tests for complete and cancelled fetch-log streams

## Impact

Tauri users can stop an in-progress native request instead of only stopping JavaScript consumption. The new bridge also removes polling and response-chunk Base64 conversion overhead. Web and Node request routes remain unchanged, while their shared fetch-log wrapper now propagates consumer cancellation instead of retaining a second reader.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm exec vitest run src/ts/network/streamFetchLog.test.ts`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff upstream/main...HEAD --check`

Provider-by-provider and packaged Tauri runtime checks have not been run yet, so this PR is opened as a draft.
