### PR TITLE
refactor: extract database change accumulator from saveDb

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -25,7 +25,8 @@ import { hasher } from "./parser/parser.svelte";
 import { characterURLImport, hubURL } from "./characterCards";
 import { defaultJailbreak, defaultMainPrompt, oldJailbreak, oldMainPrompt } from "./storage/defaultPrompts";
 import { loadRisuAccountData } from "./drive/accounter";
-import { decodeRisuSave, encodeRisuSaveLegacy, RisuSaveEncoder, type toSaveType } from "./storage/risuSave";
+import { decodeRisuSave, encodeRisuSaveLegacy, RisuSaveEncoder } from "./storage/risuSave";
+import { cloneChangeTracker, DatabaseChangeAccumulator } from "./storage/databaseChangeAccumulator";
 import { AutoStorage } from "./storage/autoStorage";
 import { updateAnimationSpeed } from "./gui/animation";
 import { updateColorScheme, updateTextThemeAndCSS } from "./gui/colorscheme";
@@ -312,31 +313,7 @@ export async function saveDb() {
         }
     }
 
-    const createChangeTracker = (): toSaveType => ({
-        character: [],
-        botPreset: false,
-        modules: false,
-        loadouts: false,
-        plugins: false,
-        pluginCustomStorage: false
-    })
-    const cloneChangeTracker = (tracker: toSaveType): toSaveType => ({
-        ...tracker,
-        character: [...tracker.character]
-    })
-    const mergeChangeTrackers = (target: toSaveType, source: toSaveType) => {
-        for (const characterId of source.character) {
-            if (!target.character.includes(characterId)) {
-                target.character.push(characterId)
-            }
-        }
-        target.botPreset ||= source.botPreset
-        target.modules ||= source.modules
-        target.loadouts ||= source.loadouts
-        target.plugins ||= source.plugins
-        target.pluginCustomStorage ||= source.pluginCustomStorage
-    }
-    let changeTracker = createChangeTracker()
+    const changeAccumulator = new DatabaseChangeAccumulator()
     let savetrys = 0
 
     let encoder = new RisuSaveEncoder()
