### PR TITLE
feat: add persistent API usage tracking

### DIFF
--- a/src/ts/apiUsage.test.ts
+++ b/src/ts/apiUsage.test.ts
@@ -8,16 +8,12 @@ import {
     normalizeApiUsageStats,
     recordApiUsage,
 } from './apiUsage'
+import { ApiUsageState, replaceApiUsageState } from './apiUsageState.svelte'
 import { LLMProvider } from './model/types'
-import { DBState } from './stores.svelte'
-
-vi.mock('./stores.svelte', () => ({
-    DBState: { db: {} },
-}))
 
 describe('API usage persistence', () => {
     beforeEach(() => {
-        DBState.db.apiUsage = createEmptyApiUsageStats()
+        replaceApiUsageState(createEmptyApiUsageStats())
     })
 
     it('uses local calendar dates for daily buckets', () => {
@@ -106,7 +102,7 @@ describe('API usage persistence', () => {
             date,
         })
 
-        const day = DBState.db.apiUsage.daily['2026-07-27']
+        const day = ApiUsageState.daily['2026-07-27']
         expect(day).toMatchObject({
             inputTokens: 110,
             outputTokens: 50,
@@ -126,7 +122,7 @@ describe('API usage persistence', () => {
             reportedCostUsd: 0.0123,
             costReportedRequestCount: 1,
         })
-        expect(DBState.db.apiUsage.recentRequests).toHaveLength(2)
+        expect(ApiUsageState.recentRequests).toHaveLength(2)
     })
 
     it('keeps identical model ids separate by provider', () => {
@@ -146,7 +142,7 @@ describe('API usage persistence', () => {
             date,
         })
 
-        const day = DBState.db.apiUsage.daily[getApiUsageDateKey(date)]
+        const day = ApiUsageState.daily[getApiUsageDateKey(date)]
         expect(Object.values(day.models)).toHaveLength(2)
         expect(Object.values(day.models).map((stats) => stats.provider?.name).sort()).toEqual([
             'OpenAI',
@@ -162,10 +158,10 @@ describe('API usage persistence', () => {
             billingStatus: 'not_billed',
         })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day.reportedCostUsd).toBe(0)
         expect(day.costReportedRequestCount).toBe(1)
-        expect(DBState.db.apiUsage.recentRequests[0].reportedCostUsd).toBe(0)
+        expect(ApiUsageState.recentRequests[0].reportedCostUsd).toBe(0)
     })
 
     it('drops expired recent records while retaining daily aggregates', () => {
@@ -183,8 +179,41 @@ describe('API usage persistence', () => {
             date: new Date(now),
         })
 
-        expect(DBState.db.apiUsage.recentRequests.map((record) => record.model)).toEqual(['current'])
-        expect(Object.keys(DBState.db.apiUsage.daily)).toHaveLength(2)
+        expect(ApiUsageState.recentRequests.map((record) => record.model)).toEqual(['current'])
+        expect(Object.keys(ApiUsageState.daily)).toHaveLength(2)
+    })
+
+    it('appends normal runtime records without sorting and keeps the newest 500', () => {
+        const now = Date.now()
+        const sortSpy = vi.spyOn(Array.prototype, 'sort')
+
+        for (let index = 0; index <= API_USAGE_MAX_RECENT_RECORDS; index++) {
+            recordApiUsage({
+                model: String(index),
+                inputTokens: 1,
+                outputTokens: 1,
+                date: new Date(now + index),
+            })
+        }
+
+        expect(sortSpy).not.toHaveBeenCalled()
+        expect(ApiUsageState.recentRequests).toHaveLength(API_USAGE_MAX_RECENT_RECORDS)
+        expect(ApiUsageState.recentRequests[0].model).toBe('1')
+        expect(ApiUsageState.recentRequests.at(-1)?.model).toBe(String(API_USAGE_MAX_RECENT_RECORDS))
+        sortSpy.mockRestore()
+    })
+
+    it('inserts an out-of-order runtime record at its timestamp position', () => {
+        const now = Date.now()
+        recordApiUsage({ model: 'newest', inputTokens: 1, outputTokens: 1, date: new Date(now) })
+        recordApiUsage({ model: 'oldest', inputTokens: 1, outputTokens: 1, date: new Date(now - 2) })
+        recordApiUsage({ model: 'middle', inputTokens: 1, outputTokens: 1, date: new Date(now - 1) })
+
+        expect(ApiUsageState.recentRequests.map((record) => record.model)).toEqual([
+            'oldest',
+            'middle',
+            'newest',
+        ])
     })
 
     it('caps normalized recent records', () => {
@@ -214,7 +243,7 @@ describe('API usage persistence', () => {
             outputTokens: 1,
         })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(Object.keys(day.models)).toEqual(['model:__proto__'])
     })
 

--- a/src/ts/apiUsage.test.ts
+++ b/src/ts/apiUsage.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    API_USAGE_MAX_RECENT_RECORDS,
+    API_USAGE_RECENT_RETENTION_MS,
+    createEmptyApiUsageStats,
+    getApiUsageDateKey,
+    getApiUsageProvider,
+    normalizeApiUsageStats,
+    recordApiUsage,
+} from './apiUsage'
+import { LLMProvider } from './model/types'
+import { DBState } from './stores.svelte'
+
+vi.mock('./stores.svelte', () => ({
+    DBState: { db: {} },
+}))
+
+describe('API usage persistence', () => {
+    beforeEach(() => {
+        DBState.db.apiUsage = createEmptyApiUsageStats()
+    })
+
+    it('uses local calendar dates for daily buckets', () => {
+        expect(getApiUsageDateKey(new Date(2026, 6, 5, 23, 30))).toBe('2026-07-05')
+    })
+
+    it('normalizes missing and malformed stored data', () => {
+        expect(normalizeApiUsageStats(undefined)).toEqual(createEmptyApiUsageStats())
+        expect(normalizeApiUsageStats({ daily: [], recentRequests: {} })).toEqual(createEmptyApiUsageStats())
+
+        const now = Date.now()
+        const normalized = normalizeApiUsageStats({
+            daily: {
+                '2026-07-27': {
+                    inputTokens: -10,
+                    outputTokens: 20,
+                    requestCount: 2,
+                    failedRequestCount: 1,
+                    models: {
+                        test: {
+                            inputTokens: 5,
+                            requestCount: 1,
+                        },
+                    },
+                },
+            },
+            recentRequests: [
+                {
+                    id: 'valid',
+                    timestamp: now,
+                    model: 'test',
+                    inputTokens: -1,
+                    outputTokens: 2,
+                    reportedCostUsd: -3,
+                    status: 'invalid',
+                    mode: 'invalid',
+                },
+                { id: '', timestamp: now, model: 'invalid' },
+            ],
+        }, now)
+
+        expect(normalized.daily['2026-07-27']).toMatchObject({
+            inputTokens: 0,
+            outputTokens: 20,
+            requestCount: 2,
+            successRequestCount: 1,
+            failedRequestCount: 1,
+        })
+        expect(normalized.daily['2026-07-27'].models.test).toMatchObject({
+            inputTokens: 5,
+            requestCount: 1,
+            successRequestCount: 1,
+        })
+        expect(normalized.recentRequests).toEqual([
+            expect.objectContaining({
+                id: 'valid',
+                inputTokens: 0,
+                reportedCostUsd: null,
+                status: 'success',
+                mode: 'model',
+            }),
+        ])
+    })
+
+    it('records daily, model, status, mode, token details, and provider-reported cost', () => {
+        const date = new Date(2026, 6, 27, 12)
+        recordApiUsage({
+            model: 'shared-model',
+            provider: { id: 'provider:0', name: 'OpenAI' },
+            inputTokens: 100,
+            outputTokens: 50,
+            cachedInputTokens: 30,
+            reasoningTokens: 20,
+            providerCostUsd: 0.0123,
+            status: 'success',
+            mode: 'translate',
+            date,
+        })
+        recordApiUsage({
+            model: 'shared-model',
+            provider: { id: 'provider:0', name: 'OpenAI' },
+            inputTokens: 10,
+            outputTokens: 0,
+            status: 'failed',
+            mode: 'translate',
+            date,
+        })
+
+        const day = DBState.db.apiUsage.daily['2026-07-27']
+        expect(day).toMatchObject({
+            inputTokens: 110,
+            outputTokens: 50,
+            cachedInputTokens: 30,
+            reasoningTokens: 20,
+            requestCount: 2,
+            successRequestCount: 1,
+            failedRequestCount: 1,
+            requestCountsByMode: { translate: 2 },
+            reportedCostUsd: 0.0123,
+            costReportedRequestCount: 1,
+        })
+        expect(Object.values(day.models)[0]).toMatchObject({
+            model: 'shared-model',
+            provider: { id: 'provider:0', name: 'OpenAI' },
+            requestCount: 2,
+            reportedCostUsd: 0.0123,
+            costReportedRequestCount: 1,
+        })
+        expect(DBState.db.apiUsage.recentRequests).toHaveLength(2)
+    })
+
+    it('keeps identical model ids separate by provider', () => {
+        const date = new Date()
+        recordApiUsage({
+            model: 'shared-model',
+            provider: { id: 'provider:0', name: 'OpenAI' },
+            inputTokens: 1,
+            outputTokens: 1,
+            date,
+        })
+        recordApiUsage({
+            model: 'shared-model',
+            provider: { id: 'model:openrouter', name: 'OpenRouter' },
+            inputTokens: 2,
+            outputTokens: 2,
+            date,
+        })
+
+        const day = DBState.db.apiUsage.daily[getApiUsageDateKey(date)]
+        expect(Object.values(day.models)).toHaveLength(2)
+        expect(Object.values(day.models).map((stats) => stats.provider?.name).sort()).toEqual([
+            'OpenAI',
+            'OpenRouter',
+        ])
+    })
+
+    it('stores explicitly unbilled attempts as reported zero cost', () => {
+        recordApiUsage({
+            model: 'claude',
+            inputTokens: 100,
+            outputTokens: 0,
+            billingStatus: 'not_billed',
+        })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day.reportedCostUsd).toBe(0)
+        expect(day.costReportedRequestCount).toBe(1)
+        expect(DBState.db.apiUsage.recentRequests[0].reportedCostUsd).toBe(0)
+    })
+
+    it('drops expired recent records while retaining daily aggregates', () => {
+        const now = Date.now()
+        recordApiUsage({
+            model: 'old',
+            inputTokens: 1,
+            outputTokens: 1,
+            date: new Date(now - API_USAGE_RECENT_RETENTION_MS - 1),
+        })
+        recordApiUsage({
+            model: 'current',
+            inputTokens: 2,
+            outputTokens: 2,
+            date: new Date(now),
+        })
+
+        expect(DBState.db.apiUsage.recentRequests.map((record) => record.model)).toEqual(['current'])
+        expect(Object.keys(DBState.db.apiUsage.daily)).toHaveLength(2)
+    })
+
+    it('caps normalized recent records', () => {
+        const now = Date.now()
+        const recentRequests = Array.from({ length: API_USAGE_MAX_RECENT_RECORDS + 1 }, (_, index) => ({
+                id: String(index),
+                timestamp: now - API_USAGE_MAX_RECENT_RECORDS + index,
+                model: 'model',
+                inputTokens: 1,
+                outputTokens: 1,
+                cachedInputTokens: 0,
+                reasoningTokens: 0,
+                reportedCostUsd: null,
+                status: 'success',
+                mode: 'model',
+            }))
+        const normalized = normalizeApiUsageStats({ daily: {}, recentRequests }, now)
+
+        expect(normalized.recentRequests).toHaveLength(API_USAGE_MAX_RECENT_RECORDS)
+        expect(normalized.recentRequests[0].id).toBe('1')
+    })
+
+    it('escapes unsafe model keys', () => {
+        recordApiUsage({
+            model: '__proto__',
+            inputTokens: 1,
+            outputTokens: 1,
+        })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(Object.keys(day.models)).toEqual(['model:__proto__'])
+    })
+
+    it('normalizes custom provider identity without storing request credentials', () => {
+        expect(getApiUsageProvider(
+            'reverse_proxy',
+            { name: 'Example', provider: LLMProvider.AsIs, endpoint: '' },
+            'risu::https://example.test/v1/',
+        )).toEqual({
+            id: 'custom',
+            name: 'Example',
+            url: 'https://example.test/v1',
+        })
+    })
+})

--- a/src/ts/apiUsage.ts
+++ b/src/ts/apiUsage.ts
@@ -1,0 +1,377 @@
+import { LLMProvider, ProviderNames, type LLMModel } from './model/types'
+import { DBState } from './stores.svelte'
+
+export interface ApiUsageModelStats {
+    inputTokens: number
+    outputTokens: number
+    cachedInputTokens: number
+    reasoningTokens: number
+    requestCount: number
+    successRequestCount: number
+    failedRequestCount: number
+    cancelledRequestCount: number
+    requestCountsByMode: Record<ApiUsageRequestMode, number>
+    reportedCostUsd: number
+    costReportedRequestCount: number
+    model?: string
+    provider?: ApiUsageProvider
+}
+
+export interface ApiUsageDay extends ApiUsageModelStats {
+    models: Record<string, ApiUsageModelStats>
+}
+
+export interface ApiUsageStats {
+    daily: Record<string, ApiUsageDay>
+    recentRequests: ApiUsageRecentRecord[]
+}
+
+export interface ApiUsageRecentRecord {
+    id: string
+    timestamp: number
+    model: string
+    provider?: ApiUsageProvider
+    inputTokens: number
+    outputTokens: number
+    cachedInputTokens: number
+    reasoningTokens: number
+    reportedCostUsd: number | null
+    status: ApiUsageRequestStatus
+    mode: ApiUsageRequestMode
+}
+
+export interface ApiUsageProvider {
+    id: string
+    name: string
+    url?: string
+}
+
+export type ApiUsageRequestStatus = 'success' | 'failed' | 'cancelled'
+export type ApiUsageRequestMode = 'model' | 'submodel' | 'memory' | 'emotion' | 'otherAx' | 'translate'
+export type ApiUsageBillingStatus = 'estimated' | 'not_billed' | 'unknown'
+
+export const apiUsageRequestModes: ApiUsageRequestMode[] = [
+    'model',
+    'submodel',
+    'memory',
+    'emotion',
+    'otherAx',
+    'translate',
+]
+
+export const API_USAGE_RECENT_RETENTION_MS = 48 * 60 * 60 * 1000
+export const API_USAGE_MAX_RECENT_RECORDS = 10_000
+
+export interface ApiUsageRecord {
+    model: string
+    provider?: ApiUsageProvider
+    inputTokens: number
+    outputTokens: number
+    cachedInputTokens?: number
+    reasoningTokens?: number
+    providerCostUsd?: number
+    date?: Date
+    billingStatus?: ApiUsageBillingStatus
+    status?: ApiUsageRequestStatus
+    mode?: ApiUsageRequestMode
+}
+
+export function getApiUsageProvider(
+    model: string,
+    modelInfo: Pick<LLMModel, 'name' | 'provider' | 'endpoint'>,
+    customURL?: string,
+): ApiUsageProvider {
+    if (model === 'reverse_proxy' || model.startsWith('xcustom:::')) {
+        const url = normalizeApiUsageProviderUrl(customURL ?? modelInfo.endpoint)
+        return {
+            id: 'custom',
+            name: modelInfo.name || 'Custom API',
+            ...(url ? { url } : {}),
+        }
+    }
+    if (model === 'custom' || model.startsWith('pluginmodel:::')) {
+        return { id: 'plugin', name: modelInfo.name || 'Plugin' }
+    }
+    if (modelInfo.provider === LLMProvider.AsIs) {
+        return { id: `model:${model}`, name: modelInfo.name || model }
+    }
+    return {
+        id: `provider:${modelInfo.provider}`,
+        name: ProviderNames.get(modelInfo.provider) || modelInfo.name || model,
+    }
+}
+
+export function normalizeApiUsageProviderUrl(value: string | null | undefined): string | undefined {
+    const normalized = value?.trim().replace(/^risu::/, '').replace(/\/+$/, '')
+    return normalized || undefined
+}
+
+export function createEmptyApiUsageStats(): ApiUsageStats {
+    return { daily: {}, recentRequests: [] }
+}
+
+export function normalizeApiUsageStats(value: unknown, now = Date.now()): ApiUsageStats {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return createEmptyApiUsageStats()
+    }
+
+    const normalized = createEmptyApiUsageStats()
+    const stored = value as Partial<ApiUsageStats>
+    if (stored.daily && typeof stored.daily === 'object' && !Array.isArray(stored.daily)) {
+        for (const [date, storedDay] of Object.entries(stored.daily)) {
+            if (!storedDay || typeof storedDay !== 'object' || Array.isArray(storedDay)) continue
+
+            const day = normalizeStoredStats(storedDay)
+            const storedModels = (storedDay as Partial<ApiUsageDay>).models
+            const models: Record<string, ApiUsageModelStats> = {}
+            if (storedModels && typeof storedModels === 'object' && !Array.isArray(storedModels)) {
+                for (const [model, stats] of Object.entries(storedModels)) {
+                    if (stats && typeof stats === 'object' && !Array.isArray(stats)) {
+                        models[model] = normalizeStoredStats(stats)
+                    }
+                }
+            }
+            normalized.daily[date] = { ...day, models }
+        }
+    }
+
+    if (Array.isArray(stored.recentRequests)) {
+        const cutoff = now - API_USAGE_RECENT_RETENTION_MS
+        normalized.recentRequests = stored.recentRequests
+            .map(normalizeStoredRecentRecord)
+            .filter((record): record is ApiUsageRecentRecord => Boolean(
+                record && record.timestamp >= cutoff && record.timestamp <= now,
+            ))
+            .sort((a, b) => a.timestamp - b.timestamp)
+            .slice(-API_USAGE_MAX_RECENT_RECORDS)
+    }
+
+    return normalized
+}
+
+function normalizeNonNegativeNumber(value: unknown): number {
+    return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0
+}
+
+function normalizeOptionalCost(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null
+}
+
+function normalizeStoredRecentRecord(value: unknown): ApiUsageRecentRecord | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+    const stored = value as Partial<ApiUsageRecentRecord>
+    const id = stored.id?.trim()
+    const model = stored.model?.trim()
+    const timestamp = stored.timestamp
+    if (!id || !model || !Number.isFinite(timestamp)) return null
+
+    const status = stored.status === 'failed' || stored.status === 'cancelled' ? stored.status : 'success'
+    const mode = apiUsageRequestModes.includes(stored.mode as ApiUsageRequestMode)
+        ? stored.mode as ApiUsageRequestMode
+        : 'model'
+    const provider = normalizeStoredProvider(stored.provider)
+    return {
+        id,
+        timestamp: timestamp as number,
+        model,
+        ...(provider ? { provider } : {}),
+        inputTokens: normalizeNonNegativeNumber(stored.inputTokens),
+        outputTokens: normalizeNonNegativeNumber(stored.outputTokens),
+        cachedInputTokens: normalizeNonNegativeNumber(stored.cachedInputTokens),
+        reasoningTokens: normalizeNonNegativeNumber(stored.reasoningTokens),
+        reportedCostUsd: normalizeOptionalCost(stored.reportedCostUsd),
+        status,
+        mode,
+    }
+}
+
+function normalizeStoredProvider(value: unknown): ApiUsageProvider | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+    const stored = value as Partial<ApiUsageProvider>
+    const id = stored.id?.trim()
+    const name = stored.name?.trim()
+    if (!id || !name) return undefined
+    const url = normalizeApiUsageProviderUrl(stored.url)
+    if (id === 'custom' && !url) return undefined
+    return { id, name, ...(url ? { url } : {}) }
+}
+
+export function getApiUsageDateKey(date = new Date()): string {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+}
+
+function createEmptyRequestCountsByMode(): Record<ApiUsageRequestMode, number> {
+    return Object.fromEntries(apiUsageRequestModes.map((mode) => [mode, 0])) as Record<ApiUsageRequestMode, number>
+}
+
+function createEmptyModelStats(): ApiUsageModelStats {
+    return {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedInputTokens: 0,
+        reasoningTokens: 0,
+        requestCount: 0,
+        successRequestCount: 0,
+        failedRequestCount: 0,
+        cancelledRequestCount: 0,
+        requestCountsByMode: createEmptyRequestCountsByMode(),
+        reportedCostUsd: 0,
+        costReportedRequestCount: 0,
+    }
+}
+
+function normalizeStoredStats(value: object): ApiUsageModelStats {
+    const stored = value as Partial<ApiUsageModelStats>
+    const storedRequestCount = normalizeNonNegativeNumber(stored.requestCount)
+    const failedRequestCount = normalizeNonNegativeNumber(stored.failedRequestCount)
+    const cancelledRequestCount = normalizeNonNegativeNumber(stored.cancelledRequestCount)
+    const successRequestCount = typeof stored.successRequestCount === 'number'
+        ? normalizeNonNegativeNumber(stored.successRequestCount)
+        : Math.max(0, storedRequestCount - failedRequestCount - cancelledRequestCount)
+    const requestCountsByMode = createEmptyRequestCountsByMode()
+    if (stored.requestCountsByMode && typeof stored.requestCountsByMode === 'object') {
+        for (const mode of apiUsageRequestModes) {
+            requestCountsByMode[mode] = normalizeNonNegativeNumber(stored.requestCountsByMode[mode])
+        }
+    }
+    else {
+        requestCountsByMode.model = storedRequestCount
+    }
+    const provider = normalizeStoredProvider(stored.provider)
+    const model = typeof stored.model === 'string' && stored.model.trim() ? stored.model.trim() : undefined
+    return {
+        inputTokens: normalizeNonNegativeNumber(stored.inputTokens),
+        outputTokens: normalizeNonNegativeNumber(stored.outputTokens),
+        cachedInputTokens: normalizeNonNegativeNumber(stored.cachedInputTokens),
+        reasoningTokens: normalizeNonNegativeNumber(stored.reasoningTokens),
+        requestCount: Math.max(storedRequestCount, successRequestCount + failedRequestCount + cancelledRequestCount),
+        successRequestCount,
+        failedRequestCount,
+        cancelledRequestCount,
+        requestCountsByMode,
+        reportedCostUsd: normalizeNonNegativeNumber(stored.reportedCostUsd),
+        costReportedRequestCount: normalizeNonNegativeNumber(stored.costReportedRequestCount),
+        ...(model ? { model } : {}),
+        ...(provider ? { provider } : {}),
+    }
+}
+
+function applyUsageDelta(
+    target: ApiUsageModelStats,
+    metrics: ApiUsageModelStats | ApiUsageRecentRecord,
+) {
+    target.inputTokens += metrics.inputTokens
+    target.outputTokens += metrics.outputTokens
+    target.cachedInputTokens += metrics.cachedInputTokens
+    target.reasoningTokens += metrics.reasoningTokens
+
+    if ('timestamp' in metrics) {
+        target.requestCount += 1
+        const statusField = metrics.status === 'success'
+            ? 'successRequestCount'
+            : metrics.status === 'failed'
+                ? 'failedRequestCount'
+                : 'cancelledRequestCount'
+        target[statusField] += 1
+        target.requestCountsByMode[metrics.mode] += 1
+        if (metrics.reportedCostUsd !== null) {
+            target.reportedCostUsd += metrics.reportedCostUsd
+            target.costReportedRequestCount += 1
+        }
+        return
+    }
+
+    target.requestCount += metrics.requestCount
+    target.successRequestCount += metrics.successRequestCount
+    target.failedRequestCount += metrics.failedRequestCount
+    target.cancelledRequestCount += metrics.cancelledRequestCount
+    for (const mode of apiUsageRequestModes) {
+        target.requestCountsByMode[mode] += metrics.requestCountsByMode[mode]
+    }
+    target.reportedCostUsd += metrics.reportedCostUsd
+    target.costReportedRequestCount += metrics.costReportedRequestCount
+}
+
+function getApiUsageModelStatsKey(model: string, provider?: ApiUsageProvider): string {
+    return provider
+        ? JSON.stringify([model, provider.id, provider.id === 'custom' ? provider.url ?? provider.name : ''])
+        : model
+}
+
+function getReportedCost(record: ApiUsageRecord): number | null {
+    if (record.billingStatus === 'not_billed') return 0
+    return normalizeOptionalCost(record.providerCostUsd)
+}
+
+function createApiUsageRecentRecord(
+    record: ApiUsageRecord,
+    model: string,
+    provider: ApiUsageProvider | undefined,
+    timestamp: number,
+): ApiUsageRecentRecord {
+    const id = globalThis.crypto?.randomUUID?.()
+        ?? `${timestamp}-${Math.random().toString(36).slice(2)}`
+    return {
+        id,
+        timestamp,
+        model,
+        ...(provider ? { provider } : {}),
+        inputTokens: Math.max(0, Math.round(record.inputTokens)),
+        outputTokens: Math.max(0, Math.round(record.outputTokens)),
+        cachedInputTokens: Math.max(0, Math.round(record.cachedInputTokens ?? 0)),
+        reasoningTokens: Math.max(0, Math.round(record.reasoningTokens ?? 0)),
+        reportedCostUsd: getReportedCost(record),
+        status: record.status ?? 'success',
+        mode: record.mode ?? 'model',
+    }
+}
+
+export function recordApiUsage(record: ApiUsageRecord) {
+    if (!DBState.db.apiUsage?.daily || typeof DBState.db.apiUsage.daily !== 'object') {
+        DBState.db.apiUsage = createEmptyApiUsageStats()
+    }
+    DBState.db.apiUsage.recentRequests ??= []
+
+    const timestamp = record.date?.getTime() ?? Date.now()
+    const normalizedTimestamp = Number.isFinite(timestamp) ? timestamp : Date.now()
+    const dateKey = getApiUsageDateKey(new Date(normalizedTimestamp))
+    const storedDay = DBState.db.apiUsage.daily[dateKey]
+    const day = storedDay ? {
+        ...normalizeStoredStats(storedDay),
+        models: storedDay.models && typeof storedDay.models === 'object' ? storedDay.models : {},
+    } : {
+        ...createEmptyModelStats(),
+        models: {},
+    }
+    const rawModel = record.model || 'unknown'
+    const model = ['__proto__', 'prototype', 'constructor'].includes(rawModel)
+        ? `model:${rawModel}`
+        : rawModel
+    const provider = normalizeStoredProvider(record.provider)
+    const modelStatsKey = getApiUsageModelStatsKey(model, provider)
+    const modelStats = day.models[modelStatsKey]
+        ? normalizeStoredStats(day.models[modelStatsKey])
+        : {
+            ...createEmptyModelStats(),
+            ...(provider ? { model, provider } : {}),
+        }
+    const recentRecord = createApiUsageRecentRecord(record, model, provider, normalizedTimestamp)
+
+    applyUsageDelta(day, recentRecord)
+    applyUsageDelta(modelStats, recentRecord)
+    day.models[modelStatsKey] = modelStats
+    DBState.db.apiUsage.daily[dateKey] = day
+
+    const retentionReference = Math.max(
+        normalizedTimestamp,
+        ...DBState.db.apiUsage.recentRequests.map((candidate) => candidate.timestamp),
+    )
+    const retentionCutoff = retentionReference - API_USAGE_RECENT_RETENTION_MS
+    DBState.db.apiUsage.recentRequests = [...DBState.db.apiUsage.recentRequests, recentRecord]
+        .filter((candidate) => candidate.timestamp >= retentionCutoff)
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .slice(-API_USAGE_MAX_RECENT_RECORDS)
+}

