### PR TITLE
fix: scope lorebook activation flags per entry

### DIFF
--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -249,8 +249,6 @@ export async function loadLoreBookV3Prompt(){
     let activatedIndexes:number[] = []
     let disabledUIPrompts:string[] = []
     let matchTimes = 0
-    let keepActivateAfterMatch = false
-    let dontActivateAfterMatch = false
     while(matching){
         matching = false
         for(let i=0;i<fullLore.length;i++){
@@ -281,6 +279,8 @@ export async function loadLoreBookV3Prompt(){
             }[] = []
             let fullWordMatching = fullWordMatchingSetting
             let dontSearchWhenRecursive = false
+            let keepActivateAfterMatch = false
+            let dontActivateAfterMatch = false
             
             if(fullLore[i].mode === 'child'){
                 activated = false


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

로어북 데코레이터 @@keep_activate_after_match, @@dont_activate_after_match 가 의도하지 않은 로어북까지 참조용 변수를 만드는 문제 수정

## Related Issues

None

## Changes

기존 코드대로면 @@keep_activate_after_match 데코레이터가 있는 로어북을 처리한 뒤, 다음 로어북에서도 데코레이터가 없음에도 내부 변수를 생성하는 문제가 있습니다.
데코레이터가 없으면 실제로 참조하지는 않지만 이렇게 각 로어북 체크할 때마다 keepActivateAfterMatch, dontActivateAfterMatch를 새로 초기화하는 편이 합리적이라고 생각해 PR 올립니다.

## Impact

실제 기능에는 변화가 없습니다.

## Additional Notes

기존에 생긴 내부 변수가 정리되지는 않습니다.