### PR TITLE
feat: add reasoning effort to custom providers

### DIFF
--- a/src/lib/Others/AllSeperateParameters.svelte
+++ b/src/lib/Others/AllSeperateParameters.svelte
@@ -40,7 +40,9 @@
         modelInfo.parameters.includes('reasoning_effort') ||
         modelInfo.parameters.includes('reasoning_effort_min_medium') ||
         modelInfo.parameters.includes('reasoning_effort_none') ||
-        modelInfo.parameters.includes('reasoning_effort_xhigh')
+        modelInfo.parameters.includes('reasoning_effort_no_disabled') ||
+        modelInfo.parameters.includes('reasoning_effort_xhigh') ||
+        modelInfo.parameters.includes('reasoning_effort_max')
     )
     let hasVerbosity = $derived(modelInfo.parameters.includes('verbosity'))
     const verbosityOptions = [
@@ -49,7 +51,7 @@
         { value: 2, label: 'High' },
     ]
     let reasoningEffortOptions = $derived([
-        ...(!modelInfo.parameters.includes('reasoning_effort_min_medium') ? [{
+        ...(!modelInfo.parameters.includes('reasoning_effort_min_medium') && !modelInfo.parameters.includes('reasoning_effort_no_disabled') ? [{
             value: -1,
             label: modelInfo.parameters.includes('reasoning_effort_none') ? 'None' : 'Minimal',
         }] : []),
@@ -57,11 +59,18 @@
         { value: 1, label: 'Medium' },
         { value: 2, label: 'High' },
         ...(modelInfo.parameters.includes('reasoning_effort_xhigh') ? [{ value: 3, label: 'XHigh' }] : []),
+        ...(modelInfo.parameters.includes('reasoning_effort_max') ? [{ value: 4, label: 'Max' }] : []),
     ])
 
     $effect(() => {
+        if (!modelInfo.parameters.includes('reasoning_effort_max') && value.reasoning_effort === 4) {
+            value.reasoning_effort = modelInfo.parameters.includes('reasoning_effort_xhigh') ? 3 : 2
+        }
         if (!modelInfo.parameters.includes('reasoning_effort_xhigh') && value.reasoning_effort === 3) {
             value.reasoning_effort = 2
+        }
+        if (modelInfo.parameters.includes('reasoning_effort_no_disabled') && value.reasoning_effort < 0) {
+            value.reasoning_effort = 0
         }
         if (modelInfo.parameters.includes('reasoning_effort_min_medium') && value.reasoning_effort < 1) {
             value.reasoning_effort = 1

--- a/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
+++ b/src/lib/Setting/Pages/Advanced/CustomModelsSettings.svelte
@@ -8,10 +8,24 @@
     import OptionInput from "src/lib/UI/GUI/OptionInput.svelte";
     import Accordion from "src/lib/UI/Accordion.svelte";
     import { PlusIcon, TrashIcon, ArrowUp, ArrowDown } from "@lucide/svelte";
-    import type { LLMFlags, LLMFormat, LLMTokenizer } from "src/ts/model/types";
+    import {
+        LLMFormat,
+        type CustomModelThinkingControl,
+        type LLMFlags,
+        type LLMTokenizer,
+    } from "src/ts/model/types";
     import { v4 } from "uuid";
 
     let openedModels = $state(new Set<string>());
+    const effortFormats: LLMFormat[] = [
+        LLMFormat.OpenAICompatible,
+        LLMFormat.Anthropic,
+        LLMFormat.Mistral,
+        LLMFormat.GoogleCloud,
+        LLMFormat.VertexAIGemini,
+        LLMFormat.AWSBedrockClaude,
+        LLMFormat.OpenAIResponseAPI,
+    ]
 
     let { noAccordion }:{
         noAccordion?: boolean,
@@ -131,6 +145,15 @@
                 <OptionInput value="17">AWSBedrockClaude</OptionInput>
                 <OptionInput value="18">OpenAIResponseAPI</OptionInput>
             </SelectInput>
+            {#if effortFormats.includes(model.format)}
+                <span class="text-textcolor">Thinking control</span>
+                <SelectInput size={"sm"} value={model.thinkingControl ?? 'tokens'} onchange={(e) => {
+                    DBState.db.customModels[index].thinkingControl = e.currentTarget.value as CustomModelThinkingControl
+                }}>
+                    <OptionInput value="tokens">Token budget</OptionInput>
+                    <OptionInput value="effort">Effort level</OptionInput>
+                </SelectInput>
+            {/if}
             <span class="text-textcolor">{language.proxyAPIKey}</span>
             <TextInput size={"sm"} bind:value={DBState.db.customModels[index].key}/>
             <span class="text-textcolor">{language.additionalParams}</span>
@@ -182,6 +205,7 @@
                 name: "",
                 params: "",
                 flags: [],
+                thinkingControl: "tokens",
             })
         }}>
             <PlusIcon />

--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -7,6 +7,7 @@ import {
     ProviderNames,
     OpenAIParameters,
     ClaudeParameters,
+    getCustomModelParameters,
     type LLMModel
 } from './types'
 import { OpenAIModels } from './providers/openai'
@@ -777,7 +778,7 @@ export function getModelInfo(id?: string | null): LLMModel{
                 provider: LLMProvider.AsIs,
                 format: found.format,
                 flags: found.flags,
-                parameters: ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'repetition_penalty', 'min_p', 'top_a', 'top_k', 'thinking_tokens'],
+                parameters: getCustomModelParameters(found.format, found.thinkingControl),
                 tokenizer: found.tokenizer
             }
         }

--- a/src/ts/model/types.test.ts
+++ b/src/ts/model/types.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCustomModelParameters, LLMFormat } from './types'
+
+describe('getCustomModelParameters', () => {
+    it('keeps token budgets as the backwards-compatible default', () => {
+        const parameters = getCustomModelParameters(LLMFormat.OpenAICompatible)
+
+        expect(parameters).toContain('thinking_tokens')
+        expect(parameters).not.toContain('reasoning_effort')
+    })
+
+    it.each([
+        LLMFormat.OpenAICompatible,
+        LLMFormat.OpenAIResponseAPI,
+        LLMFormat.Anthropic,
+        LLMFormat.AWSBedrockClaude,
+    ])('exposes the full low-to-max effort ladder for format %s', (format) => {
+        const parameters = getCustomModelParameters(format, 'effort')
+
+        expect(parameters).toEqual(expect.arrayContaining([
+            'reasoning_effort',
+            'reasoning_effort_no_disabled',
+            'reasoning_effort_xhigh',
+            'reasoning_effort_max',
+        ]))
+        expect(parameters).not.toContain('thinking_tokens')
+    })
+
+    it('caps Mistral custom models at xhigh', () => {
+        const parameters = getCustomModelParameters(LLMFormat.Mistral, 'effort')
+
+        expect(parameters).toContain('reasoning_effort_xhigh')
+        expect(parameters).not.toContain('reasoning_effort_max')
+    })
+
+    it.each([
+        LLMFormat.GoogleCloud,
+        LLMFormat.VertexAIGemini,
+    ])('caps Gemini thinking levels at high for format %s', (format) => {
+        const parameters = getCustomModelParameters(format, 'effort')
+
+        expect(parameters).toContain('reasoning_effort')
+        expect(parameters).not.toContain('reasoning_effort_xhigh')
+        expect(parameters).not.toContain('reasoning_effort_max')
+    })
+
+    it('does not send an effort field to formats without documented support', () => {
+        const parameters = getCustomModelParameters(LLMFormat.Cohere, 'effort')
+
+        expect(parameters).not.toContain('reasoning_effort')
+        expect(parameters).not.toContain('thinking_tokens')
+    })
+})

--- a/src/ts/model/types.ts
+++ b/src/ts/model/types.ts
@@ -101,6 +101,53 @@ export const LLMTokenizer = {
 } as const;
 export type LLMTokenizer = (typeof LLMTokenizer)[keyof typeof LLMTokenizer];
 
+export type CustomModelThinkingControl = 'tokens' | 'effort'
+
+const customModelBaseParameters: LLMParameter[] = [
+    'temperature',
+    'top_p',
+    'frequency_penalty',
+    'presence_penalty',
+    'repetition_penalty',
+    'min_p',
+    'top_a',
+    'top_k',
+]
+
+export function getCustomModelParameters(
+    format: LLMFormat,
+    thinkingControl: CustomModelThinkingControl = 'tokens',
+): LLMParameter[] {
+    if (thinkingControl === 'tokens') {
+        return [...customModelBaseParameters, 'thinking_tokens']
+    }
+
+    const parameters: LLMParameter[] = [
+        ...customModelBaseParameters,
+        'reasoning_effort',
+        'reasoning_effort_no_disabled',
+    ]
+
+    switch (format) {
+        case LLMFormat.OpenAICompatible:
+        case LLMFormat.OpenAIResponseAPI:
+        case LLMFormat.Anthropic:
+        case LLMFormat.AWSBedrockClaude:
+            parameters.push('reasoning_effort_xhigh', 'reasoning_effort_max')
+            break
+        case LLMFormat.Mistral:
+            parameters.push('reasoning_effort_xhigh')
+            break
+        case LLMFormat.GoogleCloud:
+        case LLMFormat.VertexAIGemini:
+            break
+        default:
+            return [...customModelBaseParameters]
+    }
+
+    return parameters
+}
+
 export interface LLMModel{
     id: string
     name: string

--- a/src/ts/process/request/anthropic.ts
+++ b/src/ts/process/request/anthropic.ts
@@ -347,6 +347,8 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
         })
     }
 