@@ -362,66 +339,14 @@ export async function saveDb() {
         }
 
         const unsubscribeDb = onDatabaseUpdate((info) => {
-            if (info.path.length === 0) {
+            const result = changeAccumulator.record(info, {
+                database: DBState.db,
+                selectedCharacterIndex: selIdState,
+            })
+
+            if (result.requiresFullEncoderReload) {
                 requiresFullEncoderReload.state = true
                 savetrys = 0
-                saveTimeoutExecute()
-                return
-            }
-
-            const rootKey = info.path[0]
-
-            if (rootKey === 'botPresets' || rootKey === 'botPresetsId') {
-                changeTracker.botPreset = true
-                saveTimeoutExecute()
-                return
-            }
-
-            if (rootKey === 'modules') {
-                changeTracker.modules = true
-                saveTimeoutExecute()
-                return
-            }
-
-            if (rootKey === 'loadouts' || rootKey === 'plugins' || rootKey === 'pluginCustomStorage') {
-                changeTracker[rootKey] = true
-                saveTimeoutExecute()
-                return
-            }
-
-            if (rootKey === 'characters') {
-                const affectedCharacters: Database['characters'] = []
-
-                if (info.path.length === 1) {
-                    const oldCharacters = info.oldValue as Database['characters'] | undefined
-                    const newCharacters = info.value as Database['characters'] | undefined
-                    affectedCharacters.push(...(oldCharacters ?? []), ...(newCharacters ?? []))
-                }
-                else if (typeof info.path[1] === 'number') {
-                    if (info.path.length === 2) {
-                        const oldChar = info.oldValue as Database['characters'][number] | undefined
-                        if (oldChar) {
-                            affectedCharacters.push(oldChar)
-                        }
-                    }
-                    const char = DBState.db.characters[info.path[1]]
-                    if (char) {
-                        affectedCharacters.push(char)
-                    }
-                }
-
-                for (const char of affectedCharacters) {
-                    if (!changeTracker.character.includes(char.chaId)) {
-                        changeTracker.character.unshift(char.chaId)
-                    }
-                }
-                saveTimeoutExecute()
-                return
-            }
-
-            const char = DBState.db.characters[selIdState]
-            if (char && !changeTracker.character.includes(char.chaId)) {
-                changeTracker.character.unshift(char.chaId)
             }
             saveTimeoutExecute()
         })
@@ -460,8 +385,7 @@ export async function saveDb() {
 
         saving.state = true
         changed = false
-        const pendingSave = cloneChangeTracker(changeTracker)
-        changeTracker = createChangeTracker()
+        const pendingSave = changeAccumulator.take()
         const toSave = cloneChangeTracker(pendingSave)
         try {
             const db = getDatabase()
@@ -515,7 +439,7 @@ export async function saveDb() {
             await saveDbKei()
             await sleep(500)
         } catch (error) {
-            mergeChangeTrackers(changeTracker, pendingSave)
+            changeAccumulator.restore(pendingSave)
             savetrys += 1
             if (savetrys > 4) {
                 alertError(error)

--- a/src/ts/storage/databaseChangeAccumulator.test.ts
+++ b/src/ts/storage/databaseChangeAccumulator.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import type { Database } from './database.svelte'
+import type { DatabaseUpdateInfo } from './databaseState.svelte'
+import { DatabaseChangeAccumulator } from './databaseChangeAccumulator'
+
+type TestCharacter = Database['characters'][number]
+
+function character(chaId: string): TestCharacter {
+    return { chaId } as TestCharacter
+}
+
+function database(characters: TestCharacter[] = []): Database {
+    return { characters } as Database
+}
+
+function update(
+    path: DatabaseUpdateInfo['path'],
+    values: Partial<Omit<DatabaseUpdateInfo, 'path'>> = {},
+): DatabaseUpdateInfo {
+    return {
+        path,
+        value: undefined,
+        oldValue: undefined,
+        type: 'set',
+        ...values,
+    }
+}
+
+function record(
+    accumulator: DatabaseChangeAccumulator,
+    info: DatabaseUpdateInfo,
+    characters: TestCharacter[] = [],
+    selectedCharacterIndex = 0,
+) {
+    return accumulator.record(info, {
+        database: database(characters),
+        selectedCharacterIndex,
+    })
+}
+
+describe('DatabaseChangeAccumulator', () => {
+    it('starts empty', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        expect(accumulator.hasChanges()).toBe(false)
+        expect(accumulator.take()).toEqual({
+            character: [],
+            botPreset: false,
+            modules: false,
+            loadouts: false,
+            plugins: false,
+            pluginCustomStorage: false,
+        })
+    })
+
+    it.each([
+        ['botPresets', 'botPreset'],
+        ['botPresetsId', 'botPreset'],
+        ['modules', 'modules'],
+        ['loadouts', 'loadouts'],
+        ['plugins', 'plugins'],
+        ['pluginCustomStorage', 'pluginCustomStorage'],
+    ] as const)('classifies %s as a %s change', (root, flag) => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update([root]))
+
+        expect(accumulator.take()[flag]).toBe(true)
+    })
+
+    it('tracks the character for a nested character update', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+        const characters = [character('A'), character('B')]
+
+        record(accumulator, update(['characters', 1, 'chats', 0, 'message', 3]), characters)
+
+        expect(accumulator.take().character).toEqual(['B'])
+    })
+
+    it('deduplicates repeated changes for the same character', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+        const characters = [character('A')]
+
+        record(accumulator, update(['characters', 0, 'name']), characters)
+        record(accumulator, update(['characters', 0, 'chats', 0]), characters)
+
+        expect(accumulator.take().character).toEqual(['A'])
+    })
+
+    it('tracks a deleted character from the old value', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['characters', 1], {
+            oldValue: character('removed'),
+            type: 'delete',
+        }), [character('remaining')])
+
+        expect(accumulator.take().character).toEqual(['removed'])
+    })
+
+    it('tracks characters from both sides of an array replacement', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['characters'], {
+            oldValue: [character('old'), character('shared')],
+            value: [character('shared'), character('new')],
+        }))
+
+        expect(accumulator.take().character).toEqual(['new', 'shared', 'old'])
+    })
+
+    it('tracks the selected character for other root changes', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+        const characters = [character('A'), character('B')]
+
+        record(accumulator, update(['username']), characters, 1)
+
+        expect(accumulator.take().character).toEqual(['B'])
+    })
+
+    it('does not track a character when the selected index is invalid', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['username']), [character('A')], 4)
+
+        expect(accumulator.hasChanges()).toBe(false)
+    })
+
+    it('requests a full encoder reload for a root replacement', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        const result = record(accumulator, update([]))
+
+        expect(result.requiresFullEncoderReload).toBe(true)
+        expect(accumulator.hasChanges()).toBe(false)
+    })
+
+    it('resets after take', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['modules']))
+
+        expect(accumulator.take().modules).toBe(true)
+        expect(accumulator.take().modules).toBe(false)
+    })
+
+    it('returns snapshots independent from later changes', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['characters', 0, 'name']), [character('A')])
+        const first = accumulator.take()
+        record(accumulator, update(['characters', 0, 'name']), [character('B')])
+
+        expect(first.character).toEqual(['A'])
+        expect(accumulator.take().character).toEqual(['B'])
+    })
+
+    it('restores a failed save without losing changes recorded in flight', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['characters', 0, 'name']), [character('A')])
+        const pending = accumulator.take()
+        record(accumulator, update(['characters', 0, 'name']), [character('B')])
+        accumulator.restore(pending)
+
+        expect(accumulator.take().character).toEqual(['B', 'A'])
+    })
+
+    it('merges boolean flags when restoring a failed save', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['modules']))
+        const pending = accumulator.take()
+        record(accumulator, update(['plugins']))
+        accumulator.restore(pending)
+
+        expect(accumulator.take()).toMatchObject({
+            modules: true,
+            plugins: true,
+        })
+    })
+})

