### PR TITLE
perf: cache Lua engines per script code and skip listenerless edit calls

### DIFF
--- a/src/ts/process/scriptings.test.ts
+++ b/src/ts/process/scriptings.test.ts
@@ -1,92 +1,269 @@
 // @vitest-environment node
+// wasmoon's emscripten glue mis-resolves its wasm path under happy-dom's fake location
+import { describe, it, expect, vi, beforeAll } from 'vitest'
 
-import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
-import { beforeAll, expect, test, vi } from 'vitest'
+//#region module mocks — scriptings.ts pulls in browser-heavy modules; stub everything but the Lua engine itself
 
-vi.mock('../parser/parser.svelte', () => ({
-  hasher: vi.fn(),
-  risuChatParser: vi.fn(),
-}))
+vi.mock(import('../parser/parser.svelte'), () => ({
+    hasher: async () => 'mockhash',
+    risuChatParser: (v: string) => v,
+}) as unknown as typeof import('../parser/parser.svelte'))
 
-vi.mock('../alert', () => ({
-  alertConfirm: vi.fn(),
-  alertError: vi.fn(),
-  alertInput: vi.fn(),
-  alertNormal: vi.fn(),
-  alertSelect: vi.fn(),
-}))
+vi.mock(import('../parser/chatVar.svelte'), () => ({
+    getChatVar: () => 'null',
+    setChatVar: () => {},
+    getGlobalChatVar: () => 'null',
+}) as unknown as typeof import('../parser/chatVar.svelte'))
 
-vi.mock('../globalApi.svelte', () => ({ fetchNative: vi.fn(), readImage: vi.fn() }))
-vi.mock('../tokenizer', () => ({ tokenize: vi.fn() }))
-vi.mock('../util', () => ({
-  asBuffer: vi.fn(),
-  getPersonaPrompt: vi.fn(),
-  getUserIcon: vi.fn(),
-  getUserName: vi.fn(),
-}))
+vi.mock(import('../storage/database.svelte'), () => ({
+    getCurrentCharacter: () => ({ type: 'character', chats: [{ message: [] }], chatPage: 0, triggerscript: [] }),
+    getCurrentChat: () => ({ message: [] }),
+    getDatabase: () => ({ characters: [] }),
+    setDatabase: () => {},
+}) as unknown as typeof import('../storage/database.svelte'))
 
