### PR TITLE
perf: skip CBS re-parse when a regex script does not change the text

### DIFF
--- a/src/ts/process/scripts.test.ts
+++ b/src/ts/process/scripts.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+//#region module mocks — processScriptFull pulls in browser-heavy modules
+
+vi.mock(import('../parser/parser.svelte'), () => ({
+    assetRegex: /{{(raw|img|image|video|audio|bg|emotion|asset|video-img|source|inlay|inlayed|inlayeddata)::(.+?)}}/g,
+    risuChatParser: vi.fn((v: string) => v.replaceAll('{{marker}}', 'PARSED')),
+}) as unknown as typeof import('../parser/parser.svelte'))
+
+vi.mock(import('../storage/database.svelte'), () => ({
+    getDatabase: () => ({ presetRegex: [], characters: [], dynamicAssets: false }),
+    getCurrentCharacter: () => ({ type: 'character', chats: [{ message: [] }], chatPage: 0 }),
+    getCurrentChat: () => ({ message: [] }),
+}) as unknown as typeof import('../storage/database.svelte'))
+
+vi.mock(import('../stores.svelte'), async () => {
+    const { writable } = await import('svelte/store')
+    return {
+        CharEmotion: writable({}),
+        selectedCharID: writable(0),
+    } as unknown as typeof import('../stores.svelte')
+})
+
+vi.mock(import('../globalApi.svelte'), () => ({
+    downloadFile: async () => {},
+}) as unknown as typeof import('../globalApi.svelte'))
+
+vi.mock(import('../alert'), () => ({
+    alertError: () => {},
+    alertNormal: () => {},
+}) as unknown as typeof import('../alert'))
+
+vi.mock(import('src/lang'), () => ({
+    language: { successExport: '' },
+}) as unknown as typeof import('src/lang'))
+
+vi.mock(import('../util'), () => ({
+    selectSingleFile: async () => ({ data: null }),
+}) as unknown as typeof import('../util'))
+
+vi.mock(import('./modules'), () => ({
+    getModuleAssets: () => [],
+    getModuleRegexScripts: () => [],
+}) as unknown as typeof import('./modules'))
+
+vi.mock(import('./memory/hypamemory'), () => ({
+    HypaProcesser: class {
+        async addText() {}
+        async similaritySearch() { return [] }
+    },
+}) as unknown as typeof import('./memory/hypamemory'))
+
+vi.mock(import('./scriptings'), () => ({
+    runLuaEditTrigger: async (_char: unknown, _mode: unknown, data: unknown) => data,
+}) as unknown as typeof import('./scriptings'))
+
+vi.mock(import('../plugins/plugins.svelte'), () => ({
+    pluginV2: {
+        editinput: new Set(),
+        editoutput: new Set(),
+        editprocess: new Set(),
+        editdisplay: new Set(),
+    },
+}) as unknown as typeof import('../plugins/plugins.svelte'))
+
+vi.mock(import('./triggers'), () => ({
+    runTrigger: async () => null,
+}) as unknown as typeof import('./triggers'))
+
+//#endregion
+
+import { risuChatParser } from '../parser/parser.svelte'
+import { processScriptFull, resetScriptCache } from './scripts'
+
+const parserMock = vi.mocked(risuChatParser)
+
+type Script = {
+    comment: string
+    in: string
+    out: string
+    type: string
+    flag?: string
+    ableFlag?: boolean
+}
+
+const makeChar = (scripts: Script[]) => ({
+    type: 'simple',
+    chaId: 'test-char',
+    customscript: scripts,
+}) as any
+
+describe('processScriptFull CBS reparse gating', () => {
+    beforeEach(() => {
+        resetScriptCache()
+        parserMock.mockClear()
+    })
+
+    it('parses input once when no script matches', async () => {
+        const scripts: Script[] = Array.from({ length: 5 }, (_, i) => ({
+            comment: `s${i}`,
+            in: `never-matches-${i}`,
+            out: 'x',
+            type: 'editinput',
+        }))
+
+        const r = await processScriptFull(makeChar(scripts), 'hello {{marker}} world', 'editinput', -1)
+
+        expect(r.data).toBe('hello PARSED world')
+        //only the initial parse; none of the 5 non-matching scripts re-parse
+        expect(parserMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-parses when a script changes the text, and parses CBS the script introduced', async () => {
+        const scripts: Script[] = [
+            { comment: 's', in: 'foo', out: '{{marker}}', type: 'editinput' },
+        ]
+
+        const r = await processScriptFull(makeChar(scripts), 'foo bar', 'editinput', -1)
+
+        expect(r.data).toBe('PARSED bar')
+        expect(parserMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('skips the re-parse when a match replaces text with identical text', async () => {
+        const scripts: Script[] = [
+            { comment: 's', in: 'foo', out: 'foo', type: 'editinput' },
+        ]
+
+        const r = await processScriptFull(makeChar(scripts), 'foo bar', 'editinput', -1)
+
+        expect(r.data).toBe('foo bar')
+        expect(parserMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('gates the action-script branch the same way', async () => {
+        const scripts: Script[] = [
+            //flag actions route through the @@/actions branch of executeScript
+            { comment: 'hit', in: 'foo', out: 'baz', type: 'editinput', flag: 'g<myaction>', ableFlag: true },
+            { comment: 'miss', in: 'never-matches', out: 'x', type: 'editinput', flag: 'g<myaction>', ableFlag: true },
+        ]
+
+        const r = await processScriptFull(makeChar(scripts), 'foo bar', 'editinput', -1)
+
+        expect(r.data).toBe('baz bar')
+        //initial parse + one re-parse for the matching script only
+        expect(parserMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('applies sequential scripts cumulatively', async () => {
+        const scripts: Script[] = [
+            { comment: 'a', in: 'aaa', out: 'bbb', type: 'editinput' },
+            { comment: 'nomatch', in: 'zzz', out: 'x', type: 'editinput' },
+            { comment: 'b', in: 'bbb', out: 'ccc', type: 'editinput' },
+        ]
+
+        const r = await processScriptFull(makeChar(scripts), 'aaa', 'editinput', -1)
+
+        expect(r.data).toBe('ccc')
+        //initial + 2 matching scripts
+        expect(parserMock).toHaveBeenCalledTimes(3)
+    })
+})

--- a/src/ts/process/scripts.ts
+++ b/src/ts/process/scripts.ts
@@ -245,7 +245,11 @@ export async function processScriptFull(char:character|groupChat|simpleCharacter
                         }
                     }
                     else{
-                        data = risuChatParser(data.replace(reg, outScript), { chatID: chatID, cbsConditions })
+                        const replaced = data.replace(reg, outScript)
+                        //only re-run the CBS parser when the script actually changed the text
+                        if(replaced !== data){
+                            data = risuChatParser(replaced, { chatID: chatID, cbsConditions })
+                        }
                     }
                 }
                 else{
@@ -288,7 +292,11 @@ export async function processScriptFull(char:character|groupChat|simpleCharacter
                 }
             }
             else{
-                data = risuChatParser(data.replace(reg, outScript), { chatID: chatID, cbsConditions })
+                const replaced = data.replace(reg, outScript)
+                //only re-run the CBS parser when the script actually changed the text
+                if(replaced !== data){
+                    data = risuChatParser(replaced, { chatID: chatID, cbsConditions })
+                }
             }
         }
     }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`processScriptFull` re-runs `risuChatParser` over the entire message after every regex script, even when the script's pattern didn't match anything. With N regex scripts of the processed type included, every message pays N+1 full CBS parser passes. This PR guards the two replace sites so the re-parse only happens when the replacement actually changed the text — `String.prototype.replace` returns the original string when nothing matched, so the guard is a cheap identity comparison.

## Related Issues

None. (I checked the open PRs for overlapping work on the regex script path and found none.)

## Changes

- `src/ts/process/scripts.ts`: both replace sites (the `@@`/action branch and the plain branch) now skip the `risuChatParser` call when `replace` returned the input unchanged.
- `src/ts/process/scripts.test.ts`: 5 focused tests — a non-matching script set triggers exactly one parse, a matching script still re-parses (and CBS it introduces is processed), an identical-text replacement skips the re-parse, the action branch is gated the same way, and sequential scripts still apply cumulatively.

## Impact

To be upfront: this is a small, structural win, not a dramatic one. Where it shows up depends on how many regex scripts are included.

Batch benchmark (real `risuChatParser`, storage mocked, median of 3 — 30 scripts × 3KB messages):

| Scenario | before | after |
|---|---|---|
| no script matches | 2.19 ms/msg | 0.26 ms/msg |
| 3 of 30 match | 1.83 ms/msg | 0.38 ms/msg |

Streaming benchmark (message grows to 8KB over 40 display updates, so every update is a cache miss — this is the path where the cost repeats):

| Scripts (none matching) | before | after |
|---|---|---|
| 30 | 80 ms/stream (2.0 ms/update) | 12 ms/stream (0.3 ms/update) |
| 100 | 234 ms/stream (5.9 ms/update) | 12 ms/stream (0.28 ms/update) |

Decomposing the old cost: ~95% of it was the wasted re-parses; cache-key generation plus the regex scans themselves are only ~5–8 ms/stream even at 100 scripts. After the guard, cost is essentially flat in script count.

Honest interpretation: with ≤30 scripts the difference is unlikely to be felt. With script-heavy setups (50–100 regex scripts) it removes roughly a 2–6 ms main-thread block per streaming display update (~4–12% of the main thread during active streaming at ~20 updates/s) and ~300 ms from a 50-message first page render. Matching scripts are unaffected — their output can carry CBS, so a changed result re-parses exactly as before.

**One intentional behavior change:** previously, escaped CBS produced by an earlier parse (literal `{{...}}` text) was re-parsed once per *non-matching* script, so the final output could depend on how many non-matching scripts happened to be included. With the guard, a script that doesn't change the text no longer triggers a parse, so that dependence is gone. I judged this a fix rather than a regression.

## Additional Notes

- Verified with `svelte-check` (0 errors) and the full vitest suite.
- The benchmark script is intentionally not committed; it is attached below and only uses public APIs, so it reproduces the numbers on any revision.

<details>
<summary>Benchmark script (save as <code>src/ts/process/scripts.perf.test.ts</code>, run with <code>RUN_PERF=1 npx vitest run src/ts/process/scripts.perf.test.ts</code>)</summary>

```ts
// Benchmark for the processScriptFull CBS-reparse gate. Gated behind RUN_PERF=1.
// Uses the REAL risuChatParser (storage layer mocked), so parse cost is genuine.
//
//   RUN_PERF=1 npx vitest run src/ts/process/scripts.perf.test.ts
//
import { describe, it, vi } from 'vitest'

//#region module mocks — storage/UI layer only; the parser and scripts module are real

vi.mock(import('../storage/database.svelte'), () => ({
    appVer: '0.0.0',
    getDatabase: () => ({
        presetRegex: [],
        characters: [{ type: 'character', chats: [{ message: [] }], chatPage: 0, name: 'char' }],
        dynamicAssets: false,
    }),
    getCurrentCharacter: () => ({ type: 'character', chats: [{ message: [] }], chatPage: 0 }),
    getCurrentChat: () => ({ message: [] }),
}) as unknown as typeof import('../storage/database.svelte'))

vi.mock(import('../stores.svelte'), async () => {
    const { writable } = await import('svelte/store')
    return {
        DBState: {
            db: {
                characters: [{ type: 'character', chats: [{ message: [] }], chatPage: 0, name: 'char' }],
                globalChatVariables: {},
                templateDefaultVariables: '',
            },
        },
        selIdState: { selId: 0 },
        CharEmotion: writable({}),
        selectedCharID: writable(0),
    } as unknown as typeof import('../stores.svelte')
})

vi.mock(import('../globalApi.svelte'), () => ({
    aiWatermarkingLawApplies: () => false,
    getFileSrc: () => Promise.resolve(''),
    globalFetch: async () => ({ ok: false, data: null, headers: {} }),
    downloadFile: async () => {},
}) as unknown as typeof import('../globalApi.svelte'))

vi.mock(import('./files/inlays'), () => ({
    supportsInlayImage: () => false,
}) as unknown as typeof import('./files/inlays'))

vi.mock(import('./models/local'), () => ({
    tokenizeGGUFModel: async () => [0],
}) as unknown as typeof import('./models/local'))

vi.mock(import('../plugins/plugins.svelte'), () => ({
    pluginV2: {
        providerOptions: new Map(),
        editinput: new Set(),
        editoutput: new Set(),
        editprocess: new Set(),
        editdisplay: new Set(),
    },
}) as unknown as typeof import('../plugins/plugins.svelte'))

vi.mock(import('../alert'), () => ({
    alertError: () => {},
    alertNormal: () => {},
}) as unknown as typeof import('../alert'))

vi.mock(import('./modules'), () => ({
    getModuleAssets: () => [],
    getModuleRegexScripts: () => [],
    getModuleLorebooks: () => [],
    getModuleTriggers: () => [],
}) as unknown as typeof import('./modules'))

vi.mock(import('./memory/hypamemory'), () => ({
    HypaProcesser: class {
        async addText() {}
        async similaritySearch() { return [] }
    },
}) as unknown as typeof import('./memory/hypamemory'))

vi.mock(import('./scriptings'), () => ({
    runLuaEditTrigger: async (_char: unknown, _mode: unknown, data: unknown) => data,
}) as unknown as typeof import('./scriptings'))

vi.mock(import('./triggers'), () => ({
    runTrigger: async () => null,
}) as unknown as typeof import('./triggers'))

//#endregion

import { processScriptFull, resetScriptCache } from './scripts'

const SCRIPT_COUNT = 30
const MESSAGES = 50

const paragraph = 'She walked along the riverbank as the evening light faded, thinking about everything that had happened since the morning. '
const makeMessage = (i: number) => `[msg ${i}] ` + paragraph.repeat(25) //~3KB

const makeScripts = (matching: number) => {
    const scripts: any[] = []
    for (let i = 0; i < SCRIPT_COUNT - matching; i++) {
        scripts.push({ comment: `miss${i}`, in: `pattern-that-never-matches-${i}\\d+`, out: 'x', type: 'editinput' })
    }
    for (let i = 0; i < matching; i++) {
        scripts.push({ comment: `hit${i}`, in: 'evening', out: 'late-day', type: 'editinput' })
    }
    return scripts
}

const makeChar = (scripts: any[]) => ({
    type: 'simple',
    chaId: 'perf-char',
    customscript: scripts,
}) as any

//simulates one streamed response: the message grows to ~8KB over N display updates,
//so every update is a cache miss and runs the full pipeline
const STREAM_UPDATES = 40
const finalMessage = paragraph.repeat(70) //~8.3KB

const streamScenario = async (label: string, scriptCount: number) => {
    resetScriptCache()
    const scripts: any[] = []
    for (let i = 0; i < scriptCount; i++) {
        scripts.push({
            comment: `miss${i}`,
            in: `\\[tag${i}\\|([a-z_]+)\\|mode-${i}\\]`,
            out: `<div class="asset-block a${i}"><img src="./assets/$1.webp" alt="$1"></div>`,
            type: 'editinput',
        })
    }
    const char = makeChar(scripts)
    const start = performance.now()
    for (let u = 1; u <= STREAM_UPDATES; u++) {
        const partial = finalMessage.slice(0, Math.floor(finalMessage.length * u / STREAM_UPDATES))
        await processScriptFull(char, partial, 'editinput', -1)
    }
    const elapsed = performance.now() - start
    process.stdout.write(`[stream ${label}] ${scriptCount} scripts, ${STREAM_UPDATES} updates to 8KB: ${elapsed.toFixed(1)}ms/stream, ${(elapsed / STREAM_UPDATES).toFixed(2)}ms/update\n`)
}

describe.runIf(process.env.RUN_PERF === '1')('processScriptFull benchmark', () => {
    it(`${SCRIPT_COUNT} non-matching regex scripts, ${MESSAGES} messages`, async () => {
        resetScriptCache()
        const char = makeChar(makeScripts(0))
        const start = performance.now()
        for (let i = 0; i < MESSAGES; i++) {
            await processScriptFull(char, makeMessage(i), 'editinput', -1)
        }
        const elapsed = performance.now() - start
        process.stdout.write(`[perf no-match] ${SCRIPT_COUNT} scripts x ${MESSAGES} msgs: ${elapsed.toFixed(1)}ms total, ${(elapsed / MESSAGES).toFixed(2)}ms/msg\n`)
    }, 300000)

    it(`${SCRIPT_COUNT} scripts of which 3 match, ${MESSAGES} messages`, async () => {
        resetScriptCache()
        const char = makeChar(makeScripts(3))
        const start = performance.now()
        for (let i = 0; i < MESSAGES; i++) {
            await processScriptFull(char, makeMessage(i), 'editinput', -1)
        }
        const elapsed = performance.now() - start
        process.stdout.write(`[perf 3-match] ${SCRIPT_COUNT} scripts x ${MESSAGES} msgs: ${elapsed.toFixed(1)}ms total, ${(elapsed / MESSAGES).toFixed(2)}ms/msg\n`)
    }, 300000)

    it('streaming: 0 scripts (baseline = initial parse only)', async () => {
        await streamScenario('base', 0)
    }, 300000)

    it('streaming: 30 non-matching scripts', async () => {
        await streamScenario('30s', 30)
    }, 300000)

    it('streaming: 100 non-matching scripts', async () => {
        await streamScenario('100s', 100)
    }, 300000)
})
```

</details>
