### PR TITLE
feat: persist loadout apply options

### DIFF
--- a/src/lib/Others/LoadoutModal.svelte
+++ b/src/lib/Others/LoadoutModal.svelte
@@ -15,7 +15,7 @@
 
     type LoadoutApplyOption = 'modules' | 'globalVariables' | 'preset' | 'persona';
 
-    let loadOptions: Record<LoadoutApplyOption, boolean> = $state({
+    let loadOptions: Record<LoadoutApplyOption, boolean> = $derived(DBState.db.loadoutApplyOptions ?? {
         modules: true,
         globalVariables: true,
         preset: true,

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -706,6 +706,12 @@ export function setDatabase(data:Database){
     data.enableRisuaiProTools ??= data.plugins.length > 0
     data.keepSessionAlive ??= 'off'
     data.loadouts ??= []
+    data.loadoutApplyOptions ??= {
+        modules: true,
+        globalVariables: true,
+        preset: true,
+        persona: true
+    }
     data.longPressToPopupEditor ??= false
     data.customSidebarItems ??= []
     data.moveInsteadOfCopyOnCMPConvert ??= false
@@ -1270,6 +1276,12 @@ export interface Database{
     keepSessionAlive: 'off' | 'pip' | 'sound'
     longPressToPopupEditor?: boolean
     loadouts: Loadout[]
+    loadoutApplyOptions: {
+        modules: boolean
+        globalVariables: boolean
+        preset: boolean
+        persona: boolean
+    }
     disableAprilFools?:boolean
     customSidebarItems: CustomSideBarItem[]
     lastLoadedLoadoutName: string


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Persists the Loadout apply-option toggles (Modules / Global Variables / Preset / Persona) so they survive reopening the Loadout modal and restarting the app.

The toggles are currently component-local state initialized to all-true on every mount, so a user who prefers importing only some elements has to re-uncheck them on every open and can accidentally apply unwanted elements after forgetting to.

## Related Issues

Closes #1423.

## Changes

**`src/ts/storage/database.svelte.ts`**
- Added a `loadoutApplyOptions` field to the `Database` interface, next to `loadouts`
- Added an all-true `data.loadoutApplyOptions ??=` default in `setDatabase`

**`src/lib/Others/LoadoutModal.svelte`**
- Replaced the component-local `$state` toggle object with a `$derived` reference to `DBState.db.loadoutApplyOptions`, keeping the all-true object as a fallback; toggle writes go through the DB proxy and are picked up by the normal debounced save

## Impact

- Apply-option toggles now persist across modal reopens, app restarts, and account sync, defaulting to all-true so behavior is unchanged until a user changes them.
- The preference is stored at the database level, not in presets — switching presets does not reset it, and preset save/apply paths are untouched.
- If the modal is opened via the Ctrl+O hotkey while the app is still loading, the fallback renders the previous all-true defaults instead of crashing, and the toggles switch to the persisted values once the database finishes loading.
- Older app versions ignore the new field and keep their current per-session behavior; the field round-trips through save files unchanged.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`
