### PR TITLE
feat: persist reroll variants in chat message data

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -5,7 +5,7 @@
     import { selectedCharID, PlaygroundStore, createSimpleCharacter, hypaV3ModalOpen, ScrollToMessageStore, additionalChatMenu, additionalFloatingActionButtons, easyPanelStore, chatPanelStore } from "../../ts/stores.svelte";
     import { tick } from 'svelte';
     import Chat from "./Chat.svelte";
-    import { type Message } from "../../ts/storage/database.svelte";
+    import { type MessageVariant } from "../../ts/storage/database.svelte";
     import { DBState } from 'src/ts/stores.svelte';
     import { getCharImage } from "../../ts/characters";
     import { chatProcessStage, doingChat, sendChat } from "../../ts/process/index.svelte";
@@ -22,7 +22,7 @@
     import { aiLawApplies, chatFoldedState, chatFoldedStateMessageIndex, downloadFile } from 'src/ts/globalApi.svelte';
     import { runTrigger } from 'src/ts/process/triggers';
     import { v4 } from 'uuid';
-    import { PreUnreroll, Prereroll } from 'src/ts/process/prereroll';
+    import { attachVariants, collectVariants, switchVariant } from 'src/ts/process/prereroll';
     import { processMultiCommand } from 'src/ts/process/command';
     import { postChatFile } from 'src/ts/process/files/multisend';
     import { getInlayAsset } from 'src/ts/process/files/inlays';
@@ -46,9 +46,7 @@
     let openMenu = $state(false)
     let loadPages = $state(getInitialChatLoadPages(DBState.db))
     let autoMode = $state(false)
-    let rerolls:Message[][] = []
-    let rerollid = -1
-    let lastCharId = -1
+    let pendingVariants:MessageVariant[]|null = null
     let doingChatInputTranslate = false
     let toggleStickers:boolean = $state(false)
     let fileInput:string[] = $state([])
@@ -146,10 +144,6 @@
         if($doingChat){
             return
         }
-        if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
-        }
 
         let cha = DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message
 
@@ -208,7 +202,7 @@
         messageInput = ''
         messageInputTranslate = ''
         DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message = cha
-        rerolls = []
+        pendingVariants = null
         await sleep(10)
         updateInputSizeAll()
         await sendChatMain(continueResponse)
@@ -219,39 +213,16 @@
         if($doingChat){
             return
         }
-        if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
-        }
-        const genId = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)?.generationInfo?.generationId
-        if(genId){
-            const r = Prereroll(genId)
-            if(r){
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - 1].data = r
-                return
-            }
-        }
-        if(rerollid < rerolls.length - 1){
-            if(Array.isArray(rerolls[rerollid + 1])){
-                rerollid += 1
-                let rerollData = safeStructuredClone(rerolls[rerollid])
-                let msgs = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-                for(let i = 0; i < rerollData.length; i++){
-                    msgs[msgs.length - rerollData.length + i] = rerollData[i]
-                }
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = msgs
-            }
+        const lastMsg = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)
+        if(lastMsg && switchVariant(lastMsg, 1)){
             return
-        }
-        if(rerolls.length === 0){
-            rerolls.push(safeStructuredClone([DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)]))
-            rerollid = rerolls.length - 1
         }
         let cha = safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message)
         if(cha.length === 0 ){
             return
         }
         openMenu = false
+        const lastBeforePop = cha[cha.length - 1]
         const saying = cha[cha.length - 1].saying
         let sayingQu = 2
         while(cha[cha.length - 1].role !== 'user'){
@@ -266,6 +237,8 @@
                 return
             }
         }
+        const popped = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - cha.length
+        pendingVariants = popped === 1 ? collectVariants(lastBeforePop) : null
         DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = cha
         await sendChatMain()
     }
@@ -274,29 +247,9 @@
         if($doingChat){
             return
         }
