### PR TITLE
feat: add Claude 5 Opus and fix adaptive-only thinking mode

### DIFF
--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -36,6 +36,7 @@
     import { openPresetList } from "src/ts/stores.svelte";
     import { selectSingleFile } from "src/ts/util";
     import { getModelInfo, LLMFlags, LLMFormat, LLMProvider } from "src/ts/model/modellist";
+    import { resolveClaudeThinkingType } from "src/ts/model/types";
     import RegexList from "src/lib/SideBars/Scripts/RegexList.svelte";
     import SettingRenderer from "../SettingRenderer.svelte";
     import { allBasicParameterItems } from "src/ts/setting/botSettingsParamsData";
@@ -121,6 +122,13 @@
             DBState.db.nanogptRequestModel = '';
             DBState.db.nanogptRequestModelName = '';
             prevNanogptInputMode = nanogptInputMode;
+        }
+    });
+
+    $effect(() => {
+        const resolved = resolveClaudeThinkingType(modelInfo.flags, DBState.db.thinkingType)
+        if (resolved !== DBState.db.thinkingType) {
+            DBState.db.thinkingType = resolved
         }
     });
 

--- a/src/ts/model/providers/anthropic.ts
+++ b/src/ts/model/providers/anthropic.ts
@@ -2,6 +2,25 @@ import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, ClaudeParameters, type 
 
 export const AnthropicModels: LLMModel[] = [
 
+    {
+        name: "Claude 5 Opus",
+        id: 'claude-opus-5',
+        shortName: "5 Opus",
+        provider: LLMProvider.Anthropic,
+        format: LLMFormat.Anthropic,
+        flags: [
+            LLMFlags.hasImageInput,
+            LLMFlags.hasFirstSystemPrompt,
+            LLMFlags.hasStreaming,
+            LLMFlags.claudeAdaptiveThinking,
+            LLMFlags.claudeXHighEffort,
+            LLMFlags.claudeThinkingOnByDefault
+        ],
+        parameters: [],
+        tokenizer: LLMTokenizer.Claude,
+        recommended: true
+    },
+
     // Claude 4.8 (No Date)
     {
         name: "Claude 4.8 Opus",

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -102,6 +102,19 @@ export const LLMTokenizer = {
 } as const;
 export type LLMTokenizer = (typeof LLMTokenizer)[keyof typeof LLMTokenizer];
 
+export type ClaudeThinkingType = 'off' | 'budget' | 'adaptive'
+
+export function resolveClaudeThinkingType(flags: LLMFlags[], thinkingType: ClaudeThinkingType): ClaudeThinkingType {
+    if (
+        thinkingType === 'budget' &&
+        !flags.includes(LLMFlags.claudeThinking) &&
+        flags.includes(LLMFlags.claudeAdaptiveThinking)
+    ) {
+        return 'adaptive'
+    }
+    return thinkingType
+}
+
 export interface LLMModel{
     id: string
     name: string

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -27,7 +27,8 @@ export const LLMFlags = {
     claudeXHighEffort: 23,
     deepSeekThinkingToggle: 24,
     noStructuredOutput: 25,
-    geminiThinkingNoMinimal: 26
+    geminiThinkingNoMinimal: 26,
+    claudeThinkingOnByDefault: 27
 } as const;
 export type LLMFlags = (typeof LLMFlags)[keyof typeof LLMFlags];
 

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -3,6 +3,7 @@ import { HttpRequest } from "@smithy/protocol-http"
 import { SignatureV4 } from "@smithy/signature-v4"
 import { addFetchLog, fetchNative, globalFetch, textifyReadableStream } from "src/ts/globalApi.svelte"
 import { LLMFlags, LLMFormat } from "src/ts/model/modellist"
+import { resolveClaudeThinkingType } from "src/ts/model/types"
 import { registerClaudeObserver } from "src/ts/observer.svelte"
 import { getDatabase } from "src/ts/storage/database.svelte"
 import { replaceAsync, simplifySchema, sleep } from "src/ts/util"
@@ -361,7 +362,9 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
     })
 
     // Handle thinking mode: off, adaptive, or budget
-    if(db.thinkingType === 'off'){
+    const thinkingType = resolveClaudeThinkingType(arg.modelInfo.flags, db.thinkingType)
+
+    if(thinkingType === 'off'){
         if(arg.modelInfo.flags.includes(LLMFlags.claudeThinkingOnByDefault)){
             body.thinking = { type: 'disabled' }
         }
@@ -369,7 +372,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
             delete body.thinking
         }
     }
-    else if(db.thinkingType === 'adaptive' && arg.modelInfo.flags.includes(LLMFlags.claudeAdaptiveThinking)){
+    else if(thinkingType === 'adaptive' && arg.modelInfo.flags.includes(LLMFlags.claudeAdaptiveThinking)){
         // Adaptive thinking mode
         delete body.thinking
         body.thinking = { type: 'adaptive', display: 'summarized' }

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -362,7 +362,12 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
 
     // Handle thinking mode: off, adaptive, or budget
     if(db.thinkingType === 'off'){
-        delete body.thinking
+        if(arg.modelInfo.flags.includes(LLMFlags.claudeThinkingOnByDefault)){
+            body.thinking = { type: 'disabled' }
+        }
+        else {
+            delete body.thinking
+        }
     }
     else if(db.thinkingType === 'adaptive' && arg.modelInfo.flags.includes(LLMFlags.claudeAdaptiveThinking)){
         // Adaptive thinking mode

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SettingItem } from './types';
-import { LLMFlags } from '../model/types';
+import { LLMFlags, resolveClaudeThinkingType } from '../model/types';
 
 /**
  * Basic parameter settings that are always visible
@@ -162,7 +162,7 @@ export const modelSpecificParameterItems: SettingItem[] = [
         bindKey: 'thinkingTokens',
         condition: (ctx) =>
             ctx.modelInfo.parameters.includes('thinking_tokens') &&
-            ctx.db.thinkingType === 'budget',
+            resolveClaudeThinkingType(ctx.modelInfo.flags, ctx.db.thinkingType) === 'budget',
         options: {
             min: -1,
             max: 64000,
@@ -178,7 +178,7 @@ export const modelSpecificParameterItems: SettingItem[] = [
         bindKey: 'adaptiveThinkingEffort',
         condition: (ctx) =>
             ctx.modelInfo.flags.includes(LLMFlags.claudeAdaptiveThinking) &&
-            ctx.db.thinkingType === 'adaptive',
+            resolveClaudeThinkingType(ctx.modelInfo.flags, ctx.db.thinkingType) === 'adaptive',
         options: {
             segmentOptions: [
                 { value: 'low', label: 'Low' },


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds the newly released Anthropic model `claude-opus-5` as a built-in selectable model.

Its request surface matches Claude 4.8 Opus, so the model entry is a copy with a new id. Opus 5 does change one default: omitting the `thinking` parameter now runs adaptive thinking instead of running without thinking. That exposed two gaps in how the stored thinking type is applied, both fixed here.

## Related Issues

None.

## Changes

**`src/ts/model/providers/anthropic.ts`**
- Added the `claude-opus-5` entry, mirroring `claude-opus-4-8` with an empty `parameters` list and the new `claudeThinkingOnByDefault` flag

**`src/ts/model/types.ts`**
- Added `LLMFlags.claudeThinkingOnByDefault` for models where omitting `thinking` enables thinking instead of disabling it
- Added `resolveClaudeThinkingType()` to map the stored `budget` thinking type to `adaptive` on models that support adaptive thinking but not manual token budgets

**`src/ts/process/request/anthropic.ts`**
- Resolved the thinking type before branching on it
- Sent `thinking: { type: 'disabled' }` on `claudeThinkingOnByDefault` models when thinking is off, instead of omitting the field

**`src/ts/setting/botSettingsParamsData.ts`**
- Used the resolved thinking type in the visibility conditions for the adaptive effort selector and the thinking token slider

**`src/lib/Setting/Pages/BotSettings.svelte`**
- Normalized a stored thinking type that the selected model cannot use, so the Thinking Mode control matches what is actually sent

## Impact

- A new selectable model appears under the Anthropic provider. No existing model entry is changed.
- **Claude 4.7 Opus, 4.8 Opus, and 5 Opus now run adaptive thinking under the default `budget` thinking type.** These models do not support manual token budgets, so `Budget (Manual Tokens)` is hidden for them, but `thinkingType` still defaults to `budget` and is never migrated. The request therefore carried no `thinking` field at all: 4.7 and 4.8 ran without thinking, and Opus 5 ran adaptive thinking with its reasoning hidden, which rendered as an empty `<Thoughts>` block.
- This increases token usage for 4.7 and 4.8 users who never changed the thinking setting, and makes the adaptive effort selector visible to them. Selecting `Off` restores no-thinking behavior, and `Off` now works correctly on Opus 5 as well.
- Claude 4.6 and older are unaffected, since they support manual token budgets and keep the `budget` thinking type.
- No storage format, database schema, or non-Anthropic provider behavior is changed.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

`pnpm build` completed with existing non-blocking warnings.

Live `/v1/messages` probes against `claude-opus-5` confirmed each choice in the model entry:

- `temperature`, `top_k`, and `top_p` fail with `400 ... is deprecated for this model`, so the entry keeps an empty `parameters` list.
- `thinking: { type: 'enabled', budget_tokens: N }` fails with `400 "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`, so `thinking_tokens` is not offered.
- An assistant prefill turn fails with `400 This model does not support assistant message prefill.`, so `hasPrefill` is not set.
- `thinking: { type: 'disabled' }` combined with an `output_config.effort` of `xhigh` fails with `400`, so the off path sends no `output_config`. Effort `low` through `max` all succeed with adaptive thinking.
- Streaming, the `output-128k-2025-02-19` beta header with `max_tokens` above 8192, and `extended-cache-ttl-2025-04-11` with `cache_control` all succeed.

The thinking default was verified by sending one reasoning-heavy prompt three ways. Omitting `thinking` returned a `thinking` block and billed thinking tokens, `thinking: { type: 'disabled' }` returned no `thinking` block, and `thinking: { type: 'adaptive' }` returned a summarized block. This is what `claudeThinkingOnByDefault` encodes.

#1524 also adds an `LLMFlags` entry at index 26 and inserts a branch into the same thinking chain in `anthropic.ts`. The two flags apply to disjoint model sets, so there is no behavioral interaction, but whichever merges second will need a rebase.