+    const usesReasoningEffort = arg.modelInfo.parameters.includes('reasoning_effort')
+
     console.log(arg.modelInfo.parameters)
     let body = applyParameters({
         model: arg.modelInfo.internalID,
@@ -355,13 +357,20 @@ export async function requestClaude(arg:RequestDataArgumentExtended):Promise<req
         max_tokens: maxTokens,
         stream: useStreaming ?? false,
     }, arg.modelInfo.parameters, {
-        'thinking_tokens': 'thinking.budget_tokens'
+        'thinking_tokens': 'thinking.budget_tokens',
+        'reasoning_effort': 'output_config.effort',
     }, arg.mode, {
         modelId: arg.modelInfo.id
     })
 
     // Handle thinking mode: off, adaptive, or budget
-    if(db.thinkingType === 'off'){
+    if(usesReasoningEffort){
+        delete body.thinking
+        body.thinking = arg.modelInfo.format === LLMFormat.AWSBedrockClaude
+            ? { type: 'adaptive' }
+            : { type: 'adaptive', display: 'summarized' }
+    }
+    else if(db.thinkingType === 'off'){
         delete body.thinking
     }
     else if(db.thinkingType === 'adaptive' && arg.modelInfo.flags.includes(LLMFlags.claudeAdaptiveThinking)){

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -9,7 +9,13 @@ import { callTool, decodeToolCall, encodeToolCall } from "../mcp/mcp"
 import { alertError } from "src/ts/alert";
 import { addFetchLog } from "src/ts/globalApi.svelte"
 import type { RequestDataArgumentExtended, requestDataResponse, StreamResponseChunk } from './request'
-import { applyAdditionalParameters, applyParameters, getAdditionalParameters, type LLMParameter } from './shared'
+import {
+    applyAdditionalParameters,
+    applyParameters,
+    getAdditionalParameters,
+    isReasoningCapabilityParameter,
+    type LLMParameter,
+} from './shared'
 import { bodyIntercepterStore } from "src/ts/stores.svelte"
 
 type GeminiFunctionCall = {
@@ -317,14 +323,15 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
 
     let para:LLMParameter[] = ['temperature', 'top_p', 'top_k', 'presence_penalty', 'frequency_penalty']
 
-    if(arg.modelInfo.flags.includes(LLMFlags.geminiThinking)){
-        para.push('thinking_tokens')
-        para.push('reasoning_effort')
+    for (const thinkingParameter of ['thinking_tokens', 'reasoning_effort'] as LLMParameter[]) {
+        if (arg.modelInfo.parameters.includes(thinkingParameter)) {
+            para.push(thinkingParameter)
+        }
     }
 
-    para = para.filter((v) => {
-        return arg.modelInfo.parameters.includes(v)
-    })
+    para = arg.modelInfo.parameters.filter((parameter) =>
+        para.includes(parameter) || isReasoningCapabilityParameter(parameter)
+    )
 
     let body: any = {
         contents: reformatedChat,
@@ -361,7 +368,7 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
         }
     }
 
-    if(arg.modelInfo.flags.includes(LLMFlags.geminiThinking)){
+    if(arg.modelInfo.parameters.includes('thinking_tokens') || arg.modelInfo.parameters.includes('reasoning_effort')){
         const generationConfig = body.generation_config
 
         // 2.5's flat thinkingBudget is wrapped into thinkingConfig here.

--- a/src/ts/process/request/openAI/requests.responses.test.ts
+++ b/src/ts/process/request/openAI/requests.responses.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer } from 'src/ts/model/types'
 import { fetchNative } from 'src/ts/globalApi.svelte'
 import { callTool } from '../../mcp/mcp'
-import { __testResponsesAPI, requestOpenAIResponseAPI } from './requests'
+import { __testResponsesAPI, requestOpenAI, requestOpenAIResponseAPI } from './requests'
 
 const mocks = vi.hoisted(() => ({
     db: {
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
         additionalParams: [],
         autofillRequestUrl: false,
         customModels: [],
+        frequencyPenalty: 0,
         gptVisionQuality: 'high',
         jsonSchema: '{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}',
         jsonSchemaEnabled: false,
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => ({
         nanogptUseSubscriptionEndpoint: false,
         openAIKey: 'openai-key',
         proxyKey: 'proxy-key',
+        PresensePenalty: 0,
         requestRetrys: 0,
         reasoningEffort: 2,
         seperateParametersEnabled: false,
@@ -192,6 +194,7 @@ describe('OpenAI Responses API helpers', () => {
         mocks.db.nanogptUseSubscriptionEndpoint = false
         mocks.db.simplifiedToolUse = false
         mocks.db.autofillRequestUrl = false
+        mocks.db.reasoningEffort = 2
     })
 
     it('builds a Responses request body for text, developer role, multimodal input, tools, and model parameters', async () => {
@@ -245,6 +248,92 @@ describe('OpenAI Responses API helpers', () => {
         const body = await __testResponsesAPI.buildResponsesBody(baseArg())
 
         expect(body.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+    })
+
+    it('sends max effort for a custom Responses model that supports it', async () => {
+        mocks.db.reasoningEffort = 4
+
+        const body = await __testResponsesAPI.buildResponsesBody(baseArg({
+            modelInfo: {
+                ...baseArg().modelInfo,
+                parameters: [
+                    'temperature',
+                    'top_p',
+                    'reasoning_effort',
+                    'reasoning_effort_xhigh',
+                    'reasoning_effort_max',
+                ],
+            },
+        }))
+
+        expect(body.reasoning).toEqual({ effort: 'max', summary: 'auto' })
+    })
+
+    it('sends max effort for a custom OpenAI-compatible model', async () => {
+        mocks.db.reasoningEffort = 4
+
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'xcustom:::openai',
+            customURL: 'https://api.openai.com/v1/chat/completions',
+            formated: [{ role: 'user', content: 'Hello' }],
+            key: 'openai-key',
+            previewBody: true,
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                format: LLMFormat.OpenAICompatible,
+                id: 'xcustom:::openai',
+                internalID: 'gpt-5.6',
+                parameters: [
+                    'reasoning_effort',
+                    'reasoning_effort_no_disabled',
+                    'reasoning_effort_xhigh',
+                    'reasoning_effort_max',
+                ],
+                provider: LLMProvider.AsIs,
+            },
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.body).toMatchObject({
+            model: 'gpt-5.6',
+            reasoning_effort: 'max',
+        })
+    })
+
+    it('sends the selected effort and internal model ID for a custom Mistral model', async () => {
+        mocks.db.reasoningEffort = 3
+
+        const result = await requestOpenAI(baseArg({
+            aiModel: 'xcustom:::mistral',
+            customURL: 'https://api.mistral.ai/v1/chat/completions',
+            formated: [{ role: 'user', content: 'Hello' }],
+            key: 'mistral-key',
+            previewBody: true,
+            modelInfo: {
+                ...baseArg().modelInfo,
+                flags: [],
+                format: LLMFormat.Mistral,
+                id: 'xcustom:::mistral',
+                internalID: 'magistral-medium-latest',
+                parameters: [
+                    'temperature',
+                    'top_p',
+                    'reasoning_effort',
+                    'reasoning_effort_no_disabled',
+                    'reasoning_effort_xhigh',
+                ],
+                provider: LLMProvider.AsIs,
+            },
+        }))
+
+        expect(result.type).toBe('success')
+        const preview = JSON.parse(result.result as string)
+        expect(preview.body).toMatchObject({
+            model: 'magistral-medium-latest',
+            reasoning_effort: 'xhigh',
+        })
     })
 
     it('does not request reasoning summaries for Responses non-reasoning models', async () => {

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -13,7 +13,13 @@ import { applyChatTemplate } from "../../templates/chatTemplate"
 import { supportsInlayImage } from "../../files/inlays"
 import { callTool, decodeToolCall, encodeToolCall } from "../../mcp/mcp"
 import type { RequestDataArgumentExtended, requestDataResponse, StreamResponseChunk } from '../request'
-import { applyAdditionalParameters, applyParameters, getAdditionalParameters } from '../shared'
+import {
+    applyAdditionalParameters,
+    applyParameters,
+    getAdditionalParameters,
+    isReasoningCapabilityParameter,
+    type LLMParameter,
+} from '../shared'
 
 import type { Contents, OpenAIChatExtra, OpenAIChatFull, ToolCall } from './types'
 
@@ -227,7 +233,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
 
     console.log(formatedChat)
     if(arg.modelInfo.format === LLMFormat.Mistral){
-        requestModel = aiModel
+        requestModel = arg.modelInfo.internalID ?? aiModel
 
         let reformatedChat:OpenAIChatExtra[] = []
 
@@ -281,6 +287,16 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
 
         const requestURL = arg.customURL ?? "https://api.mistral.ai/v1/chat/completions"
         const networkOptions = getLocalNetworkRequestOptions(requestURL, db, false)
+        const supportedParameters: LLMParameter[] = [
+            'temperature',
+            'presence_penalty',
+            'frequency_penalty',
+            'top_p',
+            'reasoning_effort',
+        ]
+        const requestParameters = arg.modelInfo.parameters.filter((parameter) =>
+            supportedParameters.includes(parameter) || isReasoningCapabilityParameter(parameter)
+        )
 
         const targs = {
             body: applyParameters({
@@ -288,7 +304,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
                 messages: reformatedChat,
                 safe_prompt: false,
                 max_tokens: arg.maxTokens,
-            }, ['temperature', 'presence_penalty', 'frequency_penalty', 'top_p'], {}, arg.mode, {
+            }, requestParameters, {}, arg.mode, {
                 modelId: arg.modelInfo.id
             } ),
             headers: {

--- a/src/ts/process/request/openAI/responses.ts
+++ b/src/ts/process/request/openAI/responses.ts
@@ -9,7 +9,13 @@ import { NANOGPT_RESPONSES_ENDPOINT, NANOGPT_SUBSCRIPTION_RESPONSES_ENDPOINT } f
 import { extractJSON, getOpenAIJSONSchema } from "../../templates/jsonSchema"
 import { callTool, decodeToolCall, encodeToolCall } from "../../mcp/mcp"
 import type { RequestDataArgumentExtended, requestDataResponse, StreamResponseChunk } from '../request'
-import { applyAdditionalParameters, applyParameters, getAdditionalParameters } from '../shared'
+import {
+    applyAdditionalParameters,
+    applyParameters,
+    getAdditionalParameters,
+    isReasoningCapabilityParameter,
+    type LLMParameter,
+} from '../shared'
 
 import type { OpenAIChatExtra, ResponseFunctionCallItem, ResponseInputItem, ResponseItem, ResponseOutputItem } from './types'
 import { getLocalNetworkRequestOptions, type LocalNetworkRequestOptions } from './shared'
@@ -333,13 +339,18 @@ async function buildResponsesBody(arg:RequestDataArgumentExtended):Promise<Recor
         tools.push({ type: 'web_search_preview' })
     }
 
+    const supportedParameters: LLMParameter[] = ['temperature', 'top_p', 'reasoning_effort', 'verbosity']
+    const requestParameters = arg.modelInfo.parameters.filter((parameter) =>
+        supportedParameters.includes(parameter) || isReasoningCapabilityParameter(parameter)
+    )
+
     let body = applyParameters({
         model: getResponsesRequestModel(arg),
         input: await buildResponseInputItems(arg),
         max_output_tokens: arg.maxTokens,
         tools: tools,
         store: false
-    }, ['temperature', 'top_p', 'reasoning_effort', 'verbosity'].filter((p) => arg.modelInfo.parameters.includes(p as any)) as any, {
+    }, requestParameters, {
         reasoning_effort: 'reasoning.effort',
         verbosity: 'text.verbosity'
     }, arg.mode, {

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -13,7 +13,9 @@ export type LLMParameter =
     | 'reasoning_effort'
     | 'reasoning_effort_min_medium'
     | 'reasoning_effort_none'
+    | 'reasoning_effort_no_disabled'
     | 'reasoning_effort_xhigh'
+    | 'reasoning_effort_max'
     | 'thinking_tokens'
     | 'verbosity'
 
@@ -22,10 +24,12 @@ export type ModelModeExtended = 'model' | 'submodel' | 'memory' | 'emotion' | 'o
 const reasoningCapabilityParameters: LLMParameter[] = [
     'reasoning_effort_min_medium',
     'reasoning_effort_none',
+    'reasoning_effort_no_disabled',
     'reasoning_effort_xhigh',
+    'reasoning_effort_max',
 ]
 
-function isReasoningCapabilityParameter(parameter: LLMParameter): boolean {
+export function isReasoningCapabilityParameter(parameter: LLMParameter): boolean {
     return reasoningCapabilityParameters.includes(parameter)
 }
 
@@ -147,12 +151,21 @@ export function applyParameters(
     const db = getDatabase()
     const reasoningDisabledEffort = parameters.includes('reasoning_effort_none') ? 'none' : 'minimal'
     const reasoningMinEffort = parameters.includes('reasoning_effort_min_medium') ? 'medium' : 'low'
+    const supportsDisabledReasoning = !parameters.includes('reasoning_effort_no_disabled')
     const supportsXHighReasoning = parameters.includes('reasoning_effort_xhigh')
+    const supportsMaxReasoning = parameters.includes('reasoning_effort_max')
 
-    function getEffort(effort: number, disabledEffort: 'minimal' | 'none' = 'minimal', supportsXHigh = false, minEffort: 'low' | 'medium' = 'low') {
+    function getEffort(
+        effort: number,
+        disabledEffort: 'minimal' | 'none' = 'minimal',
+        supportsDisabled = true,
+        supportsXHigh = false,
+        supportsMax = false,
+        minEffort: 'low' | 'medium' = 'low',
+    ) {
         switch (effort) {
             case -1: {
-                return disabledEffort
+                return supportsDisabled ? disabledEffort : minEffort
             }
             case 0: {
                 return minEffort
@@ -164,6 +177,12 @@ export function applyParameters(
                 return 'high'
             }
             case 3: {
+                return supportsXHigh ? 'xhigh' : 'high'
+            }
+            case 4: {
+                if (supportsMax) {
+                    return 'max'
+                }
                 return supportsXHigh ? 'xhigh' : 'high'
             }
             default: {
@@ -248,7 +267,9 @@ export function applyParameters(
                     value = getEffort(
                         sepParams.reasoning_effort,
                         reasoningDisabledEffort,
+                        supportsDisabledReasoning,
                         supportsXHighReasoning,
+                        supportsMaxReasoning,
                         reasoningMinEffort
                     )
                     break
@@ -310,7 +331,9 @@ export function applyParameters(
                 value = getEffort(
                     db.reasoningEffort,
                     reasoningDisabledEffort,
+                    supportsDisabledReasoning,
                     supportsXHighReasoning,
+                    supportsMaxReasoning,
                     reasoningMinEffort
                 )
                 break

--- a/src/ts/process/request/tests/reasoningEffort.test.ts
+++ b/src/ts/process/request/tests/reasoningEffort.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { applyParameters } from '../shared'
+
+const mocks = vi.hoisted(() => ({
+    db: {
+        reasoningEffort: 0,
+        seperateParametersEnabled: false,
+    },
+}))
+
+vi.mock('src/ts/storage/database.svelte', () => ({
+    getDatabase: () => mocks.db,
+}))
+
+describe('reasoning effort parameters', () => {
+    beforeEach(() => {
+        mocks.db.reasoningEffort = 0
+        mocks.db.seperateParametersEnabled = false
+    })
+
+    it('maps the custom provider maximum effort to max', () => {
+        mocks.db.reasoningEffort = 4
+
+        const body = applyParameters(
+            {},
+            [
+                'reasoning_effort',
+                'reasoning_effort_no_disabled',
+                'reasoning_effort_xhigh',
+                'reasoning_effort_max',
+            ],
+            {},
+            'model',
+            { modelId: 'custom-model' },
+        )
+
+        expect(body.reasoning_effort).toBe('max')
+    })
+
+    it('uses the documented nested field for Responses API effort', () => {
+        mocks.db.reasoningEffort = 4
+
+        const body = applyParameters(
+            {},
+            ['reasoning_effort', 'reasoning_effort_max'],
+            { reasoning_effort: 'reasoning.effort' },
+            'model',
+            { modelId: 'custom-responses-model' },
+        )
+
+        expect(body).toEqual({ reasoning: { effort: 'max' } })
+    })
+
+    it('uses the documented nested field for Anthropic effort', () => {
+        mocks.db.reasoningEffort = 4
+
+        const body = applyParameters(
+            {},
+            ['reasoning_effort', 'reasoning_effort_max'],
+            { reasoning_effort: 'output_config.effort' },
+            'model',
+            { modelId: 'custom-anthropic-model' },
+        )
+
+        expect(body).toEqual({ output_config: { effort: 'max' } })
+    })
+
+    it('falls back to low when a stale disabled value is used by a low-to-max model', () => {
+        mocks.db.reasoningEffort = -1
+
+        const body = applyParameters(
+            {},
+            ['reasoning_effort', 'reasoning_effort_no_disabled'],
+            {},
+            'model',
+            { modelId: 'custom-model' },
+        )
+
+        expect(body.reasoning_effort).toBe('low')
+    })
+
+    it('caps max at the highest effort supported by the selected format', () => {
+        mocks.db.reasoningEffort = 4
+
+        const xhighBody = applyParameters(
+            {},
+            ['reasoning_effort', 'reasoning_effort_xhigh'],
+            {},
+            'model',
+            { modelId: 'custom-mistral-model' },
+        )
+        const highBody = applyParameters(
+            {},
+            ['reasoning_effort'],
+            {},
+            'model',
+            { modelId: 'custom-gemini-model' },
+        )
+
+        expect(xhighBody.reasoning_effort).toBe('xhigh')
+        expect(highBody.reasoning_effort).toBe('high')
+    })
+})

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -274,18 +274,21 @@ export const modelSpecificParameterItems: SettingItem[] = [
             ctx.modelInfo.parameters.includes('reasoning_effort') ||
             ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') ||
             ctx.modelInfo.parameters.includes('reasoning_effort_none') ||
-            ctx.modelInfo.parameters.includes('reasoning_effort_xhigh'),
+            ctx.modelInfo.parameters.includes('reasoning_effort_no_disabled') ||
+            ctx.modelInfo.parameters.includes('reasoning_effort_xhigh') ||
+            ctx.modelInfo.parameters.includes('reasoning_effort_max'),
         options: {
             segmentOptions: [
-                { value: -1, label: 'Minimal', condition: (ctx) => !ctx.modelInfo.parameters.includes('reasoning_effort_none') && !ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') },
-                { value: -1, label: 'None', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_none') },
+                { value: -1, label: 'Minimal', condition: (ctx) => !ctx.modelInfo.parameters.includes('reasoning_effort_none') && !ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') && !ctx.modelInfo.parameters.includes('reasoning_effort_no_disabled') },
+                { value: -1, label: 'None', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_none') && !ctx.modelInfo.parameters.includes('reasoning_effort_no_disabled') },
                 { value: 0, label: 'Low', condition: (ctx) => !ctx.modelInfo.parameters.includes('reasoning_effort_min_medium') },
                 { value: 1, label: 'Medium' },
                 { value: 2, label: 'High' },
                 { value: 3, label: 'XHigh', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_xhigh') },
+                { value: 4, label: 'Max', condition: (ctx) => ctx.modelInfo.parameters.includes('reasoning_effort_max') },
             ]
         },
-        keywords: ['reasoning', 'effort', 'xhigh'],
+        keywords: ['reasoning', 'effort', 'xhigh', 'max'],
     },
     {
         id: 'params.verbosity',

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -660,6 +660,9 @@ export function setDatabase(data:Database){
         otherAx: data.fallbackModels.otherAx.filter((v) => v !== '')
     }
     data.customModels ??= []
+    for (const customModel of data.customModels) {
+        customModel.thinkingControl ??= 'tokens'
+    }
     data.authRefreshes ??= []
     data.openAIFlexProcessing ??= false
     data.rememberToolUsage ??= true
@@ -1195,6 +1198,7 @@ export interface Database{
         name: string
         params: string
         flags: LLMFlags[]
+        thinkingControl: CustomModelThinkingControl
     }[]
     igpPrompt:string
     useTokenizerCaching:boolean
@@ -2278,6 +2282,7 @@ import type { SerializableHypaV2Data } from '../process/memory/hypav2';
 import { decodeRPack, encodeRPack } from '../rpack/rpack_js';
 import { DBState, selectedCharID } from '../stores.svelte';
 import { LLMFlags, LLMFormat, LLMTokenizer } from '../model/modellist';
+import type { CustomModelThinkingControl } from '../model/types';
 import type { HypaModel } from '../process/memory/hypamemory';
 import type { SerializableHypaV3Data } from '../process/memory/hypav3';
 import { defaultHotkeys, type Hotkey } from '../defaulthotkeys';


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Add an opt-in reasoning effort control for custom models, with request fields and effort ceilings matched to each supported API format.

## Related Issues

None.

## Changes

- Add a per-custom-model Thinking control selector while preserving token budgets as the migration-safe default.
- Support low, medium, high, xhigh, and max for OpenAI-compatible, OpenAI Responses, and Anthropic custom formats.
- Send OpenAI Responses effort through reasoning.effort.
- Send Anthropic and Bedrock effort through output_config.effort with adaptive thinking.
- Cap Mistral at xhigh and Gemini native formats at high according to their documented schemas.
- Preserve reasoning capability markers when request builders filter model parameters.
- Fix custom Mistral requests to use the configured internal model ID.
- Add model capability, effort mapping, and request preview tests.

## Impact

Existing custom models continue using thinking token budgets until users explicitly switch their Thinking control to Effort level. Effort availability remains model-dependent; unsupported selections are capped to the highest level documented for the selected format.

## Additional Notes

API references used:
- https://developers.openai.com/api/docs/guides/reasoning
- https://platform.claude.com/docs/en/build-with-claude/effort
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
- https://docs.mistral.ai/api/endpoint/chat
- https://ai.google.dev/gemini-api/docs/generate-content/thinking

Validation:
- corepack pnpm check
- corepack pnpm test (245 passed, 3 skipped)
- corepack pnpm build
