### PR TITLE
fix: initialize seperateModels in database migration

### DIFF
--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -624,6 +624,12 @@ export function setDatabase(data:Database){
         model: data.hypaCustomSettings?.model ?? ""     
     }
     data.doNotChangeSeperateModels ??= false
+    data.seperateModels ??= {
+        memory: '',
+        emotion: '',
+        translate: '',
+        otherAx: ''
+    }
     data.modelTools ??= []
     data.enableScrollToActiveChar ??= true
     


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes the crash when opening Ax Models Definition (and sending requests) with Separate Models for Auxiliary Models enabled on a database that predates the feature.

`setDatabase` never initializes `seperateModels`, so databases created before the field existed keep it `undefined`. The only initializer is `changeToPreset`, and even that is skipped when `doNotChangeSeperateModels` is enabled. Enabling the toggle on such a database throws `Cannot read properties of undefined (reading 'memory')` in the settings panel, and the request path fails the same way on `db.seperateModels[model]`.

## Related Issues

Fixes #1419.

## Changes

**`src/ts/storage/database.svelte.ts`**
- Added a `data.seperateModels ??= { memory: '', emotion: '', translate: '', otherAx: '' }` default in `setDatabase`, next to the existing `doNotChangeSeperateModels` default and matching the fallback shape `changeToPreset` already uses

## Impact

- Databases that predate the separate aux models feature no longer crash the Ax Models Definition panel or chat requests when the toggle is enabled; they behave the same as databases initialized through a preset switch, falling back to the sub model until an aux model is selected.
- `??=` also recovers a `null` value and never overwrites an existing configuration.
- Presets saved from such databases now store the empty object instead of `undefined`; applying them produces the same result as before, since `changeToPreset` already falls back to the identical shape.
- No behavior changes for databases that already had the field. No request routing, storage format, or platform-specific logic is changed.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`
