### PR TITLE
feat: add sticky chat toolbar option

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -981,6 +981,7 @@ export const languageChinese = {
     "enable": "激活",
     "postFile": "上传文件",
     "requestInfoInsideChat": "在聊天中显示请求数据",
+    "stickyChatToolbar": "滚动时固定聊天工具栏和请求信息",
     "inputTokens": "输入 Tokens",
     "outputTokens": "输出 Tokens",
     "tokenWarning": "Token 计算可能不精确，仅作参考。",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -981,6 +981,7 @@ export const languageGerman = {
     "enable": "Aktivieren",
     "postFile": "Datei senden",
     "requestInfoInsideChat": "Anfrageinfo im Chat anzeigen",
+    "stickyChatToolbar": "Chat-Werkzeugleiste und Anfrageinfo beim Scrollen fixieren",
     "inputTokens": "Eingabe-Tokens",
     "outputTokens": "Ausgabe-Tokens",
     "tokenWarning": "Die Token-Berechnung kann ungenau sein. Es wird empfohlen, sie als Referenz zu verwenden.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1140,6 +1140,7 @@ export const languageEnglish = {
     enable: "Enable",
     postFile: "Post File",
     requestInfoInsideChat: "Show Request Info Inside Chat",
+    stickyChatToolbar: "Keep Chat Toolbar and Request Info Visible While Scrolling",
     inputTokens: "Input Tokens",
     outputTokens: "Output Tokens",
     tokenWarning: "Token caculation can be inaccurate. It is recommended to use it as a reference.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -981,6 +981,7 @@ export const languageSpanish = {
     "enable": "Habilitar",
     "postFile": "Publicar Archivo",
     "requestInfoInsideChat": "Mostrar Información de la Solicitud Dentro del Chat",
+    "stickyChatToolbar": "Mantener visibles la barra de herramientas y la información de la solicitud al desplazarse",
     "inputTokens": "Tokens de Entrada",
     "outputTokens": "Tokens de Salida",
     "tokenWarning": "El cálculo de tokens puede ser inexacto. se recomienda usarlo como referencia.",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1002,6 +1002,7 @@ export const languageKorean = {
     "enable": "활성화",
     "postFile": "파일 업로드",
     "requestInfoInsideChat": "채팅 내부에서 요청 정보 보이기",
+    "stickyChatToolbar": "스크롤 중 채팅 툴바와 요청 정보 고정",
     "inputTokens": "입력 토큰",
     "outputTokens": "출력 토큰",
     "tokenWarning": "토큰 계산은 정확하지 않을 수 있습니다. 참고용으로만 사용해주세요.",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -981,6 +981,7 @@ export const languageVietnamese = {
     "enable": "Bật",
     "postFile": "Đăng tập tin",
     "requestInfoInsideChat": "Hiển thị thông tin yêu cầu trong trò chuyện",
+    "stickyChatToolbar": "Giữ thanh công cụ trò chuyện và thông tin yêu cầu khi cuộn",
     "inputTokens": "Token đầu vào",
     "outputTokens": "Token đầu ra",
     "tokenWarning": "Tính toán token có thể không chính xác. Nên sử dụng nó để tham khảo.",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -981,6 +981,7 @@ export const languageChineseTraditional = {
     "enable": "啟用",
     "postFile": "上傳檔案",
     "requestInfoInsideChat": "在對話中顯示發送資料",
+    "stickyChatToolbar": "捲動時固定對話工具列與請求資訊",
     "inputTokens": "輸入 Token",
     "outputTokens": "輸出 Token",
     "tokenWarning": "Token 計算可能不精確，僅作參考。",

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -1122,7 +1122,7 @@
         {:else}
             {@render senderIcon({rounded: DBState.db.roundIcons})}
             <span class="flex flex-col ml-4 w-full max-w-full min-w-0 text-black">
-                <div class="flexium items-center chat-width">
+                <div class="chat-message-title flexium items-center chat-width">
                     {#if DBState.db.characters[selIdState.selId]?.chaId === "§playground" && !blankMessage && DBState.db.characters[selIdState.selId]?.chats?.[DBState.db.characters[selIdState.selId]?.chatPage]?.message?.[idx]}
                         <span class="chat-width text-xl border-darkborderc flex items-center text-textcolor">
                             <span>{DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage].message[idx].role === 'char' ? 'Assistant' : 'User'}</span>
@@ -1139,9 +1139,11 @@
                             <span>{name}</span>
                         </div>
                     {/if}
-                    {@render iconButtons()}
                 </div>
-                {@render genInfo()}
+                <div class="chat-toolbar-region" class:chat-toolbar-sticky={DBState.db.stickyChatToolbar}>
+                    {@render iconButtons()}
+                    {@render genInfo()}
+                </div>
                 {@render textBox()}
             </span>
         {/if}
@@ -1155,3 +1157,32 @@
     "border-amber-500": disabled === 'allBefore',
 }}></div>
 {/if}
+
+<style>
+    .chat-message-title,
+    .chat-toolbar-region {
+        min-height: 1.75rem;
+    }
+
+    .chat-toolbar-region {
+        align-self: flex-end;
+        max-width: 100%;
+        margin-top: -1.75rem;
+    }
+
+    .chat-toolbar-sticky {
+        position: sticky;
+        top: max(2rem, calc(env(safe-area-inset-top) + 0.25rem));
+        z-index: 10;
+        isolation: isolate;
+    }
+
+    .chat-toolbar-sticky::before {
+        content: "";
+        position: absolute;
+        inset: -0.5rem -0.375rem -0.25rem;
+        z-index: -1;
+        pointer-events: none;
+        background: var(--risu-theme-bgcolor);
+    }
+</style>

--- a/src/ts/setting/accessibilitySettingsData.ts
+++ b/src/ts/setting/accessibilitySettingsData.ts
@@ -130,6 +130,13 @@ export const accessibilitySettingsItems: SettingItem[] = [
         keywords: ['request', 'info', 'chat']
     },
     {
+        id: 'acc.stickyChatToolbar',
+        type: 'check',
+        labelKey: 'stickyChatToolbar',
+        bindKey: 'stickyChatToolbar',
+        keywords: ['sticky', 'chat', 'toolbar', 'request', 'info', 'scroll']
+    },
+    {
         id: 'acc.inlayErrorResponse',
         type: 'check',
         labelKey: 'inlayErrorResponse',

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -689,6 +689,7 @@ export function setDatabase(data:Database){
     data.autoScrollToNewMessage ??= true
     data.alwaysScrollToNewMessage ??= false
     data.newMessageButtonStyle ??= 'bottom-center'
+    data.stickyChatToolbar ??= false
     data.chatLoadInitialPages = normalizeChatLoadPages(data.chatLoadInitialPages, DEFAULT_CHAT_LOAD_INITIAL_PAGES)
     data.chatLoadAdditionalPages = normalizeChatLoadPages(data.chatLoadAdditionalPages, DEFAULT_CHAT_LOAD_ADDITIONAL_PAGES)
     data.streamingDisplayOptimizationMode ??= (data as {largeChatPerformanceMode?: StreamingDisplayOptimizationMode}).largeChatPerformanceMode ?? 'off'
@@ -1016,6 +1017,7 @@ export interface Database{
     enabledModules: string[]
     sideMenuRerollButton?:boolean
     requestInfoInsideChat?:boolean
+    stickyChatToolbar?:boolean
     additionalParams:[string, string][]
     applyAdditionalParamsToAll:boolean
     heightMode:string


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds an optional setting that keeps each message's chat toolbar and request information visible while scrolling through long responses.

## Related Issues

None.

## Changes

- Added a migration-safe `stickyChatToolbar` database setting and exposed it under Accessibility settings.
- Added localized setting labels for all currently supported languages.
- Separated the message title from the toolbar so only the action buttons and request information become sticky.
- Added theme-aware spacing and an opaque background so message content and interactive Lua buttons scroll cleanly behind the toolbar instead of showing through it.

## Impact

The setting is disabled by default, so existing chat behavior remains unchanged. When enabled, message actions and request details remain accessible while reading long messages.

## Preview

https://github.com/user-attachments/assets/1fa7328f-9e01-4036-90da-ab0c80afdb10
+ Also works well with Request Info option

## Additional Notes

Validated with:

- `pnpm check`
- `git diff --check`