-vi.mock('../storage/database.svelte', () => ({
-  getCurrentCharacter: vi.fn(() => ({})),
-  getCurrentChat: vi.fn(() => ({ message: [] })),
-  getDatabase: vi.fn(() => ({ characters: [] })),
-  setDatabase: vi.fn(),
-}))
-
-vi.mock('../stores.svelte', () => ({
-  DBState: { db: {} },
-  ReloadChatPointer: { update: vi.fn() },
-  ReloadGUIPointer: { update: vi.fn() },
-  selectedCharID: { subscribe: (run: (value: number) => void) => (run(0), () => undefined) },
-}))
-
-vi.mock('./modules', () => ({
-  getModuleLorebooks: vi.fn(() => []),
-  getModuleTriggers: vi.fn(() => []),
-}))
-
-vi.mock('./files/inlays', () => ({ getInlayAsset: vi.fn(), writeInlayImage: vi.fn() }))
-vi.mock('./lorebook.svelte', () => ({ loadLoreBookV3Prompt: vi.fn() }))
-vi.mock('./memory/hypamemory', () => ({ HypaProcesser: vi.fn() }))
-vi.mock('./request/request', () => ({ requestChatData: vi.fn() }))
-vi.mock('./stableDiff', () => ({ generateAIImage: vi.fn() }))
-
-let runScripted: typeof import('./scriptings').runScripted
-
-beforeAll(async () => {
-  const jsonLua = await readFile(resolve(process.cwd(), 'public/lua/json.lua'), 'utf8')
-  vi.stubGlobal('fetch', vi.fn(async () => new Response(jsonLua, { status: 200 })))
-  const scriptings = await import('./scriptings')
-  runScripted = scriptings.runScripted
+vi.mock(import('../stores.svelte'), async () => {
+    const { writable } = await import('svelte/store')
+    return {
+        DBState: { db: { characters: [] } },
+        ReloadChatPointer: writable({}),
+        ReloadGUIPointer: writable(0),
+        selectedCharID: writable(0),
+    } as unknown as typeof import('../stores.svelte')
 })
 
-test('does not stop generation when setStateChanged is a no-op', async () => {
-  const result = await runScripted(
-    `
-      function onStart(id)
-        return setStateChanged(id, "unchanged", "value")
-      end
-    `,
-    {
-      char: {} as never,
-      chat: { message: [] } as never,
-      setVar: () => false,
-      getVar: () => 'null',
-      mode: 'start',
-    }
-  )
+vi.mock(import('../alert'), () => ({
+    alertSelect: async () => '0',
+    alertError: () => {},
+    alertInput: async () => '',
+    alertNormal: () => {},
+    alertConfirm: async () => false,
+}) as unknown as typeof import('../alert'))
 
-  expect(result.stopSending).toBe(false)
-  expect(result.res).toBeNull()
+vi.mock(import('./memory/hypamemory'), () => ({
+    HypaProcesser: class {
+        async addText() {}
+        async similaritySearch() { return [] }
+    },
+}) as unknown as typeof import('./memory/hypamemory'))
+
+vi.mock(import('./stableDiff'), () => ({
+    generateAIImage: async () => '',
+}) as unknown as typeof import('./stableDiff'))
+
+vi.mock(import('./files/inlays'), () => ({
+    writeInlayImage: async () => '',
+    getInlayAsset: async () => null,
+}) as unknown as typeof import('./files/inlays'))
+
+vi.mock(import('./request/request'), () => ({
+    requestChatData: async () => ({ type: 'fail', result: 'mocked' }),
+}) as unknown as typeof import('./request/request'))
+
+vi.mock(import('./modules'), () => ({
+    getModuleTriggers: () => [],
+    getModuleLorebooks: () => [],
+}) as unknown as typeof import('./modules'))
+
+vi.mock(import('../tokenizer'), () => ({
+    tokenize: async () => 0,
+}) as unknown as typeof import('../tokenizer'))
+
+vi.mock(import('../globalApi.svelte'), () => ({
+    fetchNative: async () => ({ status: 200, text: async () => '' }),
+    readImage: async () => new Uint8Array(),
+}) as unknown as typeof import('../globalApi.svelte'))
+
+vi.mock(import('./lorebook.svelte'), () => ({
+    loadLoreBookV3Prompt: async () => ({ actives: [] }),
+}) as unknown as typeof import('./lorebook.svelte'))
+
+vi.mock(import('../util'), () => ({
+    asBuffer: (v: unknown) => v,
+    getPersonaPrompt: () => '',
+    getUserName: () => 'user',
+    getUserIcon: () => '',
+    selectSingleFile: async () => ({ data: null }),
+}) as unknown as typeof import('../util'))
+
+//#endregion
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { LuaFactory } from 'wasmoon'
+import { Mutex } from '../mutex'
+import { runScripted } from './scriptings'
+
+//the factory fetches /lua/json.lua at runtime; serve the real file from disk
+const jsonLua = fs.readFileSync(
+    path.resolve(process.cwd(), 'public/lua/json.lua'),
+    'utf-8'
+)
+
+const createEngineSpy = vi.spyOn(LuaFactory.prototype, 'createEngine')
+const runExclusiveSpy = vi.spyOn(Mutex.prototype, 'runExclusive')
+
+beforeAll(() => {
+    vi.stubGlobal('fetch', async () => ({ status: 200, text: async () => jsonLua }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
 })
 
-test('keeps explicit false as the generation stop signal', async () => {
-  const result = await runScripted('function onStart() return false end', {
-    char: {} as never,
-    chat: { message: [] } as never,
-    mode: 'start',
-  })
+const baseArg = (mode: string, data: string) => ({
+    char: { type: 'simple', customscript: [], chaId: 'test-char' } as any,
+    chat: { message: [] } as any,
+    mode,
+    data,
+    setVar: () => {},
+    getVar: () => 'null',
+})
 
-  expect(result.res).toBe(false)
-  expect(result.stopSending).toBe(true)
+describe('runScripted engine cache', () => {
+    it('creates one engine per script code and reuses it across calls and modes', async () => {
+        const code = `
+listenEdit('editDisplay', function(id, data) return data .. '!' end)
+function onOutput() return false end
+`
+        const before = createEngineSpy.mock.calls.length
+
+        const r1 = await runScripted(code, baseArg('editDisplay', 'hello'))
+        expect(r1.res).toBe('hello!')
+        expect(createEngineSpy.mock.calls.length).toBe(before + 1)
+
+        const r2 = await runScripted(code, baseArg('editDisplay', 'world'))
+        expect(r2.res).toBe('world!')
+
+        //different mode reuses the same engine, and its lua globals are shared
+        const r3 = await runScripted(code, baseArg('output', ''))
+        expect(r3.stopSending).toBe(true)
+
+        expect(createEngineSpy.mock.calls.length).toBe(before + 1)
+    })
+
+    it('does not recreate engines when two scripts alternate (old thrashing case)', async () => {
+        const codeA = `listenEdit('editDisplay', function(id, data) return data .. 'A' end)`
+        const codeB = `listenEdit('editDisplay', function(id, data) return data .. 'B' end)`
+        const before = createEngineSpy.mock.calls.length
+
+        for (let i = 0; i < 3; i++) {
+            const rA = await runScripted(codeA, baseArg('editDisplay', 'm'))
+            expect(rA.res).toBe('mA')
+            const rB = await runScripted(codeB, baseArg('editDisplay', 'm'))
+            expect(rB.res).toBe('mB')
+        }
+
+        expect(createEngineSpy.mock.calls.length).toBe(before + 2)
+    })
+
+    it('evicts the least recently used engine past the cache limit and rebuilds it on next use', async () => {
+        const codes = Array.from({ length: 17 }, (_, i) =>
+            `function onOutput() return false end --script ${i}`)
+        const before = createEngineSpy.mock.calls.length
+
+        for (const code of codes) {
+            await runScripted(code, baseArg('output', ''))
+        }
+        expect(createEngineSpy.mock.calls.length).toBe(before + 17)
+
+        //most recent one is still cached
+        await runScripted(codes[16], baseArg('output', ''))
+        expect(createEngineSpy.mock.calls.length).toBe(before + 17)
+
+        //oldest one was evicted, so it gets rebuilt
+        await runScripted(codes[0], baseArg('output', ''))
+        expect(createEngineSpy.mock.calls.length).toBe(before + 18)
+    })
+})
+
+describe('runScripted listener skip', () => {
+    it('skips engine invocation for edit modes with no registered listener', async () => {
+        const code = `function onOutput() return false end --skip test`
+
+        //first call must run to discover the listener flags; with no listener the data passes through
+        const r1 = await runScripted(code, baseArg('editDisplay', 'hello'))
+        expect(r1.res).toBe('hello')
+
+        const engines = createEngineSpy.mock.calls.length
+        const runs = runExclusiveSpy.mock.calls.length
+
+        //subsequent edit-mode calls return without touching the engine or the mutex
+        const chat = { message: [] } as any
+        const r2 = await runScripted(code, { ...baseArg('editDisplay', 'hello'), chat })
+        expect(r2.res).toBe(undefined)
+        expect(r2.stopSending).toBe(false)
+        expect(r2.chat).toBe(chat)
+        await runScripted(code, baseArg('editInput', 'hello'))
+        await runScripted(code, baseArg('editOutput', 'hello'))
+        await runScripted(code, baseArg('editRequest', 'hello'))
+
+        expect(runExclusiveSpy.mock.calls.length).toBe(runs)
+        expect(createEngineSpy.mock.calls.length).toBe(engines)
+
+        //non-edit modes still run normally
+        const r3 = await runScripted(code, baseArg('output', ''))
+        expect(r3.stopSending).toBe(true)
+    })
+
+    it('does not skip when a listener is registered', async () => {
+        const code = `listenEdit('editInput', function(id, data) return data .. '?' end)`
+
+        await runScripted(code, baseArg('editInput', 'a'))
+        const runs = runExclusiveSpy.mock.calls.length
+
+        const r = await runScripted(code, baseArg('editInput', 'b'))
+        expect(r.res).toBe('b?')
+        expect(runExclusiveSpy.mock.calls.length).toBe(runs + 1)
+    })
+
+    it('picks up listeners registered late inside a handler', async () => {
+        const code = `
+function onStart()
+    listenEdit('editDisplay', function(id, data) return data .. '#' end)
+end
+`
+        //no listener yet: first call runs (data passes through), then flags mark editDisplay as empty
+        const r1 = await runScripted(code, baseArg('editDisplay', 'hi'))
+        expect(r1.res).toBe('hi')
+        //second call is skipped (res undefined, callers fall back to their own data)
+        const r2 = await runScripted(code, baseArg('editDisplay', 'hi'))
+        expect(r2.res).toBe(undefined)
+
+        //onStart registers the listener; flags refresh after the run
+        await runScripted(code, baseArg('start', ''))
+
+        const r3 = await runScripted(code, baseArg('editDisplay', 'hi'))
+        expect(r3.res).toBe('hi#')
+    })
+})
+
+describe('setStateChanged stop signal', () => {
+    it('does not stop generation when setStateChanged is a no-op', async () => {
+        const result = await runScripted(
+            `
+function onStart(id)
+    return setStateChanged(id, "unchanged", "value")
+end
+`,
+            {
+                char: {} as never,
+                chat: { message: [] } as never,
+                setVar: () => false,
+                getVar: () => 'null',
+                mode: 'start',
+            }
+        )
+
+        expect(result.stopSending).toBe(false)
+        expect(result.res).toBeNull()
+    })
+
+    it('keeps explicit false as the generation stop signal', async () => {
+        const result = await runScripted('function onStart() return false end', {
+            char: {} as never,
+            chat: { message: [] } as never,
+            mode: 'start',
+        })
+
+        expect(result.res).toBe(false)
+        expect(result.stopSending).toBe(true)
+    })
 })

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -33,8 +33,12 @@ interface BasicScriptingEngineState {
     getVar?: (key:string) => string,
 }
 
+type EditListenerMode = 'editRequest'|'editDisplay'|'editInput'|'editOutput'
+
 interface LuaScriptingEngineState extends BasicScriptingEngineState {
     engine?: LuaEngine;
+    listenerFlags?: Record<EditListenerMode, boolean>;
+    listenerFlagsDirty?: boolean;
     type: 'lua';
 }
 
@@ -45,9 +49,11 @@ interface PythonScriptingEngineState extends BasicScriptingEngineState {
 
 type ScriptingEngineState = LuaScriptingEngineState | PythonScriptingEngineState;
 
+//keyed by script code and LRU-bounded, so multiple scripts never evict each other per call.
+//`mode` only selects which global function runs on an engine.
 let ScriptingEngines = new Map<string, ScriptingEngineState>()
 let luaFactoryPromise: Promise<void> | null = null;
-let pendingEngineCreations = new Map<string, Promise<ScriptingEngineState>>();
+const ENGINE_CACHE_LIMIT = 16
 
 export async function runScripted(code:string, arg:{
     char?:character|groupChat|simpleCharacterArgument,
@@ -72,10 +78,21 @@ export async function runScripted(code:string, arg:{
     let stopSending = false
     let lowLevelAccess = arg.lowLevelAccess ?? false
 
+    const isEditMode = mode === 'editRequest' || mode === 'editDisplay' || mode === 'editInput' || mode === 'editOutput'
+    if(type === 'lua' && isEditMode){
+        const cachedState = ScriptingEngines.get(code)
+        if(cachedState?.type === 'lua' && cachedState.code === code &&
+            cachedState.listenerFlags?.[mode as EditListenerMode] === false){
+            //the script registered no listener for this mode, so running it would be a no-op
+            touchEngineState(code, cachedState)
+            return { stopSending, chat, res: undefined }
+        }
+    }
+
     if(type === 'lua'){
         await ensureLuaFactory()
     }
-    let ScriptingEngineState = await getOrCreateEngineState(mode, type);
+    const ScriptingEngineState = getOrCreateEngineState(code, type);
     
     return await ScriptingEngineState.mutex.runExclusive(async () => {
         ScriptingEngineState.chat = chat
@@ -85,7 +102,7 @@ export async function runScripted(code:string, arg:{
             let declareAPI:(name: string, func:Function) => void
 
             if(ScriptingEngineState.type === 'lua'){
-                console.log('Creating new Lua engine for mode:', mode)
+                console.log('Creating new Lua engine')
                 ScriptingEngineState.engine?.global.close()
                 ScriptingEngineState.code = code
                 ScriptingEngineState.engine = await luaFactory.createEngine({injectObjects: true})
@@ -95,13 +112,18 @@ export async function runScripted(code:string, arg:{
                 }
             }
             if(ScriptingEngineState.type === 'py'){
-                console.log('Creating new Pyodide context for mode:', mode)
+                console.log('Creating new Pyodide context')
                 ScriptingEngineState.pyodide?.close()
                 ScriptingEngineState.pyodide = new PyodideContext()
                 declareAPI = (name:string, func:Function) => {
                     ScriptingEngineState.pyodide?.declareAPI(name, func as any)
                 }
             }
+            declareAPI('__notifyListenEdit', () => {
+                if(ScriptingEngineState.type === 'lua'){
+                    ScriptingEngineState.listenerFlagsDirty = true
+                }
+            })
             declareAPI('getChatVar', (id:string,key:string) => {
                 return ScriptingEngineState.getVar(key)
             })
@@ -1053,7 +1075,6 @@ export async function runScripted(code:string, arg:{
                 return ''
             })
 
-            console.log('Running Lua code:', code)
             if(ScriptingEngineState.type === 'lua'){
                 await ScriptingEngineState.engine?.doString(luaCodeWrapper(code))
             }
@@ -1129,6 +1150,11 @@ export async function runScripted(code:string, arg:{
                 }
             } catch (error) {
                 console.error(error)
+            }
+            //only re-query listener registrations when listenEdit was actually called during this run
+            if(ScriptingEngineState.listenerFlagsDirty !== false){
+                await refreshListenerFlags(ScriptingEngineState)
+                ScriptingEngineState.listenerFlagsDirty = false
             }
         }
         if(ScriptingEngineState.type === 'py'){
@@ -1213,35 +1239,71 @@ async function ensureLuaFactory() {
     }
 }
 
-async function getOrCreateEngineState(
-    mode: string, 
+function touchEngineState(code: string, state: ScriptingEngineState){
+    //re-insert to mark as most recently used
+    ScriptingEngines.delete(code)
+    ScriptingEngines.set(code, state)
+}
+
+function disposeEngineState(state: ScriptingEngineState){
+    //the mutex queue is FIFO, so this waits for any in-flight run before closing
+    state.mutex.runExclusive(async () => {
+        if(state.type === 'lua'){
+            state.engine?.global.close()
+        }
+        else{
+            state.pyodide?.close()
+        }
+    }).catch(console.error)
+}
+
+function getOrCreateEngineState(
+    code: string,
     type: 'lua'|'py'
-): Promise<ScriptingEngineState> {
-    let engineState = ScriptingEngines.get(mode);
-    if (engineState) {
-        return engineState;
+): ScriptingEngineState {
+    const existing = ScriptingEngines.get(code);
+    if (existing && existing.type === type) {
+        touchEngineState(code, existing)
+        return existing;
     }
-    
-    let pendingCreation = pendingEngineCreations.get(mode);
-    if (pendingCreation) {
-        return pendingCreation;
+    if (existing) {
+        //same code requested with a different engine type
+        ScriptingEngines.delete(code)
+        disposeEngineState(existing)
     }
-    
-    const creationPromise = (() => {
-        const engineState: ScriptingEngineState = {
-            mutex: new Mutex(),
-            type: type,
-        };
-        ScriptingEngines.set(mode, engineState);
 
-        pendingEngineCreations.delete(mode);
+    const engineState: ScriptingEngineState = {
+        mutex: new Mutex(),
+        type: type,
+    };
+    ScriptingEngines.set(code, engineState);
 
-        return Promise.resolve(engineState);
-    })();
-    
-    pendingEngineCreations.set(mode, creationPromise);
-    
-    return creationPromise;
+    while (ScriptingEngines.size > ENGINE_CACHE_LIMIT) {
+        const oldestCode = ScriptingEngines.keys().next().value
+        const oldestState = ScriptingEngines.get(oldestCode)
+        ScriptingEngines.delete(oldestCode)
+        disposeEngineState(oldestState)
+    }
+
+    return engineState;
+}
+
+async function refreshListenerFlags(state: LuaScriptingEngineState){
+    try {
+        const listenerFlags = state.engine?.global.get('__listenerFlags')
+        if(!listenerFlags){
+            return
+        }
+        const flags = Number(await listenerFlags())
+        state.listenerFlags = {
+            editRequest: (flags & 1) !== 0,
+            editDisplay: (flags & 2) !== 0,
+            editInput: (flags & 4) !== 0,
+            editOutput: (flags & 8) !== 0,
+        }
+    } catch (error) {
+        state.listenerFlags = undefined
+    }
 }
 
 function luaCodeWrapper(code:string){
@@ -1303,6 +1365,7 @@ local editInputFuncs = {}
 local editOutputFuncs = {}
 
 function listenEdit(type, func)
+    __notifyListenEdit()
     if type == 'editRequest' then
         editRequestFuncs[#editRequestFuncs + 1] = func
         return
@@ -1324,6 +1387,15 @@ function listenEdit(type, func)
     end
 
     throw('Invalid type')
+end
+
+function __listenerFlags()
+    local flags = 0
+    if #editRequestFuncs > 0 then flags = flags + 1 end
+    if #editDisplayFuncs > 0 then flags = flags + 2 end
+    if #editInputFuncs > 0 then flags = flags + 4 end
+    if #editOutputFuncs > 0 then flags = flags + 8 end
+    return flags
 end
 
 function getState(id, name)


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Lua trigger scripts currently pay a heavy per-call cost: engines are cached per `mode` but invalidated by code comparison, so whenever two or more Lua scripts are active (character card + module) every single call tears down and rebuilds the entire Lua WASM VM — and the `editDisplay` path runs once per rendered message. This PR keys the engine cache by script code (with an LRU cap) and skips edit-mode calls entirely when the script registered no listener for that mode.

## Related Issues

Follow-up to #1459 (merged) — rebased on top of it; see *Relation to #1459* at the end of *Additional Notes*.

## Changes

All changes are in `src/ts/process/scriptings.ts` (+ new tests).

**1. Engine cache keyed by script code instead of mode**
- `ScriptingEngines` is now keyed by the script's code with an LRU cap of 16 (`ENGINE_CACHE_LIMIT`). `mode` only selects which Lua global function is invoked.
- Previously, one script occupied a separate VM for every mode it ran in (`start`/`output`/`editDisplay`/`onButtonClick`/each manual trigger name/...), each re-executing the script's top level; and two scripts sharing a mode evicted each other on every call, rebuilding the VM (create engine + redeclare ~60 APIs + re-run wrapper) per rendered message.
- Evicted engines are closed via their own mutex (FIFO), so an in-flight run always finishes before its engine is destroyed.
- This also removes a latent bug where a state created for `lua` could be handed to a `py` request for the same mode key.

**2. Skip edit-mode calls with no registered listener**
- After any run that called `listenEdit` (tracked by a `__notifyListenEdit` dirty flag), the wrapper's `__listenerFlags()` is queried once and cached on the engine state.
- Subsequent `editRequest`/`editDisplay`/`editInput`/`editOutput` calls whose mode has no listener return immediately — no mutex, no coroutine, no JSON round trip. Scripts that register listeners late (e.g. inside `onStart`) are still picked up, because flags are refreshed after the run that performed the registration.
- Callers are unaffected: the skip returns `res: undefined` and every caller already falls back with `res ?? data`.

**3. Misc**
- Removed the `console.log` that dumped the entire script source on every engine creation.

**Tests**
- `scriptings.test.ts`: 6 functional tests running real wasmoon — engine reuse across calls and modes, no recreation when two scripts alternate (regression guard for the thrashing case), LRU eviction and rebuild, listener-skip contract (`res`/`chat`/`stopSending`), no-skip when a listener exists, and late `listenEdit` registration inside a handler. #1459's two `setStateChanged` tests (which introduced the same file on main) are folded in as well.
- The benchmark script is intentionally **not** committed (it has no lasting product value). It is attached under *Additional Notes* below; it only uses the public `runScripted` API, so it reproduces the numbers on any revision — save it as `src/ts/process/scriptings.perf.test.ts` and run:
  `RUN_PERF=1 npx vitest run src/ts/process/scriptings.perf.test.ts`

## Impact

Benchmark (median of 3 runs, Node/vitest, 30 rendered messages of ~840 chars):

| Scenario | before | after |
|---|---|---|
| 2 Lua trigger scripts (card + module), both listening on `editDisplay` | 3.55 ms/call | 1.19 ms/call (**~3×**) |
| 2 Lua trigger scripts, no edit listeners | 2.61 ms/call | 0.11 ms/call (**~24×**) |
| Single script listening on `editDisplay` (regression check) | 0.41 ms/call | 0.40 ms/call (parity) |
| Single card Lua with `editDisplay` listener, session of 30 messages | 19.2 ms, **3 VMs** | 15.1 ms, **1 VM** |
| Single card Lua without edit listeners (`onStart`/`onOutput` only), same session | 15.0 ms, 3 VMs | 3.5 ms, 1 VM (**~4.3×**) |

These are Node microbenchmark numbers; in the browser, WASM VM creation is more expensive, so the real-world gains for the thrashing/no-listener cases are larger.

**Behavior changes (intentional):**
- Lua globals are now shared across modes of the same script (previously a global set in `onOutput` was invisible to `editDisplay` because each mode had its own VM). This matches what script authors generally expect.
- A script's top-level code runs once per script instead of once per mode.
- Skipped edit calls return `res: undefined` instead of the passed-through data; all existing callers use `res ?? data`, so the resulting data is identical.

**Invariant to keep in mind for future API work:** each script code now has a single mutex, so a Lua-exposed API implementation must never `await` a re-entrant `runScripted` for the same code (it would deadlock). All current APIs were audited: `LLM`/`axLLM`/`simpleLLM` → `requestChatData` → `runTrigger('request')` skips `triggerlua` via `requestAllowList`, `reloadDisplay`/`reloadChat` don't await the re-render, and `loadLoreBooksMain` doesn't invoke script processing.

## Additional Notes

- Verified with `svelte-check` (0 errors) and the full vitest suite (243 passed, after the rebase onto #1459).
- The functional tests run real wasmoon under `@vitest-environment node` (wasmoon's emscripten glue mis-resolves its wasm path under happy-dom's fake `location`), with `/lua/json.lua` served from disk via a `fetch` stub.

**Relation to #1459** (merged, this branch is rebased on top of it):

- An earlier revision of #1459 also touched engine caching, but the merged version does not — the two changes are fully complementary: #1459 skips redundant state writes (`setChatVar`/`setStateChanged`) and adds lightweight chat access APIs (`getChatData`/`getChatRole`/`getRecentChats`), while this PR removes the engine rebuild cost itself. Cheaper accessors also reduce `getFullChat` overuse, so they pair well.
- #1459's additions work unchanged with the code-keyed cache: `ScriptingEngineState.chat`/`setVar` are refreshed per run under the engine mutex, and none of the new APIs re-enter `runScripted`, so the single-mutex invariant above still holds.

<details>
<summary>Benchmark script (save as <code>src/ts/process/scriptings.perf.test.ts</code>)</summary>

```ts
// @vitest-environment node
// Benchmark for the runScripted engine cache. Gated behind RUN_PERF=1 so it
// does not run in CI. It only uses the public runScripted API, so it can be
// executed unchanged on any revision to compare numbers:
//
//   RUN_PERF=1 npx vitest run src/ts/process/scriptings.perf.test.ts
//
import { describe, it, vi, beforeAll } from 'vitest'

//#region module mocks — same set as scriptings.test.ts

vi.mock(import('../parser/parser.svelte'), () => ({
    hasher: async () => 'mockhash',
    risuChatParser: (v: string) => v,
}) as unknown as typeof import('../parser/parser.svelte'))

vi.mock(import('../parser/chatVar.svelte'), () => ({
    getChatVar: () => 'null',
    setChatVar: () => {},
    getGlobalChatVar: () => 'null',
}) as unknown as typeof import('../parser/chatVar.svelte'))

vi.mock(import('../storage/database.svelte'), () => ({
    getCurrentCharacter: () => ({ type: 'character', chats: [{ message: [] }], chatPage: 0, triggerscript: [] }),
    getCurrentChat: () => ({ message: [] }),
    getDatabase: () => ({ characters: [] }),
    setDatabase: () => {},
}) as unknown as typeof import('../storage/database.svelte'))

vi.mock(import('../stores.svelte'), async () => {
    const { writable } = await import('svelte/store')
    return {
        DBState: { db: { characters: [] } },
        ReloadChatPointer: writable({}),
        ReloadGUIPointer: writable(0),
        selectedCharID: writable(0),
    } as unknown as typeof import('../stores.svelte')
})

vi.mock(import('../alert'), () => ({
    alertSelect: async () => '0',
    alertError: () => {},
    alertInput: async () => '',
    alertNormal: () => {},
    alertConfirm: async () => false,
}) as unknown as typeof import('../alert'))

vi.mock(import('./memory/hypamemory'), () => ({
    HypaProcesser: class {
        async addText() {}
        async similaritySearch() { return [] }
    },
}) as unknown as typeof import('./memory/hypamemory'))

vi.mock(import('./stableDiff'), () => ({
    generateAIImage: async () => '',
}) as unknown as typeof import('./stableDiff'))

vi.mock(import('./files/inlays'), () => ({
    writeInlayImage: async () => '',
    getInlayAsset: async () => null,
}) as unknown as typeof import('./files/inlays'))

vi.mock(import('./request/request'), () => ({
    requestChatData: async () => ({ type: 'fail', result: 'mocked' }),
}) as unknown as typeof import('./request/request'))

vi.mock(import('./modules'), () => ({
    getModuleTriggers: () => [],
    getModuleLorebooks: () => [],
}) as unknown as typeof import('./modules'))

vi.mock(import('../tokenizer'), () => ({
    tokenize: async () => 0,
}) as unknown as typeof import('../tokenizer'))

vi.mock(import('../globalApi.svelte'), () => ({
    fetchNative: async () => ({ status: 200, text: async () => '' }),
    readImage: async () => new Uint8Array(),
}) as unknown as typeof import('../globalApi.svelte'))

vi.mock(import('./lorebook.svelte'), () => ({
    loadLoreBookV3Prompt: async () => ({ actives: [] }),
}) as unknown as typeof import('./lorebook.svelte'))

vi.mock(import('../util'), () => ({
    asBuffer: (v: unknown) => v,
    getPersonaPrompt: () => '',
    getUserName: () => 'user',
    getUserIcon: () => '',
    selectSingleFile: async () => ({ data: null }),
}) as unknown as typeof import('../util'))

//#endregion

import fs from 'node:fs'
import path from 'node:path'
import { LuaFactory } from 'wasmoon'
import { runScripted } from './scriptings'

const createEngineSpy = vi.spyOn(LuaFactory.prototype, 'createEngine')

const jsonLua = fs.readFileSync(
    path.resolve(process.cwd(), 'public/lua/json.lua'),
    'utf-8'
)

beforeAll(() => {
    vi.stubGlobal('fetch', async () => ({ status: 200, text: async () => jsonLua }))
    //engine creation logs would skew timing on the old code path
    vi.spyOn(console, 'log').mockImplementation(() => {})
})

const baseArg = (mode: string, data: string) => ({
    char: { type: 'simple', customscript: [], chaId: 'perf-char' } as any,
    chat: { message: [] } as any,
    mode,
    data,
    setVar: () => {},
    getVar: () => 'null',
})

const MESSAGES = 30
const message = 'She said, "hello there!" and walked away.\n'.repeat(20) //~840 chars, a typical chat message

describe.runIf(process.env.RUN_PERF === '1')('runScripted benchmark', () => {
    it(`A: 2 scripts with editDisplay listeners, ${MESSAGES} messages rendered`, async () => {
        const codeA = `listenEdit('editDisplay', function(id, data) return data end) --perf A`
        const codeB = `listenEdit('editDisplay', function(id, data) return data end) --perf B`

        const start = performance.now()
        for (let i = 0; i < MESSAGES; i++) {
            await runScripted(codeA, baseArg('editDisplay', message))
            await runScripted(codeB, baseArg('editDisplay', message))
        }
        const elapsed = performance.now() - start
        process.stdout.write(`[perf A] 2 scripts x ${MESSAGES} messages (both listening): ${elapsed.toFixed(1)}ms total, ${(elapsed / (MESSAGES * 2)).toFixed(2)}ms/call\n`)
    }, 120000)

    it(`B: 2 scripts with only onOutput (no edit listeners), ${MESSAGES} messages rendered`, async () => {
        const codeA = `function onOutput() end --perf skip A`
        const codeB = `function onOutput() end --perf skip B`

        const start = performance.now()
        for (let i = 0; i < MESSAGES; i++) {
            await runScripted(codeA, baseArg('editDisplay', message))
            await runScripted(codeB, baseArg('editDisplay', message))
        }
        const elapsed = performance.now() - start
        process.stdout.write(`[perf B] 2 scripts x ${MESSAGES} messages (no listeners): ${elapsed.toFixed(1)}ms total, ${(elapsed / (MESSAGES * 2)).toFixed(2)}ms/call\n`)
    }, 120000)

    it(`C: single script with editDisplay listener, ${MESSAGES} messages (parity check)`, async () => {
        const code = `listenEdit('editDisplay', function(id, data) return data end) --perf C`

        const start = performance.now()
        for (let i = 0; i < MESSAGES; i++) {
            await runScripted(code, baseArg('editDisplay', message))
        }
        const elapsed = performance.now() - start
        process.stdout.write(`[perf C] 1 script x ${MESSAGES} messages (listening): ${elapsed.toFixed(1)}ms total, ${(elapsed / MESSAGES).toFixed(2)}ms/call\n`)
    }, 120000)

    //the common real-world shape: a single character card carrying one Lua script,
    //driven across modes like a chat session (onStart once, then per message
    //an output trigger plus an editDisplay render)
    it(`D: single card lua with editDisplay listener, session of ${MESSAGES} messages`, async () => {
        const code = `
listenEdit('editDisplay', function(id, data)
    local hp = getChatVar(id, 'hp')
    return data .. '\\n[HP: ' .. hp .. ']'
end)
function onStart(id) setChatVar(id, 'hp', '100') end
function onOutput(id) end
--card D`

        const enginesBefore = createEngineSpy.mock.calls.length
        const start = performance.now()
        await runScripted(code, baseArg('start', ''))
        for (let i = 0; i < MESSAGES; i++) {
            await runScripted(code, baseArg('output', ''))
            await runScripted(code, baseArg('editDisplay', message))
        }
        const elapsed = performance.now() - start
        process.stdout.write(`[perf D] 1 card script (listening), start + ${MESSAGES} messages: ${elapsed.toFixed(1)}ms total, ${createEngineSpy.mock.calls.length - enginesBefore} engine(s) created\n`)
    }, 120000)

    it(`E: single card lua without edit listeners, session of ${MESSAGES} messages`, async () => {
        const code = `
function onStart(id) setChatVar(id, 'hp', '100') end
function onOutput(id) end
--card E`

        const enginesBefore = createEngineSpy.mock.calls.length
        const start = performance.now()
        await runScripted(code, baseArg('start', ''))
        for (let i = 0; i < MESSAGES; i++) {
            await runScripted(code, baseArg('output', ''))
            await runScripted(code, baseArg('editDisplay', message))
        }
        const elapsed = performance.now() - start
        process.stdout.write(`[perf E] 1 card script (no listeners), start + ${MESSAGES} messages: ${elapsed.toFixed(1)}ms total, ${createEngineSpy.mock.calls.length - enginesBefore} engine(s) created\n`)
    }, 120000)
})
```

</details>