--- a/src/ts/apiUsage.ts
+++ b/src/ts/apiUsage.ts
@@ -1,5 +1,8 @@
 import { LLMProvider, ProviderNames, type LLMModel } from './model/types'
-import { DBState } from './stores.svelte'
+import {
+    ApiUsageState,
+    notifyApiUsageChanged,
+} from './apiUsageState.svelte'
 
 export interface ApiUsageModelStats {
     inputTokens: number
@@ -60,7 +63,7 @@ export const apiUsageRequestModes: ApiUsageRequestMode[] = [
 ]
 
 export const API_USAGE_RECENT_RETENTION_MS = 48 * 60 * 60 * 1000
-export const API_USAGE_MAX_RECENT_RECORDS = 10_000
+export const API_USAGE_MAX_RECENT_RECORDS = 500
 
 export interface ApiUsageRecord {
     model: string
@@ -330,15 +333,15 @@ function createApiUsageRecentRecord(
 }
 
 export function recordApiUsage(record: ApiUsageRecord) {
-    if (!DBState.db.apiUsage?.daily || typeof DBState.db.apiUsage.daily !== 'object') {
-        DBState.db.apiUsage = createEmptyApiUsageStats()
+    if (!ApiUsageState.daily || typeof ApiUsageState.daily !== 'object') {
+        ApiUsageState.daily = {}
     }
-    DBState.db.apiUsage.recentRequests ??= []
+    ApiUsageState.recentRequests ??= []
 
     const timestamp = record.date?.getTime() ?? Date.now()
     const normalizedTimestamp = Number.isFinite(timestamp) ? timestamp : Date.now()
     const dateKey = getApiUsageDateKey(new Date(normalizedTimestamp))
-    const storedDay = DBState.db.apiUsage.daily[dateKey]
+    const storedDay = ApiUsageState.daily[dateKey]
     const day = storedDay ? {
         ...normalizeStoredStats(storedDay),
         models: storedDay.models && typeof storedDay.models === 'object' ? storedDay.models : {},
@@ -363,15 +366,45 @@ export function recordApiUsage(record: ApiUsageRecord) {
     applyUsageDelta(day, recentRecord)
     applyUsageDelta(modelStats, recentRecord)
     day.models[modelStatsKey] = modelStats
-    DBState.db.apiUsage.daily[dateKey] = day
+    ApiUsageState.daily[dateKey] = day
 
-    const retentionReference = Math.max(
-        normalizedTimestamp,
-        ...DBState.db.apiUsage.recentRequests.map((candidate) => candidate.timestamp),
-    )
+    const recentRequests = ApiUsageState.recentRequests
+    const newestTimestamp = recentRequests.at(-1)?.timestamp ?? normalizedTimestamp
+    const retentionReference = Math.max(normalizedTimestamp, newestTimestamp)
     const retentionCutoff = retentionReference - API_USAGE_RECENT_RETENTION_MS
-    DBState.db.apiUsage.recentRequests = [...DBState.db.apiUsage.recentRequests, recentRecord]
-        .filter((candidate) => candidate.timestamp >= retentionCutoff)
-        .sort((a, b) => a.timestamp - b.timestamp)
-        .slice(-API_USAGE_MAX_RECENT_RECORDS)
+    if (normalizedTimestamp >= retentionCutoff) {
+        if (normalizedTimestamp >= newestTimestamp || recentRequests.length === 0) {
+            recentRequests.push(recentRecord)
+        }
+        else {
+            let low = 0
+            let high = recentRequests.length
+            while (low < high) {
+                const middle = Math.floor((low + high) / 2)
+                if (recentRequests[middle].timestamp <= normalizedTimestamp) {
+                    low = middle + 1
+                }
+                else {
+                    high = middle
+                }
+            }
+            recentRequests.splice(low, 0, recentRecord)
+        }
+    }
+
+    let expiredCount = 0
+    while (
+        expiredCount < recentRequests.length
+        && recentRequests[expiredCount].timestamp < retentionCutoff
+    ) {
+        expiredCount += 1
+    }
+    if (expiredCount > 0) {
+        recentRequests.splice(0, expiredCount)
+    }
+    const overflow = recentRequests.length - API_USAGE_MAX_RECENT_RECORDS
+    if (overflow > 0) {
+        recentRequests.splice(0, overflow)
+    }
+    notifyApiUsageChanged()
 }

--- a/src/ts/apiUsageRecorder.test.ts
+++ b/src/ts/apiUsageRecorder.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApiUsageRecorder } from './apiUsageRecorder'
+import { createEmptyApiUsageStats } from './apiUsage'
+import type { StreamResponseChunk, requestDataResponse } from './process/request/request'
+import { DBState } from './stores.svelte'
+
+vi.mock('./stores.svelte', () => ({
+    DBState: { db: {} },
+}))
+
+vi.mock('./tokenizer', () => ({
+    ChatTokenizer: class {
+        async tokenizeChats() {
+            return 12
+        }
+    },
+    tokenize: vi.fn(async (text: string) => text.length),
+}))
+
+function makeRecorder(options: {
+    mode?: 'model' | 'translate' | 'otherAx'
+    abortSignal?: AbortSignal
+    provider?: { id: string, name: string, url?: string }
+} = {}) {
+    return createApiUsageRecorder({
+        formated: [{ role: 'user', content: 'Hello' }],
+        mode: options.mode ?? 'model',
+        model: 'gpt-5.5',
+        modelInfo: { internalID: 'gpt-5.5' } as never,
+        abortSignal: options.abortSignal,
+        provider: options.provider,
+    })
+}
+
+describe('API usage request recorder', () => {
+    beforeEach(() => {
+        DBState.db.apiUsage = createEmptyApiUsageStats()
+    })
+
+    it('records successful translation requests', async () => {
+        const recorder = makeRecorder({ mode: 'translate' })
+        await recorder.finalizeResponse({ type: 'success', result: 'Done' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            inputTokens: 12,
+            outputTokens: 4,
+            requestCount: 1,
+            successRequestCount: 1,
+            requestCountsByMode: { translate: 1 },
+        })
+    })
+
+    it('records provider-internal retries as separate attempts', async () => {
+        const recorder = makeRecorder({ mode: 'otherAx' })
+        await recorder.recordNextAttempt('failed')
+        await recorder.finalizeResponse({ type: 'success', result: 'Done' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            requestCount: 2,
+            successRequestCount: 1,
+            failedRequestCount: 1,
+            requestCountsByMode: { otherAx: 2 },
+        })
+    })
+
+    it('stores the provider identity on recorded requests', async () => {
+        const recorder = makeRecorder({
+            provider: { id: 'custom', name: 'Example AI', url: 'https://llm.example/v1' },
+        })
+        await recorder.finalizeResponse({ type: 'success', result: 'Done' })
+
+        const model = Object.values(Object.values(DBState.db.apiUsage.daily)[0].models)[0]
+        expect(model).toMatchObject({
+            model: 'gpt-5.5',
+            provider: { id: 'custom', name: 'Example AI', url: 'https://llm.example/v1' },
+        })
+    })
+
+    it('uses each prepared request input and provider-reported usage per attempt', async () => {
+        const recorder = makeRecorder()
+        recorder.prepareAttempt({ input: { messages: ['first expanded request'] } })
+        await recorder.recordNextAttempt('success', {
+            usage: { prompt_tokens: 30, completion_tokens: 7 },
+        })
+        recorder.prepareAttempt({ input: { messages: ['second expanded request'] } })
+        await recorder.finalizeResponse({
+            type: 'success',
+            result: 'Done',
+            usage: { input_tokens: 50, output_tokens: 9 },
+        })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            inputTokens: 80,
+            outputTokens: 16,
+            requestCount: 2,
+            successRequestCount: 2,
+        })
+    })
+
+    it('records only provider-reported cache, reasoning, and exact cost details', async () => {
+        const recorder = makeRecorder()
+        await recorder.recordNextAttempt('success', {
+            usage: {
+                prompt_tokens: 100,
+                completion_tokens: 50,
+                prompt_tokens_details: { cached_tokens: 60 },
+                completion_tokens_details: { reasoning_tokens: 40 },
+                cost: 0.0123,
+            },
+        })
+        await recorder.recordNextAttempt('success', {
+            usage: {
+                promptTokenCount: 80,
+                cachedContentTokenCount: 30,
+                candidatesTokenCount: 20,
+                thoughtsTokenCount: 10,
+            },
+        })
+        await recorder.finalizeResponse({
+            type: 'success',
+            result: 'Done',
+            usage: {
+                input_tokens: 10,
+                cache_creation_input_tokens: 20,
+                cache_read_input_tokens: 70,
+                output_tokens: 25,
+            },
+        })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            inputTokens: 280,
+            outputTokens: 105,
+            cachedInputTokens: 180,
+            reasoningTokens: 50,
+            reportedCostUsd: 0.0123,
+            costReportedRequestCount: 1,
+        })
+    })
+
+    it('recounts locally when a follow-up request has no provider usage', async () => {
+        const recorder = makeRecorder()
+        const firstInput = { messages: ['first'] }
+        const secondInput = { messages: ['second request with tool output'] }
+        recorder.prepareAttempt({ input: firstInput })
+        await recorder.recordNextAttempt('success', { output: ['tool call'] })
+        recorder.prepareAttempt({ input: secondInput })
+        await recorder.finalizeResponse({ type: 'success', result: 'Done' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day.inputTokens).toBe(JSON.stringify(firstInput).length + JSON.stringify(secondInput).length)
+        expect(day.outputTokens).toBe('tool call'.length + 'Done'.length)
+    })
+
+    it('leaves failed attempts without provider cost unreported', async () => {
+        const recorder = makeRecorder()
+        await recorder.finalizeResponse({ type: 'fail', result: 'Unauthorized' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            failedRequestCount: 1,
+            reportedCostUsd: 0,
+            costReportedRequestCount: 0,
+        })
+    })
+
+    it('records explicitly unbilled batch failures as zero cost', async () => {
+        const recorder = makeRecorder()
+        recorder.prepareAttempt({ input: { messages: ['batch'] } })
+        await recorder.finalizeResponse({
+            type: 'fail',
+            result: 'Batch item errored',
+            usageBillingStatus: 'not_billed',
+        })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            failedRequestCount: 1,
+            reportedCostUsd: 0,
+            costReportedRequestCount: 1,
+        })
+    })
+
+    it('records the provider-resolved model ID instead of the routing model', async () => {
+        const recorder = makeRecorder()
+        recorder.resolveModel('google/gemma-4-31b-it')
+        await recorder.finalizeResponse({ type: 'success', result: 'Done' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day.models).toMatchObject({
+            'google/gemma-4-31b-it': {
+                requestCount: 1,
+                successRequestCount: 1,
+            },
+        })
+        expect(day.models['gpt-5.5']).toBeUndefined()
+    })
+
+    it('keeps each provider attempt under the model resolved for that attempt', async () => {
+        const recorder = makeRecorder()
+        recorder.resolveModel('provider/first-model')
+        await recorder.recordNextAttempt('failed')
+        recorder.resolveModel('provider/fallback-model')
+        await recorder.finalizeResponse({ type: 'success', result: 'Done' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day.models['provider/first-model']).toMatchObject({
+            requestCount: 1,
+            failedRequestCount: 1,
+        })
+        expect(day.models['provider/fallback-model']).toMatchObject({
+            requestCount: 1,
+            successRequestCount: 1,
+        })
+    })
+
+    it('ignores empty provider model IDs and keeps the routing fallback', async () => {
+        const recorder = makeRecorder()
+        recorder.resolveModel('   ')
+        await recorder.finalizeResponse({ type: 'success', result: 'Done' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day.models['gpt-5.5'].requestCount).toBe(1)
+    })
+
+    it('does not turn a finalized failed follow-up into a successful attempt', async () => {
+        const recorder = makeRecorder()
+        await recorder.recordNextAttempt('success')
+        await recorder.finalizeAttempt('failed')
+        await recorder.finalizeResponse({ type: 'success', result: 'Partial tool output' })
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            requestCount: 2,
+            successRequestCount: 1,
+            failedRequestCount: 1,
+        })
+    })
+
+    it('records only the final cumulative streaming output', async () => {
+        const source = new ReadableStream<StreamResponseChunk>({
+            start(controller) {
+                controller.enqueue({ '0': 'Hi', __thoughts: 'hidden' })
+                controller.enqueue({ '0': 'Hello', __thoughts: 'hidden longer' })
+                controller.close()
+            },
+        })
+        const response = await makeRecorder({ mode: 'otherAx' }).finalizeResponse({
+            type: 'streaming',
+            result: source,
+        }) as Extract<requestDataResponse, { type: 'streaming' }>
+        const reader = response.result.getReader()
+        while (!(await reader.read()).done) {
+            // Drain the tracked stream.
+        }
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            outputTokens: 5,
+            successRequestCount: 1,
+            requestCountsByMode: { otherAx: 1 },
+        })
+    })
+
+    it('records partial streaming output when cancelled', async () => {
+        const abortController = new AbortController()
+        const source = new ReadableStream<StreamResponseChunk>({
+            start(controller) {
+                controller.enqueue({ '0': 'Partial' })
+            },
+        })
+        const response = await makeRecorder({ abortSignal: abortController.signal }).finalizeResponse({
+            type: 'streaming',
+            result: source,
+        }) as Extract<requestDataResponse, { type: 'streaming' }>
+        const reader = response.result.getReader()
+        await reader.read()
+        abortController.abort()
+        await reader.cancel()
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            outputTokens: 7,
+            requestCount: 1,
+            cancelledRequestCount: 1,
+        })
+    })
+})