--- a/src/ts/storage/databaseChangeAccumulator.test.ts
+++ b/src/ts/storage/databaseChangeAccumulator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Database } from './database.svelte'
 import type { DatabaseUpdateInfo } from './databaseState.svelte'
-import { DatabaseChangeAccumulator } from './databaseChangeAccumulator'
+import { cloneChangeTracker, DatabaseChangeAccumulator } from './databaseChangeAccumulator'
 
 type TestCharacter = Database['characters'][number]
 
@@ -164,6 +164,18 @@ describe('DatabaseChangeAccumulator', () => {
         accumulator.restore(pending)
 
         expect(accumulator.take().character).toEqual(['B', 'A'])
+    })
+
+    it('keeps pending changes intact when an encoder mutates its copy', () => {
+        const accumulator = new DatabaseChangeAccumulator()
+
+        record(accumulator, update(['characters', 0, 'name']), [character('A')])
+        const pending = accumulator.take()
+        const encoderChanges = cloneChangeTracker(pending)
+        encoderChanges.character.splice(0, 1)
+        accumulator.restore(pending)
+
+        expect(accumulator.take().character).toEqual(['A'])
     })
 
     it('merges boolean flags when restoring a failed save', () => {

--- a/src/ts/storage/databaseChangeAccumulator.ts
+++ b/src/ts/storage/databaseChangeAccumulator.ts
@@ -1,0 +1,142 @@
+import type { Database } from './database.svelte'
+import type { DatabaseUpdateInfo } from './databaseState.svelte'
+import type { toSaveType } from './risuSave'
+
+export interface DatabaseChangeContext {
+    database: Database
+    selectedCharacterIndex: number
+}
+
+export interface DatabaseChangeResult {
+    requiresFullEncoderReload: boolean
+}
+
+function createChangeTracker(): toSaveType {
+    return {
+        character: [],
+        botPreset: false,
+        modules: false,
+        loadouts: false,
+        plugins: false,
+        pluginCustomStorage: false,
+    }
+}
+
+export function cloneChangeTracker(tracker: toSaveType): toSaveType {
+    return {
+        ...tracker,
+        character: [...tracker.character],
+    }
+}
+
+function mergeChangeTrackers(target: toSaveType, source: toSaveType) {
+    for (const characterId of source.character) {
+        if (!target.character.includes(characterId)) {
+            target.character.push(characterId)
+        }
+    }
+    target.botPreset ||= source.botPreset
+    target.modules ||= source.modules
+    target.loadouts ||= source.loadouts
+    target.plugins ||= source.plugins
+    target.pluginCustomStorage ||= source.pluginCustomStorage
+}
+
+export class DatabaseChangeAccumulator {
+    private changes = createChangeTracker()
+
+    record(info: DatabaseUpdateInfo, context: DatabaseChangeContext): DatabaseChangeResult {
+        if (info.path.length === 0) {
+            return {
+                requiresFullEncoderReload: true,
+            }
+        }
+
+        const rootKey = info.path[0]
+
+        if (rootKey === 'botPresets' || rootKey === 'botPresetsId') {
+            this.changes.botPreset = true
+            return {
+                requiresFullEncoderReload: false,
+            }
+        }
+
+        if (rootKey === 'modules') {
+            this.changes.modules = true
+            return {
+                requiresFullEncoderReload: false,
+            }
+        }
+
+        if (rootKey === 'loadouts' || rootKey === 'plugins' || rootKey === 'pluginCustomStorage') {
+            this.changes[rootKey] = true
+            return {
+                requiresFullEncoderReload: false,
+            }
+        }
+
+        if (rootKey === 'characters') {
+            const affectedCharacters: Database['characters'] = []
+
+            if (info.path.length === 1) {
+                const oldCharacters = info.oldValue as Database['characters'] | undefined
+                const newCharacters = info.value as Database['characters'] | undefined
+                affectedCharacters.push(...(oldCharacters ?? []), ...(newCharacters ?? []))
+            }
+            else if (typeof info.path[1] === 'number') {
+                if (info.path.length === 2) {
+                    const oldCharacter = info.oldValue as Database['characters'][number] | undefined
+                    if (oldCharacter) {
+                        affectedCharacters.push(oldCharacter)
+                    }
+                }
+                const currentCharacter = context.database.characters[info.path[1]]
+                if (currentCharacter) {
+                    affectedCharacters.push(currentCharacter)
+                }
+            }
+
+            for (const character of affectedCharacters) {
+                this.recordCharacter(character.chaId)
+            }
+
+            return {
+                requiresFullEncoderReload: false,
+            }
+        }
+
+        const selectedCharacter = context.database.characters[context.selectedCharacterIndex]
+        if (selectedCharacter) {
+            this.recordCharacter(selectedCharacter.chaId)
+        }
+
+        return {
+            requiresFullEncoderReload: false,
+        }
+    }
+
+    take(): toSaveType {
+        const changes = this.changes
+        this.changes = createChangeTracker()
+        return changes
+    }
+
+    restore(changes: toSaveType) {
+        mergeChangeTrackers(this.changes, changes)
+    }
+
+    hasChanges(): boolean {
+        return this.changes.character.length > 0 ||
+            this.changes.botPreset ||
+            this.changes.modules ||
+            this.changes.loadouts ||
+            this.changes.plugins ||
+            this.changes.pluginCustomStorage
+    }
+
+    private recordCharacter(characterId: string) {
+        if (!this.changes.character.includes(characterId)) {
+            this.changes.character.unshift(characterId)
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Extract database mutation classification and pending-save tracking from `saveDb()` into a dedicated `DatabaseChangeAccumulator`.

The accumulator converts existing `DatabaseUpdateInfo` events into the existing `toSaveType` representation, supports atomic take/reset behavior, deduplicates affected character IDs, and restores pending changes after failed saves.

## Related Issues

None.

## Changes

- Add a Svelte-independent `DatabaseChangeAccumulator` module.
- Preserve the existing classification rules for characters, presets, modules, loadouts, plugins, and plugin custom storage.
- Preserve full encoder reload handling for database root replacements.
- Move pending-change snapshot and failed-save restoration logic out of `saveDb()`.
- Keep a separate encoder input copy because `RisuSaveEncoder.set()` mutates the character list it receives.
- Add focused tests for classification, deduplication, root replacement, take/reset behavior, independent snapshots, in-flight changes, and failed-save restoration.

## Impact

This is intended to be a behavior-preserving refactor. It does not change the database proxy, save format, encoder behavior, debounce timing, storage writes, retry policy, or backup behavior.

The extraction gives save change tracking a focused boundary while retaining pending mutations that occur during an active or failed save.

## Additional Notes

Validation completed:

- `pnpm exec vitest run src/ts/storage/databaseChangeAccumulator.test.ts src/ts/storage/databaseState.svelte.test.ts` - 48 tests passed
- `pnpm check` - 0 errors and 0 warnings
- `git diff --check` - passed