-        if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
-        }
-        const genId = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)?.generationInfo?.generationId
-        if(genId){
-            const r = PreUnreroll(genId)
-            if(r){
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - 1].data = r
-                return
-            }
-        }
-        if(rerollid <= 0){
-            return
-        }
-        if(Array.isArray(rerolls[rerollid - 1])){
-            rerollid -= 1
-            let rerollData = safeStructuredClone(rerolls[rerollid])
-            let msgs = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-            for(let i = 0; i < rerollData.length; i++){
-                msgs[msgs.length - rerollData.length + i] = rerollData[i]
-            }
-            DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = msgs
+        const lastMsg = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)
+        if(lastMsg){
+            switchVariant(lastMsg, -1)
         }
     }
 
@@ -312,15 +265,15 @@
                 signal:abortController.signal,
                 continue:continued
             })
-            if(previousLength < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
-                rerolls.push(safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message).slice(previousLength))
-                rerollid = rerolls.length - 1
+            const message = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+            if(message.length - previousLength === 1 && pendingVariants){
+                attachVariants(message[message.length - 1], pendingVariants)
             }
         } catch (error) {
             console.error(error)
             alertError(error)
         }
-        lastCharId = $selectedCharID
+        pendingVariants = null
         $doingChat = false
         if(DBState.db.playMessage){
             const audio = new Audio(sendSound);

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -47,6 +47,7 @@
     let loadPages = $state(getInitialChatLoadPages(DBState.db))
     let autoMode = $state(false)
     let pendingVariants:MessageVariant[]|null = null
+    let pendingVariantsKey = ''
     let doingChatInputTranslate = false
     let toggleStickers:boolean = $state(false)
     let fileInput:string[] = $state([])
@@ -238,7 +239,14 @@
             }
         }
         const popped = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - cha.length
-        pendingVariants = popped === 1 ? collectVariants(lastBeforePop) : null
+        if(popped === 1){
+            pendingVariants = collectVariants(lastBeforePop)
+            pendingVariantsKey = currentChatKey()
+        }
+        else if(popped > 1){
+            pendingVariants = null
+        }
+        //popped === 0 keeps pendingVariants: retrying after a failed regeneration starts from the user message
         DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = cha
         await sendChatMain()
     }
@@ -255,6 +263,10 @@
 
     let abortController:null|AbortController = null
 
+    function currentChatKey(){
+        return `${$selectedCharID}:${DBState.db.characters[$selectedCharID].chatPage}`
+    }
+
     async function sendChatMain(continued:boolean = false) {
 
         let previousLength = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length
@@ -266,14 +278,17 @@
                 continue:continued
             })
             const message = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-            if(message.length - previousLength === 1 && pendingVariants){
-                attachVariants(message[message.length - 1], pendingVariants)
+            if(message.length > previousLength){
+                if(message.length - previousLength === 1 && pendingVariants && pendingVariantsKey === currentChatKey()){
+                    attachVariants(message[message.length - 1], pendingVariants)
+                }
+                pendingVariants = null
             }
+            //pendingVariants is kept when nothing was generated, so a retry can still attach it
         } catch (error) {
             console.error(error)
             alertError(error)
         }
-        pendingVariants = null
         $doingChat = false
         if(DBState.db.playMessage){
             const audio = new Audio(sendSound);

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -23,7 +23,7 @@ import { getInlayAsset } from "./files/inlays";
 import { getGenerationModelString } from "./models/modelString";
 import { connectionOpen, peerRevertChat, peerSafeCheck, peerSync } from "../sync/multiuser";
 import { runInlayScreen } from "./inlayScreen";
-import { addRerolls } from "./prereroll";
+import { appendCandidateVariants } from "./prereroll";
 import { runImageEmbedding } from "./transformers";
 import { hanuraiMemory } from "./memory/hanuraiMemory";
 import { hypaMemoryV2 } from "./memory/hypav2";
@@ -1722,7 +1722,9 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             return false
         }
 
-        addRerolls(generationId, Object.values(lastResponseChunk))
+        if(!arg.continue){
+            appendCandidateVariants(DBState.db.characters[selectedChar].chats[selectedChat].message[msgIndex], Object.values(lastResponseChunk).slice(1), generationInfo)
+        }
 
         DBState.db.characters[selectedChar].chats[selectedChat] = runCurrentChatFunction(DBState.db.characters[selectedChar].chats[selectedChat])
         currentChat = DBState.db.characters[selectedChar].chats[selectedChat]        
