### PR TITLE
feat: add Gemini 3.6 Flash and 3.5 Flash models

### DIFF
--- a/src/ts/model/providers/google.ts
+++ b/src/ts/model/providers/google.ts
@@ -19,7 +19,7 @@ export const GoogleModels: LLMModel[] = [
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
         flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
-        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true
     },

--- a/src/ts/model/providers/google.ts
+++ b/src/ts/model/providers/google.ts
@@ -2,6 +2,38 @@ import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, type LLMModel } from '.
 
 export const GoogleModels: LLMModel[] = [
 
+    // ===== Gemini 3.5/3.6 Series (2026) =====
+    {
+        name: "Gemini Flash 3.6",
+        id: 'gemini-3.6-flash',
+        provider: LLMProvider.GoogleCloud,
+        format: LLMFormat.GoogleCloud,
+        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
+        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p'],
+        tokenizer: LLMTokenizer.GoogleCloud,
+        recommended: true
+    },
+    {
+        name: "Gemini Flash 3.5",
+        id: 'gemini-3.5-flash',
+        provider: LLMProvider.GoogleCloud,
+        format: LLMFormat.GoogleCloud,
+        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
+        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        tokenizer: LLMTokenizer.GoogleCloud,
+        recommended: true
+    },
+    {
+        name: "Gemini Flash Lite 3.5",
+        id: 'gemini-3.5-flash-lite',
+        provider: LLMProvider.GoogleCloud,
+        format: LLMFormat.GoogleCloud,
+        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.hasFirstSystemPrompt],
+        parameters: ['reasoning_effort', 'temperature', 'top_k', 'top_p'],
+        tokenizer: LLMTokenizer.GoogleCloud,
+        recommended: true
+    },
+
     // ===== Gemini 3.1 Series (2026) =====
     {
         name: "Gemini Pro 3.1 Preview",

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -425,8 +425,9 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     console.log(arg.modelInfo);
 
     const isVertexGlobalOnlyModel = (modelId: string) => {
-        // Gemini 3 preview models and Gemini 3.6 Flash are only available on the global endpoint.
-        return /^gemini-3-.*-preview$/.test(modelId) || modelId === 'gemini-3.6-flash'
+        // Gemini 3 preview models and the 3.5/3.6 Flash family are not served from the regions
+        // selectable in settings (us-central1, us-west1); route them through the global endpoint.
+        return /^gemini-3-.*-preview$/.test(modelId) || /^gemini-3\.[56]-flash/.test(modelId)
     }
 
     async function generateToken(email:string,key:string){

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -425,8 +425,8 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     console.log(arg.modelInfo);
 
     const isVertexGlobalOnlyModel = (modelId: string) => {
-        // As of 2025-12, Gemini 3 preview models are only available on the global endpoint.
-        return /^gemini-3-.*-preview$/.test(modelId)
+        // Gemini 3 preview models and Gemini 3.6 Flash are only available on the global endpoint.
+        return /^gemini-3-.*-preview$/.test(modelId) || modelId === 'gemini-3.6-flash'
     }
 
     async function generateToken(email:string,key:string){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds the newly released Google models `gemini-3.6-flash`, `gemini-3.5-flash`, and `gemini-3.5-flash-lite` as built-in selectable models.

The existing Vertex derivation loop in `modellist.ts` picks up each entry automatically, so both the Gemini API and Vertex AI variants become available from a single definition.

## Related Issues

None.

## Changes

**`src/ts/model/providers/google.ts`**
- Added `gemini-3.6-flash`, `gemini-3.5-flash`, and `gemini-3.5-flash-lite` entries with the same multimodal input flags as `gemini-3-flash-preview`
- Used `reasoning_effort` as the thinking parameter so the effort setting maps to `thinkingConfig.thinkingLevel` once #1475 lands
- Omitted `presence_penalty` and `frequency_penalty` from all three, since these models reject non-zero penalty values

**`src/ts/process/request/google.ts`**
- Extended `isVertexGlobalOnlyModel` to route the three new models through the Vertex AI `global` endpoint, since they are not served from the regions selectable in settings

## Impact

- Three new selectable models appear for both the Gemini API and Vertex AI providers. Existing model entries and request behavior are unchanged.
- Until #1475 is merged, the thinking effort setting has no effect on these models, and they use their default dynamic thinking.
- `gemini-3.6-flash` and `gemini-3.5-flash-lite` reject requests ending with a model turn, so continue-style prefill is affected on those two models. This is pre-existing pipeline behavior and is out of scope here.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`

Live `generateContent` probes were run for all three models on both the Gemini API and the Vertex AI global endpoint (HTTP 200 with the expected thinking parts). Negative tests confirmed the choices above:

- Non-zero `presencePenalty` / `frequencyPenalty` fail with `INVALID_ARGUMENT: Penalty is not enabled for this model` on all three.
- `thinkingBudget` and `thinkingLevel` (including `minimal`, case-insensitive) all succeed.
- A request ending with a model turn fails on `gemini-3.6-flash` and `gemini-3.5-flash-lite` but succeeds on `gemini-3.5-flash`.
- SSE streaming works on `gemini-3.6-flash`.
- The new models return 404 on the `us-central1` / `us-west1` Vertex endpoints, while `gemini-2.5-flash` still serves regionally.