--- a/src/ts/apiUsageRecorder.test.ts
+++ b/src/ts/apiUsageRecorder.test.ts
@@ -1,12 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApiUsageRecorder } from './apiUsageRecorder'
 import { createEmptyApiUsageStats } from './apiUsage'
+import { ApiUsageState, replaceApiUsageState } from './apiUsageState.svelte'
 import type { StreamResponseChunk, requestDataResponse } from './process/request/request'
-import { DBState } from './stores.svelte'
-
-vi.mock('./stores.svelte', () => ({
-    DBState: { db: {} },
-}))
 
 vi.mock('./tokenizer', () => ({
     ChatTokenizer: class {
@@ -34,14 +30,14 @@ function makeRecorder(options: {
 
 describe('API usage request recorder', () => {
     beforeEach(() => {
-        DBState.db.apiUsage = createEmptyApiUsageStats()
+        replaceApiUsageState(createEmptyApiUsageStats())
     })
 
     it('records successful translation requests', async () => {
         const recorder = makeRecorder({ mode: 'translate' })
         await recorder.finalizeResponse({ type: 'success', result: 'Done' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             inputTokens: 12,
             outputTokens: 4,
@@ -56,7 +52,7 @@ describe('API usage request recorder', () => {
         await recorder.recordNextAttempt('failed')
         await recorder.finalizeResponse({ type: 'success', result: 'Done' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             requestCount: 2,
             successRequestCount: 1,
@@ -71,7 +67,7 @@ describe('API usage request recorder', () => {
         })
         await recorder.finalizeResponse({ type: 'success', result: 'Done' })
 
-        const model = Object.values(Object.values(DBState.db.apiUsage.daily)[0].models)[0]
+        const model = Object.values(Object.values(ApiUsageState.daily)[0].models)[0]
         expect(model).toMatchObject({
             model: 'gpt-5.5',
             provider: { id: 'custom', name: 'Example AI', url: 'https://llm.example/v1' },
@@ -91,7 +87,7 @@ describe('API usage request recorder', () => {
             usage: { input_tokens: 50, output_tokens: 9 },
         })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             inputTokens: 80,
             outputTokens: 16,
@@ -130,7 +126,7 @@ describe('API usage request recorder', () => {
             },
         })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             inputTokens: 280,
             outputTokens: 105,
@@ -150,7 +146,7 @@ describe('API usage request recorder', () => {
         recorder.prepareAttempt({ input: secondInput })
         await recorder.finalizeResponse({ type: 'success', result: 'Done' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day.inputTokens).toBe(JSON.stringify(firstInput).length + JSON.stringify(secondInput).length)
         expect(day.outputTokens).toBe('tool call'.length + 'Done'.length)
     })
@@ -159,7 +155,7 @@ describe('API usage request recorder', () => {
         const recorder = makeRecorder()
         await recorder.finalizeResponse({ type: 'fail', result: 'Unauthorized' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             failedRequestCount: 1,
             reportedCostUsd: 0,
@@ -176,7 +172,7 @@ describe('API usage request recorder', () => {
             usageBillingStatus: 'not_billed',
         })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             failedRequestCount: 1,
             reportedCostUsd: 0,
@@ -189,7 +185,7 @@ describe('API usage request recorder', () => {
         recorder.resolveModel('google/gemma-4-31b-it')
         await recorder.finalizeResponse({ type: 'success', result: 'Done' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day.models).toMatchObject({
             'google/gemma-4-31b-it': {
                 requestCount: 1,
@@ -206,7 +202,7 @@ describe('API usage request recorder', () => {
         recorder.resolveModel('provider/fallback-model')
         await recorder.finalizeResponse({ type: 'success', result: 'Done' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day.models['provider/first-model']).toMatchObject({
             requestCount: 1,
             failedRequestCount: 1,
@@ -222,7 +218,7 @@ describe('API usage request recorder', () => {
         recorder.resolveModel('   ')
         await recorder.finalizeResponse({ type: 'success', result: 'Done' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day.models['gpt-5.5'].requestCount).toBe(1)
     })
 
@@ -232,7 +228,7 @@ describe('API usage request recorder', () => {
         await recorder.finalizeAttempt('failed')
         await recorder.finalizeResponse({ type: 'success', result: 'Partial tool output' })
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             requestCount: 2,
             successRequestCount: 1,
@@ -257,7 +253,7 @@ describe('API usage request recorder', () => {
             // Drain the tracked stream.
         }
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             outputTokens: 5,
             successRequestCount: 1,
@@ -281,7 +277,7 @@ describe('API usage request recorder', () => {
         abortController.abort()
         await reader.cancel()
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             outputTokens: 7,
             requestCount: 1,
@@ -309,7 +305,7 @@ describe('API usage request recorder', () => {
             // Drain the tracked stream.
         }
 
-        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        const day = Object.values(ApiUsageState.daily)[0]
         expect(day).toMatchObject({
             inputTokens: 23,
             outputTokens: 4,

--- a/src/ts/apiUsageRecorder.test.ts
+++ b/src/ts/apiUsageRecorder.test.ts
@@ -288,4 +288,34 @@ describe('API usage request recorder', () => {
             cancelledRequestCount: 1,
         })
     })
+
+    it('keeps provider usage while recording a terminal streaming failure', async () => {
+        const source = new ReadableStream<StreamResponseChunk>({
+            start(controller) {
+                controller.enqueue({
+                    '0': 'Incomplete response',
+                    __usage: JSON.stringify({ input_tokens: 23, output_tokens: 4 }),
+                    __usageStatus: 'failed',
+                })
+                controller.close()
+            },
+        })
+        const response = await makeRecorder().finalizeResponse({
+            type: 'streaming',
+            result: source,
+        }) as Extract<requestDataResponse, { type: 'streaming' }>
+        const reader = response.result.getReader()
+        while (!(await reader.read()).done) {
+            // Drain the tracked stream.
+        }
+
+        const day = Object.values(DBState.db.apiUsage.daily)[0]
+        expect(day).toMatchObject({
+            inputTokens: 23,
+            outputTokens: 4,
+            requestCount: 1,
+            successRequestCount: 0,
+            failedRequestCount: 1,
+        })
+    })
 })

--- a/src/ts/apiUsageRecorder.ts
+++ b/src/ts/apiUsageRecorder.ts
@@ -1,0 +1,339 @@
+import type { LLMModel } from './model/modellist'
+import type { OpenAIChat } from './process/index.svelte'
+import type {
+    ApiUsageAttemptDetails,
+    ApiUsageAttemptResult,
+    requestDataResponse,
+    StreamResponseChunk,
+} from './process/request/request'
+import {
+    recordApiUsage,
+    type ApiUsageProvider,
+    type ApiUsageRequestMode,
+    type ApiUsageRequestStatus,
+} from './apiUsage'
+import { ChatTokenizer, tokenize, type TokenizerEncodeOptions } from './tokenizer'
+
+interface ApiUsageRecorderOptions {
+    formated: OpenAIChat[]
+    mode: ApiUsageRequestMode
+    model: string
+    modelInfo: LLMModel
+    provider?: ApiUsageProvider
+    abortSignal?: AbortSignal | null
+}
+
+interface NormalizedUsage {
+    inputTokens: number
+    outputTokens: number
+    cachedInputTokens: number
+    reasoningTokens: number
+    providerCostUsd?: number
+}
+
+function getTokenizerOptions(model: string, modelInfo: LLMModel): TokenizerEncodeOptions {
+    return {
+        aiModel: model,
+        modelInfo,
+        localOnly: true,
+    }
+}
+
+async function countOutputTokens(
+    output: string[],
+    tokenizerOptions: TokenizerEncodeOptions,
+): Promise<number> {
+    try {
+        let tokens = 0
+        for (const text of output) {
+            tokens += await tokenize(text, tokenizerOptions)
+        }
+        return tokens
+    }
+    catch (error) {
+        console.error('[API Usage] Failed to count output tokens', error)
+        return 0
+    }
+}
+
+function getStreamOutput(chunk: StreamResponseChunk): string[] {
+    return Object.entries(chunk)
+        .filter(([key, text]) => !key.startsWith('__') && Boolean(text))
+        .map(([, text]) => text)
+}
+
+function snapshotValue<T>(value: T): T {
+    try {
+        return structuredClone(value)
+    }
+    catch {
+        return JSON.parse(JSON.stringify(value)) as T
+    }
+}
+
+function serializeInput(input: unknown): string {
+    return JSON.stringify(input, (key, value) => {
+        if (typeof value !== 'string') return value
+        if ((key === 'data' || key === 'image_url' || key === 'file_data') && value.startsWith('data:')) {
+            return '[binary data]'
+        }
+        return value
+    })
+}
+
+function normalizeUsage(usage: unknown): NormalizedUsage | null {
+    if (!usage || typeof usage !== 'object') return null
+    const value = usage as Record<string, unknown>
+    const number = (candidate: unknown) => typeof candidate === 'number' && Number.isFinite(candidate)
+        ? Math.max(0, candidate)
+        : 0
+    const optionalNumber = (candidate: unknown) => typeof candidate === 'number'
+        && Number.isFinite(candidate)
+        && candidate >= 0
+        ? candidate
+        : undefined
+    const object = (candidate: unknown) => candidate && typeof candidate === 'object'
+        ? candidate as Record<string, unknown>
+        : {}
+    const costDetails = object(value.cost_details)
+    const providerCostUsd = value.is_byok === true
+        ? optionalNumber(costDetails.upstream_inference_cost) ?? optionalNumber(value.cost)
+        : optionalNumber(value.cost)
+
+    if ('promptTokenCount' in value || 'candidatesTokenCount' in value) {
+        const inputTokens = number(value.promptTokenCount)
+        const reasoningTokens = number(value.thoughtsTokenCount)
+        return {
+            inputTokens,
+            outputTokens: number(value.candidatesTokenCount) + reasoningTokens,
+            cachedInputTokens: Math.min(inputTokens, number(value.cachedContentTokenCount)),
+            reasoningTokens,
+            providerCostUsd,
+        }
+    }
+
+    if ('prompt_tokens' in value || 'completion_tokens' in value) {
+        const inputTokens = number(value.prompt_tokens)
+        const outputTokens = number(value.completion_tokens)
+        const promptDetails = object(value.prompt_tokens_details)
+        const completionDetails = object(value.completion_tokens_details)
+        const cacheReadInputTokens = Math.min(inputTokens, number(promptDetails.cached_tokens))
+        const cacheWriteInputTokens = Math.min(
+            inputTokens - cacheReadInputTokens,
+            number(promptDetails.cache_write_tokens),
+        )
+        return {
+            inputTokens,
+            outputTokens,
+            cachedInputTokens: cacheReadInputTokens + cacheWriteInputTokens,
+            reasoningTokens: Math.min(outputTokens, number(completionDetails.reasoning_tokens)),
+            providerCostUsd,
+        }
+    }
+
+    if ('input_tokens' in value || 'output_tokens' in value) {
+        const baseInputTokens = number(value.input_tokens)
+        const cacheCreationInputTokens = number(value.cache_creation_input_tokens)
+        const cacheReadInputTokens = number(value.cache_read_input_tokens)
+        const inputTokens = baseInputTokens + cacheCreationInputTokens + cacheReadInputTokens
+        const outputTokens = number(value.output_tokens)
+        const inputDetails = object(value.input_tokens_details)
+        const outputDetails = object(value.output_tokens_details)
+        const topLevelCachedTokens = cacheCreationInputTokens + cacheReadInputTokens
+        const detailedCachedTokens = number(inputDetails.cached_tokens) + number(inputDetails.cache_write_tokens)
+        return {
+            inputTokens,
+            outputTokens,
+            cachedInputTokens: Math.min(
+                inputTokens,
+                Math.max(topLevelCachedTokens, detailedCachedTokens),
+            ),
+            reasoningTokens: Math.min(outputTokens, number(outputDetails.reasoning_tokens)),
+            providerCostUsd,
+        }
+    }
+
+    return null
+}
+
+function getStreamAttemptResult(chunk: StreamResponseChunk): ApiUsageAttemptResult {
+    let usage: unknown
+    try {
+        usage = chunk.__usage ? JSON.parse(chunk.__usage) : undefined
+    }
+    catch {
+        usage = undefined
+    }
+    const billingStatus = chunk.__usageBillingStatus === 'not_billed'
+        || chunk.__usageBillingStatus === 'unknown'
+        || chunk.__usageBillingStatus === 'estimated'
+        ? chunk.__usageBillingStatus
+        : undefined
+    return { usage, billingStatus }
+}
+
+export function createApiUsageRecorder(options: ApiUsageRecorderOptions) {
+    const tokenizerOptions = getTokenizerOptions(options.model, options.modelInfo)
+    const chatAdditionalTokens = options.model.startsWith('gpt') ? 5 : 3
+    const useName = options.model.startsWith('gpt') ? 'noName' : 'name'
+    const tokenizer = new ChatTokenizer(chatAdditionalTokens, useName, tokenizerOptions)
+    const countChats = async (chats: OpenAIChat[]) => {
+        const snapshot = snapshotValue(chats)
+        if (snapshot.some((chat) => typeof chat.content !== 'string')) {
+            return tokenize(serializeInput(snapshot), tokenizerOptions)
+        }
+        const baseTokens = await tokenizer.tokenizeChats(snapshot)
+        const structuredFields = snapshot.map((chat) => {
+            const extended = chat as OpenAIChat & { tool_calls?: unknown, tool_call_id?: unknown }
+            return {
+                tool_calls: extended.tool_calls,
+                tool_call_id: extended.tool_call_id,
+            }
+        }).filter((chat) => chat.tool_calls || chat.tool_call_id)
+        return baseTokens + (structuredFields.length > 0
+            ? await tokenize(serializeInput(structuredFields), tokenizerOptions)
+            : 0)
+    }
+    const countInput = (attempt: ApiUsageAttemptDetails) => {
+        const promise = attempt.inputChats
+            ? countChats(attempt.inputChats)
+            : attempt.input !== undefined
+                ? tokenize(serializeInput(snapshotValue(attempt.input)), tokenizerOptions)
+                : countChats(options.formated)
+        return promise.catch((error) => {
+            console.error('[API Usage] Failed to count input tokens', error)
+            return 0
+        })
+    }
+    let currentAttempt: ApiUsageAttemptDetails = {
+        inputChats: options.formated,
+    }
+    let inputTokensPromise = countInput(currentAttempt)
+    let resolvedModel = options.modelInfo.internalID || options.model
+    let finalized = false
+
+    async function recordAttempt(status: ApiUsageRequestStatus, result: ApiUsageAttemptResult = {}) {
+        const attemptModel = resolvedModel
+        const reportedUsage = normalizeUsage(result.usage)
+        const [inputTokens, outputTokens] = await Promise.all([
+            reportedUsage ? reportedUsage.inputTokens : inputTokensPromise,
+            reportedUsage ? reportedUsage.outputTokens : countOutputTokens(result.output ?? [], tokenizerOptions),
+        ])
+        const billingStatus = result.billingStatus
+            ?? (reportedUsage || status === 'success' ? 'estimated' : 'unknown')
+        recordApiUsage({
+            model: attemptModel,
+            provider: options.provider,
+            inputTokens,
+            outputTokens,
+            cachedInputTokens: reportedUsage?.cachedInputTokens,
+            reasoningTokens: reportedUsage?.reasoningTokens,
+            providerCostUsd: reportedUsage?.providerCostUsd,
+            billingStatus,
+            status,
+            mode: options.mode,
+        })
+    }
+
+    async function finalize(status: ApiUsageRequestStatus, result: ApiUsageAttemptResult = {}) {
+        if (finalized) return
+        finalized = true
+        await recordAttempt(status, result)
+    }
+
+    return {
+        resolveModel(model: string | null | undefined) {
+            const normalizedModel = model?.trim()
+            if (normalizedModel) resolvedModel = normalizedModel
+        },
+        prepareAttempt(attempt: ApiUsageAttemptDetails) {
+            currentAttempt = {
+                ...currentAttempt,
+                ...attempt,
+                input: attempt.inputChats !== undefined ? undefined : attempt.input ?? currentAttempt.input,
+                inputChats: attempt.input !== undefined ? undefined : attempt.inputChats ?? currentAttempt.inputChats,
+            }
+            inputTokensPromise = countInput(currentAttempt)
+        },
+        async finalizeResponse(response: requestDataResponse): Promise<requestDataResponse> {
+            if (response.type === 'success') {
+                await finalize('success', {
+                    usage: response.usage,
+                    output: [response.result],
+                    billingStatus: response.usageBillingStatus,
+                })
+                return response
+            }
+            if (response.type === 'multiline') {
+                await finalize('success', {
+                    usage: response.usage,
+                    output: response.result.map(([, text]) => text),
+                    billingStatus: response.usageBillingStatus,
+                })
+                return response
+            }
+            if (response.type === 'fail') {
+                await finalize(options.abortSignal?.aborted ? 'cancelled' : 'failed', {
+                    usage: response.usage,
+                    billingStatus: response.usageBillingStatus,
+                })
+                return response
+            }
+
+            const streamingResponse = response as Extract<requestDataResponse, { type: 'streaming' }>
+            const reader = streamingResponse.result.getReader()
+            let lastResponseChunk: StreamResponseChunk = {}
+            const trackedStream = new ReadableStream<StreamResponseChunk>({
+                async pull(controller) {
+                    try {
+                        const { done, value } = await reader.read()
+                        if (value) {
+                            lastResponseChunk = { ...lastResponseChunk, ...value }
+                            controller.enqueue(value)
+                        }
+                        if (done) {
+                            const result = getStreamAttemptResult(lastResponseChunk)
+                            await finalize(
+                                options.abortSignal?.aborted ? 'cancelled' : 'success',
+                                { ...result, output: getStreamOutput(lastResponseChunk) },
+                            )
+                            controller.close()
+                        }
+                    }
+                    catch (error) {
+                        const result = getStreamAttemptResult(lastResponseChunk)
+                        await finalize(
+                            options.abortSignal?.aborted ? 'cancelled' : 'failed',
+                            { ...result, output: getStreamOutput(lastResponseChunk) },
+                        )
+                        controller.error(error)
+                    }
+                },
+                async cancel(reason) {
+                    try {
+                        await reader.cancel(reason)
+                    }
+                    finally {
+                        const result = getStreamAttemptResult(lastResponseChunk)
+                        await finalize('cancelled', { ...result, output: getStreamOutput(lastResponseChunk) })
+                    }
+                },
+            })
+
+            return {
+                ...streamingResponse,
+                result: trackedStream,
+            }
+        },
+        async finalizeFailure() {
+            await finalize(options.abortSignal?.aborted ? 'cancelled' : 'failed')
+        },
+        async finalizeAttempt(completedStatus: 'success' | 'failed', result?: ApiUsageAttemptResult) {
+            await finalize(completedStatus, result)
+        },
+        async recordNextAttempt(completedStatus: 'success' | 'failed', result?: ApiUsageAttemptResult) {
+            if (finalized) return
+            await recordAttempt(completedStatus, result)
+        },
+    }
+}

--- a/src/ts/apiUsageRecorder.ts
+++ b/src/ts/apiUsageRecorder.ts
@@ -293,8 +293,9 @@ export function createApiUsageRecorder(options: ApiUsageRecorderOptions) {
                         }
                         if (done) {
                             const result = getStreamAttemptResult(lastResponseChunk)
+                            const streamStatus = lastResponseChunk.__usageStatus === 'failed' ? 'failed' : 'success'
                             await finalize(
-                                options.abortSignal?.aborted ? 'cancelled' : 'success',
+                                options.abortSignal?.aborted ? 'cancelled' : streamStatus,
                                 { ...result, output: getStreamOutput(lastResponseChunk) },
                             )
                             controller.close()

--- a/src/ts/apiUsageState.svelte.ts
+++ b/src/ts/apiUsageState.svelte.ts
@@ -1,0 +1,21 @@
+import type { ApiUsageStats } from './apiUsage'
+
+export const ApiUsageState = $state<ApiUsageStats>({
+    daily: {},
+    recentRequests: [],
+})
+
+let usageChanged = () => {}
+
+export function replaceApiUsageState(value: ApiUsageStats) {
+    ApiUsageState.daily = value.daily
+    ApiUsageState.recentRequests = value.recentRequests
+}
+
+export function notifyApiUsageChanged() {
+    usageChanged()
+}
+
+export function setApiUsageChangeListener(listener: () => void) {
+    usageChanged = listener
+}

--- a/src/ts/apiUsageStorage.test.ts
+++ b/src/ts/apiUsageStorage.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    API_USAGE_SAVE_DEBOUNCE_MS,
+    API_USAGE_STORAGE_KEY,
+    API_USAGE_STORAGE_VERSION,
+    initializeApiUsagePersistence,
+    type ApiUsageStorage,
+} from './apiUsageStorage'
+import {
+    API_USAGE_MAX_RECENT_RECORDS,
+    createEmptyApiUsageStats,
+    recordApiUsage,
+    type ApiUsageStats,
+} from './apiUsage'
+import { ApiUsageState, replaceApiUsageState } from './apiUsageState.svelte'
+
+class MemoryApiUsageStorage implements ApiUsageStorage {
+    value: Uint8Array | null = null
+    failWrites = false
+    getItem = vi.fn(async () => this.value)
+    setItem = vi.fn(async (_key: string, value: Uint8Array) => {
+        if (this.failWrites) throw new Error('storage unavailable')
+        this.value = value
+    })
+}
+
+function storedPayload(stats: unknown) {
+    return new TextEncoder().encode(JSON.stringify({
+        version: API_USAGE_STORAGE_VERSION,
+        stats,
+    }))
+}
+
+function recentRecord(id: string, timestamp: number) {
+    return {
+        id,
+        timestamp,
+        model: 'test-model',
+        inputTokens: 1,
+        outputTokens: 2,
+        cachedInputTokens: 0,
+        reasoningTokens: 0,
+        reportedCostUsd: null,
+        status: 'success',
+        mode: 'model',
+    }
+}
+
+describe('API usage dedicated persistence', () => {
+    beforeEach(() => {
+        replaceApiUsageState(createEmptyApiUsageStats())
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.restoreAllMocks()
+    })
+
+    it('loads and normalizes persisted API usage', async () => {
+        const storage = new MemoryApiUsageStorage()
+        const now = Date.now()
+        storage.value = storedPayload({
+            daily: [],
+            recentRequests: [
+                recentRecord('newer', now),
+                recentRecord('older', now - 1),
+                { id: '', timestamp: now, model: 'invalid' },
+            ],
+        })
+        const database = {
+            apiUsage: {
+                daily: { legacy: { requestCount: 100 } },
+                recentRequests: [],
+            } as unknown as ApiUsageStats,
+        }
+
+        await initializeApiUsagePersistence(database, storage)
+
+        expect(ApiUsageState.daily).toEqual({})
+        expect(ApiUsageState.recentRequests.map((record) => record.id)).toEqual(['older', 'newer'])
+        expect(database.apiUsage).toBeUndefined()
+    })
+
+    it('migrates legacy usage once without duplicating aggregates after reload', async () => {
+        const storage = new MemoryApiUsageStorage()
+        const now = Date.now()
+        const legacy = {
+            daily: {
+                '2026-07-28': {
+                    inputTokens: 10,
+                    outputTokens: 2,
+                    requestCount: 1,
+                    models: {},
+                },
+            },
+            recentRequests: Array.from(
+                { length: API_USAGE_MAX_RECENT_RECORDS + 1 },
+                (_, index) => recentRecord(String(index), now - index),
+            ),
+        } as unknown as ApiUsageStats
+        const firstDatabase = { apiUsage: legacy }
+
+        await initializeApiUsagePersistence(firstDatabase, storage)
+
+        expect(storage.setItem).toHaveBeenCalledWith(API_USAGE_STORAGE_KEY, expect.any(Uint8Array))
+        expect(firstDatabase.apiUsage).toBeUndefined()
+        expect(ApiUsageState.daily['2026-07-28'].requestCount).toBe(1)
+        expect(ApiUsageState.recentRequests).toHaveLength(API_USAGE_MAX_RECENT_RECORDS)
+
+        const secondDatabase = { apiUsage: legacy }
+        await initializeApiUsagePersistence(secondDatabase, storage)
+
+        expect(secondDatabase.apiUsage).toBeUndefined()
+        expect(ApiUsageState.daily['2026-07-28'].requestCount).toBe(1)
+        expect(storage.setItem).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the legacy source when migration persistence fails', async () => {
+        const storage = new MemoryApiUsageStorage()
+        storage.failWrites = true
+        const database = {
+            apiUsage: {
+                daily: {},
+                recentRequests: [],
+            },
+        }
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        await initializeApiUsagePersistence(database, storage)
+
+        expect(database.apiUsage).toBeDefined()
+        expect(ApiUsageState).toEqual(createEmptyApiUsageStats())
+    })
+
+    it('debounces request-path writes and isolates persistence errors', async () => {
+        vi.useFakeTimers()
+        const storage = new MemoryApiUsageStorage()
+        await initializeApiUsagePersistence({}, storage)
+        storage.failWrites = true
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        expect(() => {
+            recordApiUsage({ model: 'first', inputTokens: 1, outputTokens: 1 })
+            recordApiUsage({ model: 'second', inputTokens: 1, outputTokens: 1 })
+        }).not.toThrow()
+        expect(storage.setItem).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(API_USAGE_SAVE_DEBOUNCE_MS - 1)
+        expect(storage.setItem).not.toHaveBeenCalled()
+        await vi.advanceTimersByTimeAsync(1)
+
+        expect(storage.setItem).toHaveBeenCalledTimes(1)
+        expect(ApiUsageState.recentRequests).toHaveLength(2)
+    })
+})

--- a/src/ts/apiUsageStorage.ts
+++ b/src/ts/apiUsageStorage.ts
@@ -1,0 +1,124 @@
+import { normalizeApiUsageStats, type ApiUsageStats } from './apiUsage'
+import {
+    ApiUsageState,
+    replaceApiUsageState,
+    setApiUsageChangeListener,
+} from './apiUsageState.svelte'
+
+export const API_USAGE_STORAGE_KEY = 'apiUsage/stats.bin'
+export const API_USAGE_STORAGE_VERSION = 1
+export const API_USAGE_SAVE_DEBOUNCE_MS = 500
+
+export interface ApiUsageStorage {
+    getItem(key: string): Promise<Buffer | Uint8Array | null>
+    setItem(key: string, value: Uint8Array): Promise<unknown>
+}
+
+interface LegacyApiUsageDatabase {
+    apiUsage?: ApiUsageStats
+}
+
+interface StoredApiUsage {
+    version: number
+    stats: ApiUsageStats
+}
+
+let activeStorage: ApiUsageStorage | null = null
+let saveTimeout: ReturnType<typeof setTimeout> | null = null
+let writeChain = Promise.resolve(true)
+let pendingLegacyDatabase: LegacyApiUsageDatabase | null = null
+
+function decodeStoredApiUsage(value: Buffer | Uint8Array): unknown {
+    const decoded = JSON.parse(new TextDecoder().decode(value))
+    if (
+        decoded
+        && typeof decoded === 'object'
+        && !Array.isArray(decoded)
+        && (decoded as Partial<StoredApiUsage>).version === API_USAGE_STORAGE_VERSION
+        && 'stats' in decoded
+    ) {
+        return (decoded as Partial<StoredApiUsage>).stats
+    }
+    throw new Error('Unsupported API usage storage format')
+}
+
+function clearLegacyApiUsage() {
+    if (pendingLegacyDatabase?.apiUsage) {
+        delete pendingLegacyDatabase.apiUsage
+    }
+    pendingLegacyDatabase = null
+}
+
+async function writeApiUsageSnapshot(): Promise<boolean> {
+    if (!activeStorage) return false
+    try {
+        const payload: StoredApiUsage = {
+            version: API_USAGE_STORAGE_VERSION,
+            stats: ApiUsageState,
+        }
+        await activeStorage.setItem(
+            API_USAGE_STORAGE_KEY,
+            new TextEncoder().encode(JSON.stringify(payload)),
+        )
+        clearLegacyApiUsage()
+        return true
+    }
+    catch (error) {
+        console.error('Failed to persist API usage statistics', error)
+        return false
+    }
+}
+
+export function scheduleApiUsagePersistence() {
+    if (saveTimeout) {
+        clearTimeout(saveTimeout)
+    }
+    saveTimeout = setTimeout(() => {
+        saveTimeout = null
+        void flushApiUsagePersistence()
+    }, API_USAGE_SAVE_DEBOUNCE_MS)
+}
+
+export function flushApiUsagePersistence(): Promise<boolean> {
+    if (saveTimeout) {
+        clearTimeout(saveTimeout)
+        saveTimeout = null
+    }
+    writeChain = writeChain.then(writeApiUsageSnapshot, writeApiUsageSnapshot)
+    return writeChain
+}
+
+export async function initializeApiUsagePersistence(
+    database: LegacyApiUsageDatabase,
+    storage: ApiUsageStorage,
+) {
+    activeStorage = storage
+    pendingLegacyDatabase = null
+
+    let storedValue: Buffer | Uint8Array | null = null
+    try {
+        storedValue = await activeStorage.getItem(API_USAGE_STORAGE_KEY)
+    }
+    catch (error) {
+        console.error('Failed to load API usage statistics', error)
+    }
+
+    if (storedValue) {
+        try {
+            replaceApiUsageState(normalizeApiUsageStats(decodeStoredApiUsage(storedValue)))
+            delete database.apiUsage
+            return
+        }
+        catch (error) {
+            console.error('Failed to decode API usage statistics', error)
+        }
+    }
+
+    replaceApiUsageState(normalizeApiUsageStats(database.apiUsage))
+    if (database.apiUsage) {
+        pendingLegacyDatabase = database
+        await flushApiUsagePersistence()
+    }
+}
+
+setApiUsageChangeListener(scheduleApiUsagePersistence)

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -46,6 +46,7 @@ import { isTauri } from "./platform";
 import { registerModelDynamic } from "./model/modellist";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { appDataDir, join } from "@tauri-apps/api/path";
+import { initializeApiUsagePersistence } from "./apiUsageStorage";
 
 const appWindow = isTauri ? getCurrentWebviewWindow() : null
 
@@ -223,6 +224,8 @@ export async function loadData() {
             } catch (error) {
 
             }
+            LoadingStatusState.text = "Loading API Usage Statistics..."
+            await initializeApiUsagePersistence(getDatabase(), forageStorage)
             LoadingStatusState.text = "Checking For Format Update..."
             await checkNewFormat()
             const db = getDatabase();

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -389,6 +389,11 @@ export async function saveDb() {
                 return
             }
 
+            if (rootKey === 'apiUsage') {
+                saveTimeoutExecute()
+                return
+            }
+
             if (rootKey === 'characters') {
                 const affectedCharacters: Database['characters'] = []
 

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -429,6 +429,8 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
             ? "global." + arg.modelInfo.internalID 
             : "us." + arg.modelInfo.internalID;
 
+        arg.onUsageModelResolved?.(arg.modelInfo.internalID)
+
         const url = `https://${host}/model/${awsModel}/invoke${stream ? "-with-response-stream" : ""}`
 
         let params = {...body}
@@ -586,6 +588,8 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
         body = applyAdditionalParameters(body, headers, additionalParams)
     }
 
+    arg.onUsageModelResolved?.(typeof body.model === 'string' ? body.model : undefined)
+
     let betas:string[] = []
 
     if(body.max_tokens > 8192){
@@ -625,6 +629,10 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
             }]
         }
 
+        arg.onUsageAttemptPrepared?.({
+            input: body.messages,
+        })
+
         const resp = await fetchNative(batchRequestUrl, {
             "body": JSON.stringify(batchRequestBody),
             "method": "POST",
@@ -647,7 +655,8 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
             })
             return {
                 type: 'fail',
-                result: responseText
+                result: responseText,
+                usageBillingStatus: 'not_billed',
             }
         }
 
@@ -665,7 +674,8 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
             })
             return {
                 type: 'fail',
-                result: 'No results URL returned from Claude batch request'
+                result: 'No results URL returned from Claude batch request',
+                usageBillingStatus: 'not_billed',
             }
         }
 
@@ -812,7 +822,10 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
                                     thinking = false
                                 }
 
-                                controller.enqueue({ "0": resText })
+                                controller.enqueue({
+                                    "0": resText,
+                                    "__usage": JSON.stringify(batchData.result.message.usage ?? {}),
+                                })
                                 addFetchLog({
                                     body: batchRequestBody,
                                     headers: headers,
@@ -841,6 +854,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
                                     chatId: arg.chatId,
                                     status: batchRes.status
                                 })
+                                controller.enqueue({ "__usageBillingStatus": "not_billed" })
                                 controller.error(new Error(message))
                                 return
                             }
@@ -854,6 +868,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
                                     chatId: arg.chatId,
                                     status: batchRes.status
                                 })
+                                controller.enqueue({ "__usageBillingStatus": "not_billed" })
                                 controller.close()
                                 return
                             }
@@ -867,6 +882,7 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
                                     chatId: arg.chatId,
                                     status: batchRes.status
                                 })
+                                controller.enqueue({ "__usageBillingStatus": "not_billed" })
                                 controller.error(new Error('Claude batch request expired'))
                                 return
                             }
@@ -897,7 +913,8 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
 }
 
 async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:string}, body:any, arg:RequestDataArgumentExtended):Promise<requestDataResponse> {
-    
+    arg.onUsageAttemptPrepared?.({ input: body.messages })
+
     if(arg.useStreaming){
         
         const res = await fetchNative(replacerURL, {
@@ -923,10 +940,18 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
                 let text = ''
                 let reader = res.body.getReader()
                 let parserData = ''
+                let usage: Record<string, number> = {}
                 const decoder = new TextDecoder()
                 const parseEvent = ((e:string) => {
                     try {               
                         const parsedData = JSON.parse(e)
+
+                        if(parsedData?.type === 'message_start' && parsedData.message?.usage){
+                            usage = { ...usage, ...parsedData.message.usage }
+                        }
+                        if(parsedData?.type === 'message_delta' && parsedData.usage){
+                            usage = { ...usage, ...parsedData.usage }
+                        }
 
                         if(parsedData?.type === 'content_block_delta'){
                             if(parsedData?.delta?.type === 'text' || parsedData.delta?.type === 'text_delta'){
@@ -998,6 +1023,8 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
                                     prevText = ''
                                     text = ''
                                     reader.cancel()
+                                    await arg.onUsageNextAttempt?.('failed')
+                                    arg.onUsageAttemptPrepared?.({ input: body.messages })
                                     const res = await fetchNative(replacerURL, {
                                         body: JSON.stringify(body),
                                         headers: headers,
@@ -1008,6 +1035,7 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
                                     })
                             
                                     if(res.status !== 200){
+                                        await arg.onUsageFinalAttempt?.('failed')
                                         controller.enqueue({
                                             "0": await textifyReadableStream(res.body)
                                         })
@@ -1024,7 +1052,8 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
                         text = prevText
 
                         controller.enqueue({
-                            "0": text
+                            "0": text,
+                            ...(Object.keys(usage).length > 0 ? { "__usage": JSON.stringify(usage) } : {}),
                         })
 
                     } catch (error) {
@@ -1034,7 +1063,8 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
                 if(thinking){
                     text += "</Thoughts>\n\n"
                     controller.enqueue({
-                        "0": text
+                        "0": text,
+                        ...(Object.keys(usage).length > 0 ? { "__usage": JSON.stringify(usage) } : {}),
                     })
                 }
                 controller.close()
@@ -1088,6 +1118,10 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
     const hasToolUse = (contents as any[]).some((v) => v.type === 'tool_use')
 
     if(hasToolUse){
+        await arg.onUsageNextAttempt?.('success', {
+            usage: res.data.usage,
+            output: [JSON.stringify(contents)],
+        })
 
         const messages:Claude3ExtendedChat[] = body.messages
         const response:Claude3Chat = {
@@ -1200,11 +1234,13 @@ async function requestClaudeHTTP(replacerURL:string, headers:{[key:string]:strin
     if(arg.extractJson && db.jsonSchemaEnabled){
         return {
             type: 'success',
-            result: arg.additionalOutput + extractJSON(resText, db.jsonSchema)
+            result: arg.additionalOutput + extractJSON(resText, db.jsonSchema),
+            usage: res.data.usage,
         }
     }
     return {
         type: 'success',
-        result: arg.additionalOutput + resText
+        result: arg.additionalOutput + resText,
+        usage: res.data.usage,
     }
 }

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -579,6 +579,7 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     }
 
     body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
+    arg.onUsageModelResolved?.(arg.modelInfo.internalID)
 
     if(arg.previewBody){
         return {
@@ -597,6 +598,7 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
 async function requestGoogle(url:string, body:any, headers:{[key:string]:string}, arg:RequestDataArgumentExtended):Promise<requestDataResponse> {
     
     const db = getDatabase()
+    arg.onUsageAttemptPrepared?.({ input: body.contents })
 
     const fallBackGemini = async (originalError:string):Promise<requestDataResponse> => {
         if(!db.antiServerOverloads){
@@ -715,7 +717,8 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
         }
     }
 
-    let rDatas:{text: string, thought?: boolean}[] = [] 
+    let rDatas:{text: string, thought?: boolean}[] = []
+    let responseUsage: unknown
     const processDataItem = async (data:any):Promise<GeminiPart[]> => {
         const parts = data?.candidates?.[0]?.content?.parts as GeminiPart[]
 
@@ -775,6 +778,7 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
         }
 
         if(data?.usageMetadata){
+            responseUsage = data.usageMetadata
             
             for (const interceptor of bodyIntercepterStore) {
                 try {
@@ -922,6 +926,10 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
         let resRec
         let attempt = 0
         do {
+            await arg.onUsageNextAttempt?.(attempt === 0 ? 'success' : 'failed', attempt === 0 ? {
+                usage: responseUsage,
+                output: [JSON.stringify(calls)],
+            } : undefined)
             attempt++
             resRec = await requestGoogle(url, body, headers, arg)
             
@@ -935,6 +943,7 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
 
         // If the next request fails, only the responses so far are returned
         if(resRec.type === 'fail'){
+            await arg.onUsageFinalAttempt?.('failed')
             alertError(`Failed to fetch model response after tool execution`)
             return {
                 type: 'success',
@@ -943,7 +952,9 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
         } else if(resRec.type === 'success'){
             return {
                 type: 'success',
-                result: result + '\n\n' + resRec.result
+                result: result + '\n\n' + resRec.result,
+                usage: resRec.usage,
+                usageBillingStatus: resRec.usageBillingStatus,
             }
         }
         
@@ -963,7 +974,8 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
     console.log(result)
     return {
         type: 'success',
-        result: result
+        result: result,
+        usage: responseUsage,
     }
 }
 
@@ -1236,7 +1248,21 @@ function wrapToolStream(
                         let errorFlag = true
                         
                         do {
+                            let usage: unknown
+                            try {
+                                usage = attempt === 0 && value["__usageMetadata"]
+                                    ? JSON.parse(value["__usageMetadata"])
+                                    : undefined
+                            }
+                            catch {
+                                usage = undefined
+                            }
+                            await arg.onUsageNextAttempt?.(attempt === 0 ? 'success' : 'failed', attempt === 0 ? {
+                                usage,
+                                output: [content, JSON.stringify(calls)],
+                            } : undefined)
                             attempt++
+                            arg.onUsageAttemptPrepared?.({ input: body.contents })
                             resRec = await fetchNative(url, {
                                 headers: headers,
                                 body: JSON.stringify(body),
@@ -1261,6 +1287,7 @@ function wrapToolStream(
                         } while (attempt <= db.requestRetrys) // Retry up to db.requestRetrys times
 
                         if(errorFlag){
+                            await arg.onUsageFinalAttempt?.('failed')
                             alertError(`Failed to fetch model response after tool execution`)
                             return controller.close()
                         }
@@ -1282,7 +1309,7 @@ function wrapToolStream(
                                 + callCodes.join('\n\n')
                         }
 
-                        controller.enqueue({"0": prefix})
+                        controller.enqueue({"0": prefix, "__usage": ""})
                         
                         continue
                     }
@@ -1305,14 +1332,16 @@ function wrapToolStream(
                         "0": (prefix ? prefix + '\n\n' : '')
                             + (thoughts ? `<Thoughts>\n\n${thoughts}\n\n</Thoughts>\n\n` : '')
                             + (lastThought ? lastThought + '\n\n' : '') 
-                            + content
+                            + content,
+                        ...(value["__usageMetadata"] ? { "__usage": value["__usageMetadata"] } : {}),
                     })
                 }
                 else {
                     controller.enqueue({
                         "0": (prefix ? prefix + '\n\n' : '')
                             + (thoughts + lastThought ? `<Thoughts>\n\n${thoughts + lastThought}\n\n</Thoughts>\n\n` : '')
-                            + content
+                            + content,
+                        ...(value["__usageMetadata"] ? { "__usage": value["__usageMetadata"] } : {}),
                     })
                 }
             }

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -624,6 +624,7 @@ async function requestGoogle(url:string, body:any, headers:{[key:string]:string}
             }
         }
 
+        await arg.onUsageNextAttempt?.('failed')
         return requestGoogle(url, body, headers, arg)
     }
 

--- a/src/ts/process/request/google.usage.test.ts
+++ b/src/ts/process/request/google.usage.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requestGoogleCloudVertex } from './google'
+
+const mocks = vi.hoisted(() => ({
+    db: {
+        antiServerOverloads: true,
+        google: { accessToken: 'google-key' },
+        gptVisionQuality: 'high',
+        jsonSchemaEnabled: false,
+        saveSignatures: false,
+        vertexAccessToken: '',
+        vertexAccessTokenExpires: Number.MAX_SAFE_INTEGER,
+        vertexClientEmail: '',
+        vertexPrivateKey: '',
+        vertexRegion: 'us-central1',
+    },
+    fetchNative: vi.fn(),
+}))
+
+vi.mock('src/ts/storage/database.svelte', () => ({
+    getDatabase: () => mocks.db,
+    setDatabase: vi.fn(),
+}))
+
+vi.mock('src/ts/globalApi.svelte', () => ({
+    addFetchLog: vi.fn(),
+    fetchNative: mocks.fetchNative,
+    textifyReadableStream: vi.fn(),
+}))
+
+vi.mock('src/ts/model/modellist', () => ({
+    LLMFlags: {},
+    LLMFormat: {
+        GoogleCloud: 5,
+        VertexAIGemini: 6,
+    },
+}))
+
+vi.mock('src/ts/util', () => ({
+    base64url: vi.fn(),
+    simplifySchema: (schema: unknown) => schema,
+}))
+
+vi.mock('../files/inlays', () => ({
+    saveInlayedSignature: vi.fn(),
+    setInlayAsset: vi.fn(),
+    writeInlayImage: vi.fn(),
+}))
+
+vi.mock('../templates/jsonSchema', () => ({
+    extractJSON: (data: string) => data,
+    getGeneralJSONSchema: vi.fn(),
+}))
+
+vi.mock('../mcp/mcp', () => ({
+    callTool: vi.fn(),
+    decodeToolCall: vi.fn(),
+    encodeToolCall: vi.fn(),
+}))
+
+vi.mock('src/ts/alert', () => ({
+    alertError: vi.fn(),
+}))
+
+vi.mock('src/ts/stores.svelte', () => ({
+    bodyIntercepterStore: [],
+}))
+
+vi.mock('./shared', () => ({
+    applyAdditionalParameters: (body: unknown) => body,
+    applyParameters: (body: unknown) => body,
+    getAdditionalParameters: () => [],
+}))
+
+const overloadResponse = () => ({
+    ok: false,
+    status: 429,
+    text: async () => 'RESOURCE_EXHAUSTED',
+})
+
+const successResponse = () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+        candidates: [{ content: { parts: [{ text: 'Gemini answer' }] } }],
+        usageMetadata: {
+            promptTokenCount: 13,
+            candidatesTokenCount: 4,
+        },
+    }),
+})
+
+const baseArg = (overrides: Record<string, unknown> = {}) => ({
+    aiModel: 'gemini-2.5-flash',
+    formated: [{ role: 'user', content: 'Hello' }],
+    maxTokens: 128,
+    mode: 'model',
+    modelInfo: {
+        flags: [],
+        format: 5,
+        id: 'gemini-2.5-flash',
+        internalID: 'gemini-2.5-flash',
+        parameters: [],
+    },
+    useStreaming: false,
+    ...overrides,
+}) as any
+
+describe('Gemini usage attempt recording', () => {
+    beforeEach(() => {
+        mocks.fetchNative.mockReset()
+        mocks.db.antiServerOverloads = true
+    })
+
+    it('records one failed attempt before a RESOURCE_EXHAUSTED retry succeeds', async () => {
+        mocks.fetchNative
+            .mockResolvedValueOnce(overloadResponse())
+            .mockResolvedValueOnce(successResponse())
+        const attempts: string[] = []
+
+        const result = await requestGoogleCloudVertex(baseArg({
+            onUsageNextAttempt: async (status: string) => attempts.push(status),
+        }))
+        attempts.push(result.type === 'success' ? 'success' : 'failed')
+
+        expect(mocks.fetchNative).toHaveBeenCalledTimes(2)
+        expect(attempts).toEqual(['failed', 'success'])
+        expect(result).toMatchObject({
+            type: 'success',
+            usage: {
+                promptTokenCount: 13,
+                candidatesTokenCount: 4,
+            },
+        })
+    })
+
+    it('records every failed RESOURCE_EXHAUSTED attempt before eventual success', async () => {
+        mocks.fetchNative
+            .mockResolvedValueOnce(overloadResponse())
+            .mockResolvedValueOnce(overloadResponse())
+            .mockResolvedValueOnce(successResponse())
+        const attempts: string[] = []
+
+        const result = await requestGoogleCloudVertex(baseArg({
+            onUsageNextAttempt: async (status: string) => attempts.push(status),
+        }))
+        attempts.push(result.type === 'success' ? 'success' : 'failed')
+
+        expect(mocks.fetchNative).toHaveBeenCalledTimes(3)
+        expect(attempts).toEqual(['failed', 'failed', 'success'])
+    })
+
+    it('does not fabricate a retry attempt when overload retries are disabled', async () => {
+        mocks.db.antiServerOverloads = false
+        mocks.fetchNative.mockResolvedValueOnce(overloadResponse())
+        const onUsageNextAttempt = vi.fn()
+
+        const result = await requestGoogleCloudVertex(baseArg({
+            onUsageNextAttempt,
+        }))
+
+        expect(mocks.fetchNative).toHaveBeenCalledTimes(1)
+        expect(onUsageNextAttempt).not.toHaveBeenCalled()
+        expect(result.type).toBe('fail')
+    })
+})

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer } from 'src/ts/model/types'
 import { fetchNative } from 'src/ts/globalApi.svelte'
 import { callTool } from '../../mcp/mcp'
-import { __testResponsesAPI, requestOpenAIResponseAPI } from './requests'
+import { __testResponsesAPI, requestOpenAI, requestOpenAIResponseAPI } from './requests'
 
 const mocks = vi.hoisted(() => ({
     db: {
@@ -22,6 +22,9 @@ const mocks = vi.hoisted(() => ({
         nanogptRequestModel: 'nanogpt-model',
         nanogptUseSubscriptionEndpoint: false,
         openAIKey: 'openai-key',
+        openAIFlexProcessing: false,
+        openrouterKey: 'openrouter-key',
+        openrouterRequestModel: 'google/gemma-4-31b-it',
         proxyKey: 'proxy-key',
         requestRetrys: 0,
         reasoningEffort: 2,
@@ -103,6 +106,9 @@ vi.mock('src/ts/model/modellist', () => ({
         Mistral: 4,
         OpenAIResponseAPI: 18,
     },
+    LLMProvider: {
+        OpenAI: 0,
+    },
     getFreeOpenRouterModels: vi.fn(),
 }))
 
@@ -178,7 +184,7 @@ function sseStream(events: string[]) {
     })
 }
 
-describe('OpenAI Responses API helpers', () => {
+describe('OpenAI request helpers', () => {
     beforeEach(() => {
         mocks.fetchNative.mockReset()
         mocks.globalFetch.mockReset()
@@ -190,6 +196,8 @@ describe('OpenAI Responses API helpers', () => {
         mocks.db.nanogptProvider = ''
         mocks.db.nanogptRequestModel = 'nanogpt-model'
         mocks.db.nanogptUseSubscriptionEndpoint = false
+        mocks.db.openrouterRequestModel = 'google/gemma-4-31b-it'
+        mocks.db.openAIFlexProcessing = false
         mocks.db.simplifiedToolUse = false
         mocks.db.autofillRequestUrl = false
     })
@@ -428,10 +436,12 @@ describe('OpenAI Responses API helpers', () => {
 
     it('wires NanoGPT Responses endpoint, model, auth, and provider header', async () => {
         mocks.db.nanogptProvider = 'provider-a'
+        const onUsageModelResolved = vi.fn()
 
         const result = await requestOpenAIResponseAPI(baseArg({
             aiModel: 'nanogpt',
             previewBody: true,
+            onUsageModelResolved,
             modelInfo: {
                 ...baseArg().modelInfo,
                 internalID: 'nanogpt',
@@ -445,6 +455,81 @@ describe('OpenAI Responses API helpers', () => {
         expect(preview.body.model).toBe('nanogpt-model')
         expect(preview.headers.Authorization).toBe('Bearer nanogpt-key')
         expect(preview.headers['X-Provider']).toBe('provider-a')
+        expect(onUsageModelResolved).toHaveBeenCalledWith('nanogpt-model')
+    })
+
+    it('reports the exact OpenRouter request model to API usage tracking', async () => {
+        const onUsageModelResolved = vi.fn()
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'openrouter',
+            previewBody: true,
+            useStreaming: false,
+            onUsageModelResolved,
+            formated: [{ role: 'user', content: 'Hello' }],
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                id: 'openrouter',
+                internalID: 'openrouter',
+                parameters: [],
+            },
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.body.model).toBe('google/gemma-4-31b-it')
+        expect(onUsageModelResolved).toHaveBeenCalledWith('google/gemma-4-31b-it')
+    })
+
+    it('reports the final request input for a custom official OpenAI endpoint', async () => {
+        mocks.db.openAIFlexProcessing = true
+        mocks.globalFetch.mockResolvedValueOnce({
+            ok: true,
+            data: {
+                choices: [{ message: { content: 'ok' } }],
+                usage: { prompt_tokens: 10, completion_tokens: 2 },
+            },
+        })
+        const onUsageAttemptPrepared = vi.fn()
+
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'reverse_proxy',
+            customURL: 'https://api.openai.com/v1/chat/completions',
+            useStreaming: false,
+            onUsageAttemptPrepared,
+            formated: [{ role: 'user', content: 'Hello' }],
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                format: LLMFormat.OpenAICompatible,
+                internalID: 'gpt-5.5',
+                parameters: [],
+                provider: LLMProvider.AsIs,
+            },
+        }))
+
+        expect(result.type).toBe('success')
+        expect(onUsageAttemptPrepared).toHaveBeenCalledWith(expect.objectContaining({
+            inputChats: expect.any(Array),
+        }))
+        expect(mocks.globalFetch.mock.calls[0][1].body.service_tier).toBe('flex')
+    })
+
+    it('tracks a model overridden in the final custom Responses request body', async () => {
+        mocks.db.additionalParams = [['model', 'provider/custom-model']]
+        const onUsageModelResolved = vi.fn()
+
+        const result = await requestOpenAIResponseAPI(baseArg({
+            aiModel: 'reverse_proxy',
+            customURL: 'https://proxy.example/v1/responses',
+            previewBody: true,
+            onUsageModelResolved,
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.body.model).toBe('provider/custom-model')
+        expect(onUsageModelResolved).toHaveBeenCalledWith('provider/custom-model')
     })
 
     it('applies reverse proxy Responses endpoint autofill and additional params', async () => {
@@ -589,6 +674,39 @@ describe('OpenAI Responses API helpers', () => {
             }),
         ]))
         expect(followupBody.input.find((item:any) => item.type === 'function_call')).not.toHaveProperty('id')
+    })
+
+    it('finalizes a failed streaming tool follow-up as a failed API attempt', async () => {
+        vi.mocked(callTool).mockResolvedValueOnce([{ type: 'text', text: 'stream tool result' }] as any)
+        vi.mocked(fetchNative)
+            .mockResolvedValueOnce({
+                status: 200,
+                headers: { get: () => 'text/event-stream' },
+                body: sseStream([
+                    'data: {"type":"response.completed","response":{"output":[{"type":"function_call","call_id":"call_stream_2","name":"lookup","arguments":"{}","status":"completed"}]}}\n\n',
+                ]),
+            } as any)
+            .mockResolvedValueOnce({
+                status: 500,
+                headers: { get: () => 'application/json' },
+                body: null,
+            } as any)
+        const onUsageNextAttempt = vi.fn(async () => {})
+        const onUsageFinalAttempt = vi.fn(async () => {})
+
+        const result = await requestOpenAIResponseAPI(baseArg({
+            useStreaming: true,
+            tools: [{ name: 'lookup', description: 'Lookup data', inputSchema: { type: 'object' } }],
+            onUsageNextAttempt,
+            onUsageFinalAttempt,
+        }))
+
+        expect(result.type).toBe('streaming')
+        await collectStream(result.result as ReadableStream<Record<string, string>>)
+        expect(onUsageNextAttempt).toHaveBeenCalledWith('success', expect.objectContaining({
+            output: expect.any(Array),
+        }))
+        expect(onUsageFinalAttempt).toHaveBeenCalledWith('failed')
     })
 
     it('parses split CRLF SSE chunks, final unterminated events, text deltas, and function call deltas', async () => {

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer } from 'src/ts/model/types'
 import { fetchNative } from 'src/ts/globalApi.svelte'
 import { callTool } from '../../mcp/mcp'
-import { __testResponsesAPI, requestOpenAI, requestOpenAIResponseAPI } from './requests'
+import {
+    __testResponsesAPI,
+    requestOpenAI,
+    requestOpenAILegacyInstruct,
+    requestOpenAIResponseAPI,
+} from './requests'
 
 const mocks = vi.hoisted(() => ({
     db: {
@@ -21,12 +26,15 @@ const mocks = vi.hoisted(() => ({
         nanogptProvider: '',
         nanogptRequestModel: 'nanogpt-model',
         nanogptUseSubscriptionEndpoint: false,
+        mistralKey: 'mistral-key',
         openAIKey: 'openai-key',
         openAIFlexProcessing: false,
         openrouterKey: 'openrouter-key',
         openrouterRequestModel: 'google/gemma-4-31b-it',
         proxyKey: 'proxy-key',
         requestRetrys: 0,
+        PresensePenalty: 0,
+        frequencyPenalty: 0,
         reasoningEffort: 2,
         seperateParametersEnabled: false,
         simplifiedToolUse: false,
@@ -515,6 +523,121 @@ describe('OpenAI request helpers', () => {
         expect(mocks.globalFetch.mock.calls[0][1].body.service_tier).toBe('flex')
     })
 
+    it('requests streaming usage from official OpenAI while preserving stream options', async () => {
+        mocks.db.additionalParams = [['stream_options.custom_flag', 'true']]
+
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'reverse_proxy',
+            customURL: 'https://api.openai.com/v1/chat/completions',
+            previewBody: true,
+            useStreaming: true,
+            formated: [{ role: 'user', content: 'Hello' }],
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                format: LLMFormat.OpenAICompatible,
+                internalID: 'gpt-5.5',
+                parameters: [],
+                provider: LLMProvider.AsIs,
+            },
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.body.stream_options).toEqual({
+            custom_flag: true,
+            include_usage: true,
+        })
+    })
+
+    it('does not request streaming usage from arbitrary compatible endpoints', async () => {
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'reverse_proxy',
+            customURL: 'https://compatible.example/v1/chat/completions',
+            previewBody: true,
+            useStreaming: true,
+            formated: [{ role: 'user', content: 'Hello' }],
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                format: LLMFormat.OpenAICompatible,
+                internalID: 'custom-model',
+                parameters: [],
+                provider: LLMProvider.AsIs,
+            },
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.body).not.toHaveProperty('stream_options')
+    })
+
+    it('tracks the final Legacy Instruct prompt and preserves provider usage', async () => {
+        mocks.globalFetch.mockResolvedValueOnce({
+            ok: true,
+            data: {
+                choices: [{ text: 'Legacy answer' }],
+                usage: { prompt_tokens: 17, completion_tokens: 3 },
+            },
+        })
+        const onUsageAttemptPrepared = vi.fn()
+        const formated = [
+            { role: 'system', content: 'Follow policy.' },
+            { role: 'user', content: 'Hello' },
+            { role: 'assistant', content: 'Hi' },
+        ]
+
+        const result = await requestOpenAILegacyInstruct(baseArg({
+            aiModel: 'gpt35_instruct',
+            formated,
+            onUsageAttemptPrepared,
+        }))
+
+        expect(result).toMatchObject({
+            type: 'success',
+            usage: { prompt_tokens: 17, completion_tokens: 3 },
+        })
+        const sentPrompt = mocks.globalFetch.mock.calls[0][1].body.prompt
+        expect(sentPrompt).toBe('\n## Instruction\nFollow policy.\n## User\nHello\n## Assistant\nHi\n## Response\n')
+        expect(onUsageAttemptPrepared).toHaveBeenCalledWith({ input: sentPrompt })
+        expect(onUsageAttemptPrepared).not.toHaveBeenCalledWith(expect.objectContaining({
+            inputChats: expect.anything(),
+        }))
+    })
+
+    it('preserves Mistral usage returned by the provider', async () => {
+        mocks.globalFetch.mockResolvedValueOnce({
+            ok: true,
+            data: {
+                choices: [{ message: { content: 'Mistral answer' } }],
+                usage: { prompt_tokens: 19, completion_tokens: 5 },
+            },
+        })
+        const onUsageAttemptPrepared = vi.fn()
+
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'mistral-large',
+            formated: [{ role: 'user', content: 'Hello' }],
+            onUsageAttemptPrepared,
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                format: LLMFormat.Mistral,
+                internalID: 'mistral-large',
+                parameters: [],
+                provider: LLMProvider.Mistral,
+            },
+        }))
+
+        expect(result).toMatchObject({
+            type: 'success',
+            usage: { prompt_tokens: 19, completion_tokens: 5 },
+        })
+        expect(onUsageAttemptPrepared).toHaveBeenCalledWith({
+            inputChats: [{ role: 'user', content: 'Hello' }],
+        })
+    })
+
     it('tracks a model overridden in the final custom Responses request body', async () => {
         mocks.db.additionalParams = [['model', 'provider/custom-model']]
         const onUsageModelResolved = vi.fn()
@@ -575,6 +698,44 @@ describe('OpenAI request helpers', () => {
         })
         expect(JSON.stringify(external.input)).not.toContain('rs_reasoning_bad')
         expect(JSON.stringify(external.input)).not.toContain('private reasoning')
+    })
+
+    it('preserves provider usage on a non-streaming incomplete response', async () => {
+        mocks.globalFetch.mockResolvedValueOnce({
+            ok: true,
+            data: {
+                status: 'incomplete',
+                incomplete_details: { reason: 'max_output_tokens' },
+                output_text: 'Partial answer',
+                usage: { input_tokens: 31, output_tokens: 7 },
+            },
+        })
+
+        const result = await requestOpenAIResponseAPI(baseArg())
+
+        expect(result).toMatchObject({
+            type: 'fail',
+            result: expect.stringContaining('Incomplete response: max_output_tokens'),
+            usage: { input_tokens: 31, output_tokens: 7 },
+        })
+    })
+
+    it('preserves provider usage on a non-streaming failed response', async () => {
+        mocks.globalFetch.mockResolvedValueOnce({
+            ok: true,
+            data: {
+                status: 'failed',
+                error: { message: 'provider failed' },
+                usage: { input_tokens: 29, output_tokens: 2 },
+            },
+        })
+
+        const result = await requestOpenAIResponseAPI(baseArg())
+
+        expect(result).toMatchObject({
+            type: 'fail',
+            usage: { input_tokens: 29, output_tokens: 2 },
+        })
     })
 
     it('sanitizes non-streaming Responses tool continuation input with reasoning before a function call for store false', async () => {
@@ -783,5 +944,39 @@ describe('OpenAI request helpers', () => {
 
         const chunks = await chunksPromise
         expect(chunks.at(-1)?.['0']).toContain('stream failed')
+    })
+
+    it('preserves usage and failed status from a streaming incomplete response', async () => {
+        const stream = __testResponsesAPI.getResponsesTranStream(baseArg())
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output_text":"Partial answer","usage":{"input_tokens":37,"output_tokens":9}}}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)).toMatchObject({
+            __usage: JSON.stringify({ input_tokens: 37, output_tokens: 9 }),
+            __usageStatus: 'failed',
+        })
+        expect(chunks.at(-1)?.['0']).toContain('max_output_tokens')
+    })
+
+    it('preserves usage and failed status from a streaming failed response', async () => {
+        const stream = __testResponsesAPI.getResponsesTranStream(baseArg())
+        const chunksPromise = collectStream(stream.readable)
+        const writer = stream.writable.getWriter()
+        const encoder = new TextEncoder()
+
+        await writer.write(encoder.encode('data: {"type":"response.failed","response":{"status":"failed","error":{"message":"provider failed"},"usage":{"input_tokens":41,"output_tokens":3}}}\n\n'))
+        await writer.close()
+
+        const chunks = await chunksPromise
+        expect(chunks.at(-1)).toMatchObject({
+            __usage: JSON.stringify({ input_tokens: 41, output_tokens: 3 }),
+            __usageStatus: 'failed',
+        })
+        expect(chunks.at(-1)?.['0']).toContain('provider failed')
     })
 })

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -314,6 +314,9 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
             }
         }
     
+        arg.onUsageAttemptPrepared?.({
+            inputChats: targs.body.messages,
+        })
         const res = await globalFetch(requestURL, targs)
 
         const dat = res.data as any
@@ -322,7 +325,8 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
                 const msg:OpenAIChatFull = (dat.choices[0].message)
                 return {
                     type: 'success',
-                    result: msg.content ?? ''
+                    result: msg.content ?? '',
+                    usage: dat.usage,
                 }
             } catch (error) {                    
                 return {
@@ -975,6 +979,9 @@ export async function requestOpenAILegacyInstruct(arg:RequestDataArgumentExtende
     body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
     arg.onUsageModelResolved?.(typeof body.model === 'string' ? body.model : undefined)
 
+    arg.onUsageAttemptPrepared?.({
+        input: body.prompt,
+    })
     const response = await globalFetch(arg.customURL ?? "https://api.openai.com/v1/completions", {
         body: body,
         headers: headers,
@@ -991,7 +998,8 @@ export async function requestOpenAILegacyInstruct(arg:RequestDataArgumentExtende
     const text:string = response.data.choices[0].text
     return {
         type: 'success',
-        result: text.replace(/##\n/g, '')
+        result: text.replace(/##\n/g, ''),
+        usage: response.data.usage,
     }
     
 }

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -301,6 +301,8 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
             requestTimeoutMs: networkOptions.requestTimeoutMs
         } as const
 
+        arg.onUsageModelResolved?.(targs.body.model)
+
         if(arg.previewBody){
             return {
                 type: 'success',
@@ -581,11 +583,19 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         body.stream = false
     }
 
+    arg.onUsageModelResolved?.(typeof body.model === 'string' ? body.model : undefined)
+
     const localNetworkOptions = getLocalNetworkRequestOptions(replacerURL, db, false)
     const streamingLocalNetworkOptions = getLocalNetworkRequestOptions(replacerURL, db, true)
 
     if(arg.useStreaming){
         body.stream = true
+        if(shouldUseOpenAIFlexProcessing(aiModel, replacerURL, arg.modelInfo.provider)){
+            body.stream_options = {
+                ...(body.stream_options ?? {}),
+                include_usage: true,
+            }
+        }
         let urlHost = new URL(replacerURL).host
         if(urlHost.includes("localhost") || urlHost.includes("172.0.0.1") || urlHost.includes("0.0.0.0")){
             if(!isTauri && !isNodeServer){
@@ -606,6 +616,9 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
                 })
             }
         }
+        arg.onUsageAttemptPrepared?.({
+            inputChats: body.messages,
+        })
         const da = await fetchNative(replacerURL, {
             body: JSON.stringify(body),
             method: "POST",
@@ -673,6 +686,10 @@ export async function requestHTTPOpenAI(
 ):Promise<requestDataResponse>{
     
     const db = getDatabase()
+    arg.onUsageAttemptPrepared?.({
+        inputChats: Array.isArray(body.messages) ? body.messages : undefined,
+        input: Array.isArray(body.messages) ? undefined : body.prompt,
+    })
     const res = await globalFetch(replacerURL, {
         body: body,
         headers: headers,
@@ -819,6 +836,10 @@ export async function requestHTTPOpenAI(
                 let attempt = 0
                 
                 do {
+                    await arg.onUsageNextAttempt?.(attempt === 0 ? 'success' : 'failed', attempt === 0 ? {
+                        usage: dat.usage,
+                        output: [JSON.stringify(dat.choices?.[0]?.message?.tool_calls ?? [])],
+                    } : undefined)
                     attempt++
                     resRec = await requestHTTPOpenAI(replacerURL, body, headers, arg, networkOptions)
                     
@@ -833,6 +854,7 @@ export async function requestHTTPOpenAI(
                 const result = (db.simplifiedToolUse ? '' : (processTextResponse(dat) ?? '') + '\n\n') + callCode
                         
                 if(resRec.type === 'fail') {
+                    await arg.onUsageFinalAttempt?.('failed')
                     alertError(`Failed to fetch model response after tool execution`)
                     return {
                         type: 'success',
@@ -841,7 +863,9 @@ export async function requestHTTPOpenAI(
                 } else if(resRec.type === 'success') {
                     return {
                         type: 'success',
-                        result: result + '\n\n' + resRec.result
+                        result: result + '\n\n' + resRec.result,
+                        usage: resRec.usage,
+                        usageBillingStatus: resRec.usageBillingStatus,
                     }
                 }
                         
@@ -865,7 +889,8 @@ export async function requestHTTPOpenAI(
                     type: 'multiline',
                     result: dat.choices.map((v) => {
                         return ["char", v.message.content ?? '']
-                    })
+                    }),
+                    usage: dat.usage,
                 }
             }            
                     
@@ -873,7 +898,8 @@ export async function requestHTTPOpenAI(
             
             return {
                 type: 'success',
-                result: result
+                result: result,
+                usage: dat.usage,
             }
             
         } catch (error) {                    
@@ -947,6 +973,7 @@ export async function requestOpenAILegacyInstruct(arg:RequestDataArgumentExtende
     }
 
     body = applyAdditionalParameters(body, headers, getAdditionalParameters(arg.aiModel))
+    arg.onUsageModelResolved?.(typeof body.model === 'string' ? body.model : undefined)
 
     const response = await globalFetch(arg.customURL ?? "https://api.openai.com/v1/completions", {
         body: body,
@@ -1026,6 +1053,9 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
                                     if(readed["__tool_calls"]){
                                         chunk["__tool_calls"] = readed["__tool_calls"]
                                     }
+                                    if(readed["__usage"]){
+                                        chunk["__usage"] = readed["__usage"]
+                                    }
                                     control.enqueue(chunk)
                                 }
                                 else{
@@ -1033,7 +1063,11 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
                                 }
                                 return
                             }
-                            const choices = JSON.parse(rawChunk).choices
+                            const parsedChunk = JSON.parse(rawChunk)
+                            if(parsedChunk.usage){
+                                readed["__usage"] = JSON.stringify(parsedChunk.usage)
+                            }
+                            const choices = parsedChunk.choices ?? []
                             for(const choice of choices){
                                 const chunk = choice.delta.content ?? choice.text
                                 if(chunk){
@@ -1120,9 +1154,12 @@ function getTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Arr
                     const chunk:Record<string,string> = {
                         "0": `<Thoughts>\n${reasoningContent}\n</Thoughts>\n${readed["0"] ?? ''}`,
                     }
-                    if(readed["__tool_calls"]){
-                        chunk["__tool_calls"] = readed["__tool_calls"]
-                    }
+                                    if(readed["__tool_calls"]){
+                                        chunk["__tool_calls"] = readed["__tool_calls"]
+                                    }
+                                    if(readed["__usage"]){
+                                        chunk["__usage"] = readed["__usage"]
+                                    }
                     control.enqueue(chunk)
                 }
                 else{
@@ -1265,7 +1302,23 @@ function wrapToolStream(
                         let errorFlag = true
                         
                         do {
+                            let usage: unknown
+                            try {
+                                usage = attempt === 0 && value?.['__usage']
+                                    ? JSON.parse(value['__usage'])
+                                    : undefined
+                            }
+                            catch {
+                                usage = undefined
+                            }
+                            await arg.onUsageNextAttempt?.(attempt === 0 ? 'success' : 'failed', attempt === 0 ? {
+                                usage,
+                                output: [content, JSON.stringify(toolCalls)],
+                            } : undefined)
                             attempt++
+                            arg.onUsageAttemptPrepared?.({
+                                inputChats: body.messages,
+                            })
                             resRec = await fetchNative(replacerURL, {
                                 body: JSON.stringify(body),
                                 method: "POST",
@@ -1292,6 +1345,7 @@ function wrapToolStream(
                         } while (attempt <= db.requestRetrys) // Retry up to db.requestRetrys times
                         
                         if(errorFlag){
+                            await arg.onUsageFinalAttempt?.('failed')
                             alertError(`Failed to fetch model response after tool execution`)
                             return controller.close()
                         }
@@ -1302,7 +1356,7 @@ function wrapToolStream(
                         reader = transtream.readable.getReader()
                         
                         prefix += (content && !db.simplifiedToolUse ? content + '\n\n' : '') + callCodes.join('\n\n')
-                        controller.enqueue({"0": prefix})
+                        controller.enqueue({"0": prefix, "__usage": ""})
 
                         continue
                     }
@@ -1311,7 +1365,10 @@ function wrapToolStream(
                 
                 lastValue = value
                 
-                controller.enqueue({"0": (prefix ? prefix + '\n\n' : '') + content})
+                controller.enqueue({
+                    "0": (prefix ? prefix + '\n\n' : '') + content,
+                    ...(value?.["__usage"] ? { "__usage": value["__usage"] } : {}),
+                })
             }
         }
     })

--- a/src/ts/process/request/openAI/responses.ts
+++ b/src/ts/process/request/openAI/responses.ts
@@ -515,6 +515,9 @@ async function appendResponsesToolOutputs(body:any, calls:ResponseFunctionCallIt
 
 async function requestHTTPResponsesAPI(requestURL:string, body:any, headers:Record<string,string>, arg:RequestDataArgumentExtended, networkOptions:LocalNetworkRequestOptions):Promise<requestDataResponse>{
     const db = getDatabase()
+    arg.onUsageAttemptPrepared?.({
+        input: body.input,
+    })
     const response = await globalFetch(requestURL, {
         body: toExternalResponsesBody(body),
         headers: headers,
@@ -552,6 +555,10 @@ async function requestHTTPResponsesAPI(requestURL:string, body:any, headers:Reco
         let resRec:requestDataResponse
         let attempt = 0
         do{
+            await arg.onUsageNextAttempt?.(attempt === 0 ? 'success' : 'failed', attempt === 0 ? {
+                usage: data.usage,
+                output: [JSON.stringify(data.output ?? calls)],
+            } : undefined)
             attempt++
             resRec = await requestHTTPResponsesAPI(requestURL, body, headers, arg, networkOptions)
             if(resRec.type !== 'fail'){
@@ -560,7 +567,12 @@ async function requestHTTPResponsesAPI(requestURL:string, body:any, headers:Reco
         } while(attempt <= db.requestRetrys)
 
         if(resRec.type === 'success'){
-            return { type: 'success', result: prefix ? prefix + '\n\n' + resRec.result : resRec.result }
+            return {
+                type: 'success',
+                result: prefix ? prefix + '\n\n' + resRec.result : resRec.result,
+                usage: resRec.usage,
+                usageBillingStatus: resRec.usageBillingStatus,
+            }
         }
         return resRec
     }
@@ -571,7 +583,7 @@ async function requestHTTPResponsesAPI(requestURL:string, body:any, headers:Reco
         return { type: 'fail', result: incomplete || JSON.stringify(data) }
     }
 
-    return { type: 'success', result }
+    return { type: 'success', result, usage: data.usage }
 }
 
 function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream<Uint8Array, StreamResponseChunk>{
@@ -581,6 +593,7 @@ function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream
     let text = ''
     let reasoning = ''
     let error = ''
+    let usage: unknown
     const calls:Record<string, ResponseFunctionCallItem> = {}
 
     const appendReasoning = (incoming?:string) => {
@@ -607,6 +620,9 @@ function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream
         const chunk:Record<string,string> = { "0": error || result }
         if(Object.keys(calls).length > 0){
             chunk["__tool_calls"] = JSON.stringify(calls)
+        }
+        if(usage){
+            chunk["__usage"] = JSON.stringify(usage)
         }
         controller.enqueue(chunk)
     }
@@ -648,6 +664,7 @@ function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream
             error = JSON.stringify(event.error ?? event)
         }
         else if(type === 'response.completed'){
+            usage = event.response?.usage
             const finalText = extractResponsesText(event.response, arg)
             if(finalText){
                 text = finalText
@@ -728,7 +745,10 @@ function wrapResponsesToolStream(stream:ReadableStream<StreamResponseChunk>, bod
                 const { done, value } = await reader.read()
                 if(!done){
                     lastValue = value
-                    controller.enqueue({ "0": (prefix ? prefix + '\n\n' : '') + (value?.["0"] ?? '') })
+                    controller.enqueue({
+                        "0": (prefix ? prefix + '\n\n' : '') + (value?.["0"] ?? ''),
+                        ...(value?.["__usage"] ? { "__usage": value["__usage"] } : {}),
+                    })
                     continue
                 }
 
@@ -748,15 +768,29 @@ function wrapResponsesToolStream(stream:ReadableStream<StreamResponseChunk>, bod
                 const callPrefix = await appendResponsesToolOutputs(body, calls, arg, lastValue?.["0"] ?? '')
                 delete body.__lastOutput
                 prefix += (prefix && callPrefix ? '\n\n' : '') + callPrefix
-                if(prefix){
-                    controller.enqueue({ "0": prefix })
-                }
+                controller.enqueue({ "0": prefix, "__usage": "" })
 
                 let resRec:Response
                 let attempt = 0
                 let ok = false
                 do{
+                    let usage: unknown
+                    try {
+                        usage = attempt === 0 && lastValue?.["__usage"]
+                            ? JSON.parse(lastValue["__usage"])
+                            : undefined
+                    }
+                    catch {
+                        usage = undefined
+                    }
+                    await arg.onUsageNextAttempt?.(attempt === 0 ? 'success' : 'failed', attempt === 0 ? {
+                        usage,
+                        output: [lastValue?.["0"] ?? '', JSON.stringify(calls)],
+                    } : undefined)
                     attempt++
+                    arg.onUsageAttemptPrepared?.({
+                        input: body.input,
+                    })
                     resRec = await fetchNative(requestURL, {
                         body: JSON.stringify(toExternalResponsesBody(body)),
                         method: "POST",
@@ -771,6 +805,7 @@ function wrapResponsesToolStream(stream:ReadableStream<StreamResponseChunk>, bod
                 } while(!ok && attempt <= db.requestRetrys)
 
                 if(!ok){
+                    await arg.onUsageFinalAttempt?.('failed')
                     alertError(`Failed to fetch model response after tool execution`)
                     controller.close()
                     return
@@ -807,6 +842,8 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
         body.stream = false
     }
 
+    arg.onUsageModelResolved?.(typeof body.model === 'string' ? body.model : undefined)
+
     const localNetworkOptions = getLocalNetworkRequestOptions(requestURL, db, false)
     const streamingLocalNetworkOptions = getLocalNetworkRequestOptions(requestURL, db, true)
 
@@ -823,6 +860,9 @@ export async function requestOpenAIResponseAPI(arg:RequestDataArgumentExtended):
 
     if(arg.useStreaming){
         body.stream = true
+        arg.onUsageAttemptPrepared?.({
+            input: body.input,
+        })
         const response = await fetchNative(requestURL, {
             body: JSON.stringify(toExternalResponsesBody(body)),
             method: "POST",

--- a/src/ts/process/request/openAI/responses.ts
+++ b/src/ts/process/request/openAI/responses.ts
@@ -537,12 +537,20 @@ async function requestHTTPResponsesAPI(requestURL:string, body:any, headers:Reco
 
     const data = response.data as any
     if(data?.status === 'failed' || data?.error){
-        return { type: 'fail', result: JSON.stringify(data.error ?? data) }
+        return {
+            type: 'fail',
+            result: JSON.stringify(data.error ?? data),
+            usage: data.usage,
+        }
     }
     if(data?.status === 'incomplete'){
         const result = extractResponsesText(data, arg)
         const reason = data?.incomplete_details?.reason ? `Incomplete response: ${data.incomplete_details.reason}` : 'Incomplete response'
-        return { type: 'fail', result: result ? `${reason}\n${result}` : reason }
+        return {
+            type: 'fail',
+            result: result ? `${reason}\n${result}` : reason,
+            usage: data.usage,
+        }
     }
 
     const calls = extractResponsesFunctionCalls(data)
@@ -580,7 +588,11 @@ async function requestHTTPResponsesAPI(requestURL:string, body:any, headers:Reco
     const result = extractResponsesText(data, arg)
     if(!result){
         const incomplete = data?.incomplete_details?.reason ? `Incomplete response: ${data.incomplete_details.reason}` : ''
-        return { type: 'fail', result: incomplete || JSON.stringify(data) }
+        return {
+            type: 'fail',
+            result: incomplete || JSON.stringify(data),
+            usage: data.usage,
+        }
     }
 
     return { type: 'success', result, usage: data.usage }
@@ -594,6 +606,7 @@ function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream
     let reasoning = ''
     let error = ''
     let usage: unknown
+    let usageStatus: 'success' | 'failed' | undefined
     const calls:Record<string, ResponseFunctionCallItem> = {}
 
     const appendReasoning = (incoming?:string) => {
@@ -623,6 +636,9 @@ function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream
         }
         if(usage){
             chunk["__usage"] = JSON.stringify(usage)
+        }
+        if(usageStatus){
+            chunk["__usageStatus"] = usageStatus
         }
         controller.enqueue(chunk)
     }
@@ -660,11 +676,9 @@ function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream
                 status: event.item.status
             }
         }
-        else if(type === 'response.failed' || type === 'response.error' || type === 'error'){
-            error = JSON.stringify(event.error ?? event)
-        }
-        else if(type === 'response.completed'){
+        else if(type === 'response.completed' || type === 'response.incomplete' || type === 'response.failed'){
             usage = event.response?.usage
+            usageStatus = type === 'response.completed' ? 'success' : 'failed'
             const finalText = extractResponsesText(event.response, arg)
             if(finalText){
                 text = finalText
@@ -672,9 +686,19 @@ function getResponsesTranStream(arg:RequestDataArgumentExtended):TransformStream
                     reasoning = ''
                 }
             }
-            for(const call of extractResponsesFunctionCalls(event.response)){
-                calls[call.call_id] = call
+            if(type === 'response.completed'){
+                for(const call of extractResponsesFunctionCalls(event.response)){
+                    calls[call.call_id] = call
+                }
             }
+            if(type !== 'response.completed'){
+                const reason = event.response?.incomplete_details?.reason
+                error = JSON.stringify(event.error ?? event.response?.error ?? (reason ? { message: `Incomplete response: ${reason}` } : event))
+            }
+        }
+        else if(type === 'response.error' || type === 'error'){
+            usageStatus = 'failed'
+            error = JSON.stringify(event.error ?? event)
         }
     }
 
@@ -748,6 +772,7 @@ function wrapResponsesToolStream(stream:ReadableStream<StreamResponseChunk>, bod
                     controller.enqueue({
                         "0": (prefix ? prefix + '\n\n' : '') + (value?.["0"] ?? ''),
                         ...(value?.["__usage"] ? { "__usage": value["__usage"] } : {}),
+                        ...(value?.["__usageStatus"] ? { "__usageStatus": value["__usageStatus"] } : {}),
                     })
                     continue
                 }

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -2,6 +2,8 @@ import { Ollama } from 'ollama/dist/browser.mjs';
 import { language } from "../../../lang";
 import { fetchNative, globalFetch } from "../../globalApi.svelte";
 import { getModelInfo, LLMFlags, LLMFormat, type LLMModel } from "../../model/modellist";
+import { createApiUsageRecorder } from "../../apiUsageRecorder";
+import { getApiUsageProvider } from "../../apiUsage";
 import { risuChatParser, risuEscape, risuUnescape } from "../../parser/parser.svelte";
 import { pluginProcess, pluginV2 } from "../../plugins/plugins.svelte";
 import { getCurrentCharacter, getCurrentChat, getDatabase, type character } from "../../storage/database.svelte";
@@ -63,6 +65,21 @@ export interface RequestDataArgumentExtended extends requestDataArgument{
     key?:string
     additionalOutput?:string
     saveSignatures?:boolean
+    onUsageAttemptPrepared?: (attempt: ApiUsageAttemptDetails) => void
+    onUsageNextAttempt?: (completedStatus: 'success' | 'failed', result?: ApiUsageAttemptResult) => Promise<void>
+    onUsageFinalAttempt?: (completedStatus: 'success' | 'failed', result?: ApiUsageAttemptResult) => Promise<void>
+    onUsageModelResolved?: (model: string | null | undefined) => void
+}
+
+export interface ApiUsageAttemptDetails {
+    input?: unknown
+    inputChats?: OpenAIChat[]
+}
+
+export interface ApiUsageAttemptResult {
+    usage?: unknown
+    output?: string[]
+    billingStatus?: 'estimated' | 'not_billed' | 'unknown'
 }
 
 export type requestDataResponse = {
@@ -74,6 +91,8 @@ export type requestDataResponse = {
     },
     failByServerError?: boolean
     model?: string
+    usage?: unknown
+    usageBillingStatus?: 'estimated' | 'not_billed' | 'unknown'
 }|{
     type: "streaming",
     result: ReadableStream<StreamResponseChunk>,
@@ -81,6 +100,8 @@ export type requestDataResponse = {
         emotion?: string
     }
     model?: string
+    usage?: unknown
+    usageBillingStatus?: 'estimated' | 'not_billed' | 'unknown'
 }|{
     type: "multiline",
     result: ['user'|'char',string][],
@@ -88,6 +109,8 @@ export type requestDataResponse = {
         emotion?: string
     }
     model?: string
+    usage?: unknown
+    usageBillingStatus?: 'estimated' | 'not_billed' | 'unknown'
 }
 
 export interface StreamResponseChunk{[key:string]:string}
@@ -478,58 +501,77 @@ export async function requestChatDataMain(arg:requestDataArgument, model:ModelMo
     }
 
     const format = targ.modelInfo.format
-
     targ.formated = reformater(targ.formated, targ.modelInfo)
+    const shouldTrackUsage = !arg.previewBody && format !== undefined && format !== LLMFormat.Echo
+    const usageRecorder = shouldTrackUsage ? createApiUsageRecorder({
+        formated: targ.formated,
+        mode: model,
+        model: targ.aiModel,
+        modelInfo: targ.modelInfo,
+        provider: getApiUsageProvider(targ.aiModel, targ.modelInfo, targ.customURL),
+        abortSignal,
+    }) : null
+    targ.onUsageNextAttempt = usageRecorder?.recordNextAttempt
+    targ.onUsageFinalAttempt = usageRecorder?.finalizeAttempt
+    targ.onUsageModelResolved = usageRecorder?.resolveModel
+    targ.onUsageAttemptPrepared = usageRecorder?.prepareAttempt
 
-    switch(format){
-        case LLMFormat.OpenAICompatible:
-        case LLMFormat.Mistral:
-        case LLMFormat.NanoGPT:
-            return requestOpenAI(targ)
-        case LLMFormat.NanoGPTResponses:
-            return requestOpenAIResponseAPI(targ)
-        case LLMFormat.NanoGPTMessages:
-            return requestClaude(targ)
-        case LLMFormat.NanoGPTLegacy:
-            return requestOpenAILegacyInstruct(targ)
-        case LLMFormat.OpenAILegacyInstruct:
-            return requestOpenAILegacyInstruct(targ)
-        case LLMFormat.NovelAI:
-            return requestNovelAI(targ)
-        case LLMFormat.OobaLegacy:
-            return requestOobaLegacy(targ)
-        case LLMFormat.Plugin:
-            return requestPlugin(targ)
-        case LLMFormat.Ooba:
-            return requestOoba(targ)
-        case LLMFormat.VertexAIGemini:
-        case LLMFormat.GoogleCloud:
-            return requestGoogleCloudVertex(targ)
-        case LLMFormat.Kobold:
-            return requestKobold(targ)
-        case LLMFormat.NovelList:
-            return requestNovelList(targ)
-        case LLMFormat.Ollama:
-            return requestOllama(targ)
-        case LLMFormat.Cohere:
-            return requestCohere(targ)
-        case LLMFormat.Anthropic:
-        case LLMFormat.AnthropicLegacy:
-        case LLMFormat.AWSBedrockClaude:
-            return requestClaude(targ)
-        case LLMFormat.Horde:
-            return requestHorde(targ)
-        case LLMFormat.WebLLM:
-            return requestWebLLM(targ)
-        case LLMFormat.OpenAIResponseAPI:
-            return requestOpenAIResponseAPI(targ)
-        case LLMFormat.Echo:
-            return requestEcho(targ)
+    try {
+        let response: requestDataResponse
+        switch(format){
+            case LLMFormat.OpenAICompatible:
+            case LLMFormat.Mistral:
+            case LLMFormat.NanoGPT:
+                response = await requestOpenAI(targ); break
+            case LLMFormat.NanoGPTResponses:
+                response = await requestOpenAIResponseAPI(targ); break
+            case LLMFormat.NanoGPTMessages:
+                response = await requestClaude(targ); break
+            case LLMFormat.NanoGPTLegacy:
+            case LLMFormat.OpenAILegacyInstruct:
+                response = await requestOpenAILegacyInstruct(targ); break
+            case LLMFormat.NovelAI:
+                response = await requestNovelAI(targ); break
+            case LLMFormat.OobaLegacy:
+                response = await requestOobaLegacy(targ); break
+            case LLMFormat.Plugin:
+                response = await requestPlugin(targ); break
+            case LLMFormat.Ooba:
+                response = await requestOoba(targ); break
+            case LLMFormat.VertexAIGemini:
+            case LLMFormat.GoogleCloud:
+                response = await requestGoogleCloudVertex(targ); break
+            case LLMFormat.Kobold:
+                response = await requestKobold(targ); break
+            case LLMFormat.NovelList:
+                response = await requestNovelList(targ); break
+            case LLMFormat.Ollama:
+                response = await requestOllama(targ); break
+            case LLMFormat.Cohere:
+                response = await requestCohere(targ); break
+            case LLMFormat.Anthropic:
+            case LLMFormat.AnthropicLegacy:
+            case LLMFormat.AWSBedrockClaude:
+                response = await requestClaude(targ); break
+            case LLMFormat.Horde:
+                response = await requestHorde(targ); break
+            case LLMFormat.WebLLM:
+                response = await requestWebLLM(targ); break
+            case LLMFormat.OpenAIResponseAPI:
+                response = await requestOpenAIResponseAPI(targ); break
+            case LLMFormat.Echo:
+                response = await requestEcho(targ); break
+            default:
+                response = {
+                    type: 'fail',
+                    result: (language.errors.unknownModel)
+                }
+        }
+        return usageRecorder ? await usageRecorder.finalizeResponse(response) : response
     }
-
-    return {
-        type: 'fail',
-        result: (language.errors.unknownModel)
+    catch (error) {
+        await usageRecorder?.finalizeFailure()
+        throw error
     }
 }
 
@@ -870,6 +912,7 @@ async function requestPlugin(arg:RequestDataArgumentExtended):Promise<requestDat
         const bias = arg.biasString
         const model = isV3Model ? arg.aiModel.replace('pluginmodel:::', '') : db.currentPluginProvider
         const v2Function = pluginV2.providers.get(model)
+        arg.onUsageModelResolved?.(isV3Model ? arg.modelInfo.internalID || arg.aiModel : model)
 
         if(arg.previewBody){
             return {
@@ -1168,6 +1211,7 @@ async function requestOllama(arg:RequestDataArgumentExtended):Promise<requestDat
     }
 
     requestBody = applyAdditionalParameters(requestBody, customHeaders, getAdditionalParameters(arg.aiModel))
+    arg.onUsageModelResolved?.(typeof requestBody.model === 'string' ? requestBody.model : undefined)
 
     if(arg.previewBody){
         return {

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -21,7 +21,7 @@ import {
     normalizeChatLoadPages,
 } from '../chatLoadPages';
 import { setDatabaseLite } from './databaseState.svelte';
-import { normalizeApiUsageStats, type ApiUsageStats } from '../apiUsage';
+import type { ApiUsageStats } from '../apiUsage';
 
 export { onDatabaseUpdate, setDatabaseLite } from './databaseState.svelte';
 
@@ -710,7 +710,6 @@ export function setDatabase(data:Database){
     data.keepSessionAlive ??= 'off'
     data.loadouts ??= []
     data.longPressToPopupEditor ??= false
-    data.apiUsage = normalizeApiUsageStats(data.apiUsage)
     data.customSidebarItems ??= []
     data.moveInsteadOfCopyOnCMPConvert ??= false
     data.skipSavingAssetsOnWebSync ??= true
@@ -1093,7 +1092,8 @@ export interface Database{
         messages: number
         imports: number
     }
-    apiUsage: ApiUsageStats
+    /** Legacy migration source. New API usage data is stored separately. */
+    apiUsage?: ApiUsageStats
     customQuotes:boolean
     customQuotesData?:[string, string, string, string]
     groupTemplate?:string

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -21,6 +21,7 @@ import {
     normalizeChatLoadPages,
 } from '../chatLoadPages';
 import { setDatabaseLite } from './databaseState.svelte';
+import { normalizeApiUsageStats, type ApiUsageStats } from '../apiUsage';
 
 export { onDatabaseUpdate, setDatabaseLite } from './databaseState.svelte';
 
@@ -709,6 +710,7 @@ export function setDatabase(data:Database){
     data.keepSessionAlive ??= 'off'
     data.loadouts ??= []
     data.longPressToPopupEditor ??= false
+    data.apiUsage = normalizeApiUsageStats(data.apiUsage)
     data.customSidebarItems ??= []
     data.moveInsteadOfCopyOnCMPConvert ??= false
     data.skipSavingAssetsOnWebSync ??= true
@@ -1091,6 +1093,7 @@ export interface Database{
         messages: number
         imports: number
     }
+    apiUsage: ApiUsageStats
     customQuotes:boolean
     customQuotesData?:[string, string, string, string]
     groupTemplate?:string

--- a/src/ts/storage/databaseState.svelte.test.ts
+++ b/src/ts/storage/databaseState.svelte.test.ts
@@ -1,6 +1,8 @@
 import { flushSync } from 'svelte'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DBState } from '../stores.svelte'
+import { createEmptyApiUsageStats, recordApiUsage } from '../apiUsage'
+import { replaceApiUsageState } from '../apiUsageState.svelte'
 import { getDatabase, onDatabaseUpdate, setDatabaseLite, type character, type Chat, type Database } from './database.svelte'
 
 vi.mock('../globalApi.svelte', () => ({
@@ -32,6 +34,23 @@ afterEach(() => {
 })
 
 describe('database proxy layering', () => {
+    it('keeps API usage recording outside database dirty tracking', () => {
+        setDatabaseLite(database({ characters: [{ chaId: 'active', chats: [] }] as character[] }))
+        replaceApiUsageState(createEmptyApiUsageStats())
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        recordApiUsage({
+            model: 'test-model',
+            inputTokens: 10,
+            outputTokens: 2,
+        })
+
+        expect(listener).not.toHaveBeenCalled()
+        expect(getDatabase().apiUsage).toBeUndefined()
+        unsubscribe()
+    })
+
     it('tracks nested mutations after receiving a plain object', () => {
         setDatabaseLite(database({ pluginCustomStorage: { plugin: { enabled: false } } }))
         const listener = vi.fn()

--- a/src/ts/tokenizer.ts
+++ b/src/ts/tokenizer.ts
@@ -22,9 +22,10 @@ function getHash(
     currentPluginProvider: string,
     googleClaudeTokenizing: boolean,
     modelInfo: LLMModel,
-    pluginTokenizer: string
+    pluginTokenizer: string,
+    localOnly: boolean
 ): string {
-    const combined = `${data}::${aiModel}::${customTokenizer}::${currentPluginProvider}::${googleClaudeTokenizing ? '1' : '0'}::${modelInfo.tokenizer}::${pluginTokenizer}`;
+    const combined = `${data}::${aiModel}::${customTokenizer}::${currentPluginProvider}::${googleClaudeTokenizing ? '1' : '0'}::${modelInfo.id}::${modelInfo.internalID ?? ''}::${modelInfo.tokenizer}::${pluginTokenizer}::${localOnly ? '1' : '0'}`;
     return combined;
 }
 
@@ -78,21 +79,29 @@ export async function encodeWithTokenizer(data: string, tokenizerType: string): 
     }
 }
 
-export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Array)>{
+export interface TokenizerEncodeOptions {
+    aiModel?: string
+    modelInfo?: LLMModel
+    localOnly?: boolean
+}
+
+export async function encode(data:string, options:TokenizerEncodeOptions = {}):Promise<(number[]|Uint32Array|Int32Array)>{
     const db = getDatabase();
-    const modelInfo = getModelInfo(db.aiModel);
+    const aiModel = options.aiModel ?? db.aiModel;
+    const modelInfo = options.modelInfo ?? getModelInfo(aiModel);
     const pluginTokenizer = pluginV2.providerOptions.get(db.currentPluginProvider)?.tokenizer ?? "none";
 
     let cacheKey = ''
     if(db.useTokenizerCaching){
         cacheKey = getHash(
             data,
-            db.aiModel,
+            aiModel,
             db.customTokenizer,
             db.currentPluginProvider,
             db.googleClaudeTokenizing,
             modelInfo,
-            pluginTokenizer
+            pluginTokenizer,
+            options.localOnly ?? false
         );
         const cachedResult = encodeCache.get(cacheKey);
         if (cachedResult !== undefined) {
@@ -102,7 +111,7 @@ export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Arr
 
     let result: number[] | Uint32Array | Int32Array;
 
-    if(db.aiModel === 'openrouter' || db.aiModel === 'reverse_proxy'){
+    if(aiModel === 'openrouter' || aiModel === 'reverse_proxy'){
         switch(db.customTokenizer){
             case 'mistral':
                 result = await tokenizeWebTokenizers(data, 'mistral'); break;
@@ -131,7 +140,7 @@ export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Arr
             default:
                 result = await tikJS(data, 'o200k_base'); break;
         }
-    } else if (db.aiModel === 'custom' && pluginTokenizer) {
+    } else if (aiModel === 'custom' && pluginTokenizer) {
         switch(pluginTokenizer){
             case 'mistral':
                 result = await tokenizeWebTokenizers(data, 'mistral'); break;
@@ -184,7 +193,7 @@ export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Arr
             result = await tokenizeGGUFModel(data);
         } else if(modelInfo.tokenizer === LLMTokenizer.tiktokenO200Base){
             result = await tikJS(data, 'o200k_base');
-        } else if(modelInfo.tokenizer === LLMTokenizer.GoogleCloud && db.googleClaudeTokenizing){
+        } else if(modelInfo.tokenizer === LLMTokenizer.GoogleCloud && db.googleClaudeTokenizing && !options.localOnly){
             result = await tokenizeGoogleCloud(data);
         } else if(modelInfo.tokenizer === LLMTokenizer.Gemma || modelInfo.tokenizer === LLMTokenizer.GoogleCloud){
             result = await gemmaTokenize(data);
@@ -394,8 +403,8 @@ export async function tokenizerChar(char:character) {
     return encoded.length
 }
 
-export async function tokenize(data:string) {
-    const encoded = await encode(data)
+export async function tokenize(data:string, options:TokenizerEncodeOptions = {}) {
+    const encoded = await encode(data, options)
     return encoded.length
 }
 
@@ -413,17 +422,19 @@ export class ChatTokenizer {
 
     private chatAdditionalTokens:number
     private useName:'name'|'noName'
+    private options:TokenizerEncodeOptions
 
-    constructor(chatAdditionalTokens:number, useName:'name'|'noName'){
+    constructor(chatAdditionalTokens:number, useName:'name'|'noName', options:TokenizerEncodeOptions = {}){
         this.chatAdditionalTokens = chatAdditionalTokens
         this.useName = useName
+        this.options = options
     }
     async tokenizeChat(data:OpenAIChat, args:{
         countThoughts?:boolean,
     } = {}) {
-        let encoded = (await encode(data.content)).length + this.chatAdditionalTokens
+        let encoded = (await encode(data.content, this.options)).length + this.chatAdditionalTokens
         if(data.name && this.useName ==='name'){
-            encoded += (await encode(data.name)).length + 1
+            encoded += (await encode(data.name, this.options)).length + 1
         }
         if(data.multimodals && data.multimodals.length > 0){
             for(const multimodal of data.multimodals){
@@ -432,7 +443,7 @@ export class ChatTokenizer {
         }
         if(data.thoughts && data.thoughts.length > 0 && args.countThoughts){
             for(const thought of data.thoughts){
-                encoded += (await encode(thought)).length + 1
+                encoded += (await encode(thought, this.options)).length + 1
             }
         }
         return encoded


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This PR adds the persistence and request-recording foundation for API usage statistics. It records token usage, request outcomes, request modes, provider identity, and reported costs without adding a new user-facing interface.

## Related Issues

None.

## Changes

API usage is stored as daily aggregates grouped by model and provider, alongside a bounded recent-request history. Stored data is normalized for backward compatibility and malformed entries are handled safely.

The request pipeline now records individual attempts across OpenAI Chat Completions and Responses, Anthropic, and Gemini requests. This includes retries, tool follow-ups, streaming responses, failures, and cancellations.

Provider-reported usage is used when available, including cached input tokens, reasoning tokens, and reported costs. When usage metadata is unavailable, token counts are estimated locally without making additional tokenizer API requests.

The recorder also follows the model ID and request body that are actually sent to the provider, rather than relying only on the configured routing model.

## Impact

Users will begin accumulating API usage data in their local database as requests are made. Recent request records are limited to 48 hours and 10,000 entries, while compact daily aggregates are retained for longer-term statistics.

Existing request and response behavior is preserved. Usage-recording failures are isolated from chat generation so they do not interrupt normal requests.

## Additional Notes

I was trying to add the Usage settings page and tracking system in one pull request. But it requires a lot of changes, so I separated it.
This pull request has only the tracking system.

Validation completed with:

- `pnpm check`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/ts/apiUsage.test.ts src/ts/apiUsageRecorder.test.ts src/ts/process/request/google.usage.test.ts src/ts/process/request/openAI/requests.responses.test.ts`

All 63 focused tests passed, and Svelte Check reported no errors or warnings.