@@ -1768,6 +1770,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             result = inlayResult.text
             emoChanged = result2.emoChanged
             if(i === 0 && arg.continue){
+                const beforeMessage = DBState.db.characters[selectedChar].chats[selectedChat].message[msgIndex]
                 DBState.db.characters[selectedChar].chats[selectedChat].message[msgIndex] = {
                     role: 'char',
                     data: result,
@@ -1776,7 +1779,9 @@ export async function sendChat(chatProcessIndex = -1,arg:{
                     generationInfo,
                     promptInfo,
                     chatId: generationId,
-                }       
+                    variants: beforeMessage.variants,
+                    variantIndex: beforeMessage.variantIndex,
+                }
                 if(inlayResult.promise){
                     const p = await inlayResult.promise
                     DBState.db.characters[selectedChar].chats[selectedChat].message[msgIndex].data = p
@@ -1808,8 +1813,9 @@ export async function sendChat(chatProcessIndex = -1,arg:{
             }
         }
 
-        if(mrerolls.length >1){
-            addRerolls(generationId, mrerolls)
+        if(!arg.continue && mrerolls.length > 1){
+            const message = DBState.db.characters[selectedChar].chats[selectedChat].message
+            appendCandidateVariants(message[message.length - 1], mrerolls.slice(1), generationInfo)
         }
 
         DBState.db.characters[selectedChar].chats[selectedChat] = runCurrentChatFunction(DBState.db.characters[selectedChar].chats[selectedChat])

--- a/src/ts/process/prereroll.test.ts
+++ b/src/ts/process/prereroll.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_MESSAGE_VARIANTS, appendCandidateVariants, attachVariants, collectVariants, switchVariant } from './prereroll'
+import type { Message, MessageVariant } from '../storage/database.svelte'
+
+function makeMessage(data:string, variants?:MessageVariant[], variantIndex?:number):Message{
+    return {
+        role: 'char',
+        data,
+        variants,
+        variantIndex,
+    }
+}
+
+function virtualOrder(msg:Message){
+    return collectVariants(msg).map((v) => v.data)
+}
+
+describe('switchVariant', () => {
+    it('walks forward to the end and back, keeping the virtual order stable', () => {
+        const msg = makeMessage('a', [{data: 'b'}, {data: 'c'}], 0)
+        const order = virtualOrder(msg)
+        expect(order).toEqual(['a', 'b', 'c'])
+
+        expect(switchVariant(msg, 1)).toBe(true)
+        expect(msg.data).toBe('b')
+        expect(virtualOrder(msg)).toEqual(order)
+
+        expect(switchVariant(msg, 1)).toBe(true)
+        expect(msg.data).toBe('c')
+        expect(switchVariant(msg, 1)).toBe(false)
+        expect(msg.data).toBe('c')
+
+        expect(switchVariant(msg, -1)).toBe(true)
+        expect(msg.data).toBe('b')
+        expect(switchVariant(msg, -1)).toBe(true)
+        expect(msg.data).toBe('a')
+        expect(switchVariant(msg, -1)).toBe(false)
+        expect(msg.data).toBe('a')
+        expect(virtualOrder(msg)).toEqual(order)
+    })
+
+    it('treats undefined variantIndex as active at the end', () => {
+        const msg = makeMessage('c', [{data: 'a'}, {data: 'b'}])
+        expect(switchVariant(msg, 1)).toBe(false)
+        expect(switchVariant(msg, -1)).toBe(true)
+        expect(msg.data).toBe('b')
+        expect(virtualOrder(msg)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('swaps saying and generationInfo but keeps time on the message', () => {
+        const msg:Message = {...makeMessage('a', [{data: 'b', time: 1, saying: 'x', generationInfo: {model: 'm1'}}], 0), time: 2, saying: 'y', generationInfo: {model: 'm2'}}
+        expect(switchVariant(msg, 1)).toBe(true)
+        expect(msg.saying).toBe('x')
+        expect(msg.generationInfo).toEqual({model: 'm1'})
+        expect(msg.time).toBe(2)
+        expect(msg.variants[0]).toEqual({data: 'a', time: 2, saying: 'y', generationInfo: {model: 'm2'}})
+    })
+
+    it('returns false without changes when there are no variants or the slot is malformed', () => {
+        expect(switchVariant(makeMessage('a'), 1)).toBe(false)
+        const malformed = makeMessage('a', [{data: 1 as unknown as string}], 0)
+        expect(switchVariant(malformed, 1)).toBe(false)
+        expect(malformed.data).toBe('a')
+    })
+})
+
+describe('collectVariants', () => {
+    it('inserts the active message at variantIndex', () => {
+        const msg = makeMessage('b', [{data: 'a'}, {data: 'c'}], 1)
+        expect(virtualOrder(msg)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('returns only the active message when there are no variants', () => {
+        expect(virtualOrder(makeMessage('a'))).toEqual(['a'])
+    })
+})
+
+describe('attachVariants', () => {
+    it('attaches pending variants with the active at the end', () => {
+        const msg = makeMessage('new')
+        attachVariants(msg, [{data: 'a'}, {data: 'b'}])
+        expect(virtualOrder(msg)).toEqual(['a', 'b', 'new'])
+        expect(msg.variantIndex).toBe(2)
+    })
+
+    it('trims the oldest variants over the cap', () => {
+        const pending = Array.from({length: MAX_MESSAGE_VARIANTS + 3}, (_, i) => ({data: `v${i}`}))
+        const msg = makeMessage('new')
+        attachVariants(msg, pending)
+        expect(msg.variants.length).toBe(MAX_MESSAGE_VARIANTS)
+        expect(msg.variants[0].data).toBe('v3')
+        expect(msg.variantIndex).toBe(MAX_MESSAGE_VARIANTS)
+    })
+
+    it('keeps candidate variants the message already has after the active', () => {
+        const msg = makeMessage('active', [{data: 'c1'}, {data: 'c2'}], 0)
+        attachVariants(msg, [{data: 'old1'}, {data: 'old2'}])
+        expect(virtualOrder(msg)).toEqual(['old1', 'old2', 'active', 'c1', 'c2'])
+        expect(msg.variantIndex).toBe(2)
+    })
+
+    it('trims overflow from the pending side when merging with existing candidates', () => {
+        const pending = Array.from({length: MAX_MESSAGE_VARIANTS}, (_, i) => ({data: `p${i}`}))
+        const msg = makeMessage('active', [{data: 'c1'}, {data: 'c2'}], 0)
+        attachVariants(msg, pending)
+        expect(msg.variants.length).toBe(MAX_MESSAGE_VARIANTS)
+        expect(msg.variants[0].data).toBe('p2')
+        expect(msg.variantIndex).toBe(MAX_MESSAGE_VARIANTS - 2)
+        expect(virtualOrder(msg).slice(-3)).toEqual(['active', 'c1', 'c2'])
+    })
+
+    it('does nothing for an empty pending list', () => {
+        const msg = makeMessage('new')
+        attachVariants(msg, [])
+        expect(msg.variants).toBeUndefined()
+    })
+})
+
+describe('appendCandidateVariants', () => {
+    it('inserts candidates right after the active message, keeping the index', () => {
+        const msg = makeMessage('b', [{data: 'a'}], 1)
+        appendCandidateVariants(msg, ['c', 'd'])
+        expect(virtualOrder(msg)).toEqual(['a', 'b', 'c', 'd'])
+        expect(msg.variantIndex).toBe(1)
+        expect(switchVariant(msg, 1)).toBe(true)
+        expect(msg.data).toBe('c')
+    })
+
+    it('trims from the front and adjusts the index over the cap', () => {
+        const variants = Array.from({length: MAX_MESSAGE_VARIANTS}, (_, i) => ({data: `v${i}`}))
+        const msg = makeMessage('active', variants, MAX_MESSAGE_VARIANTS)
+        appendCandidateVariants(msg, ['x', 'y'])
+        expect(msg.variants.length).toBe(MAX_MESSAGE_VARIANTS)
+        expect(msg.variants[0].data).toBe('v2')
+        expect(msg.variantIndex).toBe(MAX_MESSAGE_VARIANTS - 2)
+        expect(virtualOrder(msg).slice(-3)).toEqual(['active', 'x', 'y'])
+    })
+
+    it('does nothing for empty extras', () => {
+        const msg = makeMessage('a')
+        appendCandidateVariants(msg, [])
+        expect(msg.variants).toBeUndefined()
+    })
+})

--- a/src/ts/process/prereroll.ts
+++ b/src/ts/process/prereroll.ts
@@ -1,29 +1,91 @@
-let rerolls:{[key:string]:string[]} = {};
-let rerollIndex:{[key:string]:number} = {};
+import type { Message, MessageGenerationInfo, MessageVariant } from "../storage/database.svelte";
 
-export function Prereroll(genId:string){
-    if(rerolls[genId]){
-        let index = rerollIndex[genId];
-        index += 1;
-        rerollIndex[genId] = index;
-        return rerolls[genId][index] ?? null;
-    }
-    return null;
-}
-export function PreUnreroll(genId:string){
-    if(rerolls[genId]){
-        let index = rerollIndex[genId];
-        index -= 1;
-        if(index < 0){
-            return null
-        }
-        rerollIndex[genId] = index;
-        return rerolls[genId][index] ?? null;
-    }
-    return null;
+export const MAX_MESSAGE_VARIANTS = 10;
+
+//variants is a gap buffer: the virtual order is variants[0..k-1], active message, variants[k..],
+//where k = variantIndex (defaults to variants.length, i.e. active at the end)
+
+function getVariantIndex(msg:Message){
+    const len = msg.variants?.length ?? 0;
+    const index = msg.variantIndex ?? len;
+    return Math.min(Math.max(index, 0), len);
 }
 
-export function addRerolls(genId:string, values:string[]){
-    rerolls[genId] = values;
-    rerollIndex[genId] = 0;
+function cloneGenerationInfo(info?:MessageGenerationInfo):MessageGenerationInfo|undefined{
+    if(!info){
+        return undefined;
+    }
+    return {
+        ...info,
+        stageTiming: info.stageTiming ? {...info.stageTiming} : undefined,
+    };
+}
+
+export function switchVariant(msg:Message, dir:1|-1):boolean{
+    if(!msg.variants || msg.variants.length === 0){
+        return false;
+    }
+    const index = getVariantIndex(msg);
+    const slot = dir === 1 ? index : index - 1;
+    if(slot < 0 || slot >= msg.variants.length){
+        return false;
+    }
+    const incoming = msg.variants[slot];
+    if(!incoming || typeof incoming.data !== 'string'){
+        return false;
+    }
+    //time is not swapped: cold storage idle detection relies on max message.time
+    msg.variants[slot] = {
+        data: msg.data,
+        time: msg.time,
+        saying: msg.saying,
+        generationInfo: msg.generationInfo,
+    };
+    msg.data = incoming.data;
+    msg.saying = incoming.saying;
+    msg.generationInfo = incoming.generationInfo;
+    msg.variantIndex = slot + (dir === 1 ? 1 : 0);
+    return true;
+}
+
+export function collectVariants(msg:Message):MessageVariant[]{
+    const variants = msg.variants ?? [];
+    const index = getVariantIndex(msg);
+    const active:MessageVariant = {
+        data: msg.data,
+        time: msg.time,
+        saying: msg.saying,
+        generationInfo: cloneGenerationInfo(msg.generationInfo),
+    };
+    return [...variants.slice(0, index), active, ...variants.slice(index)];
+}
+
+export function attachVariants(msg:Message, pending:MessageVariant[]){
+    if(pending.length === 0){
+        return;
+    }
+    //pending (previous generations) goes before any candidates the message already has
+    const existing = msg.variants ?? [];
+    const index = getVariantIndex(msg);
+    const merged = [...pending, ...existing];
+    const overflow = Math.max(merged.length - MAX_MESSAGE_VARIANTS, 0);
+    msg.variants = merged.slice(overflow);
+    msg.variantIndex = Math.max(index + pending.length - overflow, 0);
+}
+
+export function appendCandidateVariants(msg:Message, extras:string[], generationInfo?:MessageGenerationInfo){
+    if(extras.length === 0){
+        return;
+    }
+    const variants = msg.variants ?? [];
+    const index = getVariantIndex(msg);
+    const added:MessageVariant[] = extras.map((data) => ({
+        data,
+        time: msg.time,
+        generationInfo: cloneGenerationInfo(generationInfo),
+    }));
+    const merged = [...variants.slice(0, index), ...added, ...variants.slice(index)];
+    const overflow = Math.max(merged.length - MAX_MESSAGE_VARIANTS, 0);
+    msg.variants = merged.slice(overflow);
+    msg.variantIndex = Math.max(index - overflow, 0);
 }

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1853,6 +1853,15 @@ export interface Message{
     otherUser?:boolean
     disabled?:false|true|'allBefore'
     isComment?:boolean
+    variants?: MessageVariant[]
+    variantIndex?: number
+}
+
+export interface MessageVariant{
+    data: string
+    time?: number
+    saying?: string
+    generationInfo?: MessageGenerationInfo
 }
 
 export interface MessageGenerationInfo{


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Persists reroll/swipe variants in the chat message data, so they survive reload, character switch, continuing the conversation, and deleting later messages.

## Related Issues

Fixes #1519. Same direction as #1424, reduced to the minimal persistence core instead of a manager layer.

## Changes

Variants currently only live in two volatile stores: a module-level map in `prereroll.ts` (multi-candidate responses) and component-local `rerolls`/`rerollid` snapshots in `DefaultChatScreen.svelte` (regeneration history). Neither is saved with the chat. This PR persists variants inline on the message and replaces both stores with pure functions over the persisted fields.

- `Message` gets two optional fields: `variants?: MessageVariant[]` (alternates, excluding the active one) and `variantIndex?: number` (logical position of the active text among them). `MessageVariant` is a slim record `{ data, time?, saying?, generationInfo? }` — no `promptInfo`, no `chatId`. The active text stays canonical in `message.data`; swiping swaps content between the message and a variant slot.
- `prereroll.ts` is rewritten as four pure functions (`switchVariant`, `collectVariants`, `attachVariants`, `appendCandidateVariants`) with unit tests. `switchVariant` deliberately does not swap `time`, since cold storage idle detection relies on the max `message.time` of a chat.
- On regeneration, the previous message's variants are carried into the new message; the non-streaming continue path (which replaces the message object wholesale — the actual loss point) now carries `variants`/`variantIndex` over.
- Variants are capped at 10 per message (oldest trimmed) to bound storage growth. The cap is a fixed constant (no user setting) to keep this PR small; since it's just a trim policy, a setting can be added later without migration.
- Storing variants out-of-line (cold-storage style) was also considered, but that would add new plumbing to the backup/sync paths that are under active work right now; with the cap bounding growth, inline storage seemed the safer choice.

## Impact

- No migration and no `risuChat` version bump: both fields are optional, chats are serialized wholesale everywhere (save, sync, backup, export), and ver 2 round-trips unknown fields, so old clients import/export these chats fine.
- Multi-message regeneration (group chats) no longer keeps an in-session snapshot history; the volatile `rerolls`/`rerollid` store that backed it is removed. That history was already lost on reload/character switch. Single-message regeneration in group chats uses the persisted path (`saying` is swapped so speaker icon/name stay correct).
- Editing a message then swiping now preserves the edit in its variant slot (previously the edit was lost on unreroll).
- A regeneration that fails (or is aborted before producing anything) no longer discards the collected variant history: it is kept and re-attached on the next successful regeneration of the same chat, so a transient API error can't destroy persisted variants.
- Known limitations:
    - A Lua trigger that replaces the whole chat object in `output` can drop candidates appended just before it runs (same window existed for the old volatile store) — if preferred, the append can be moved after the trigger block.
    - `setFullChat` from Lua scripts rebuilds messages as `{role, data}` and already drops `chatId`/`time`/`generationInfo`, so variants are dropped there too (pre-existing behavior, tracked separately in #1564).
    - Multiuser peers receive newly attached variants on the next sync rather than in the generation-completion sync.

## Additional Notes

- `pnpm test` (246 passed; includes 14 new unit tests for the variant functions), `pnpm check` (0 errors), `pnpm build` — all pass.
- Will verify manually before review: reroll several times → reload → swipe both ways; delete the last messages → swipe on the new last message (the #1519 repro); continue → reload → variants preserved; failed regeneration → retry → variants recovered.
- Follow-ups I'd like to do if this lands: variant counter / delete-variant UI, and stripping variants from multiuser payloads.