### PR TITLE
fix: validate message source in Plugin V3 guest iframe

### DIFF
--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -271,6 +271,8 @@ await (async function() {
     
     
     window.addEventListener('message', async (event) => {
+        if (event.source !== window.parent) return;
+
         const data = event.data;
         if (!data) return;
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds source validation for messages received in the Plugin V3 iframe. This aligns the guest bridge's behavior with the parent bridge and prevents unintended messages from other plugins from being processed.

## Related Issues

None.

## Changes

In `GUEST_BRIDGE_SCRIPT` (injected into the Plugin V3 iframe), the `message` event handler now verifies that `event.source` matches `window.parent` before processing the message.

## Impact

Cross-plugin messages, which were previously accepted by default, are now blocked. Since sending messages to another plugin's iframe is not a normal usage pattern, this is expected to have no practical effect on existing functionality.

## Additional Notes

This is a defense-in-depth change, not a fix for a confirmed exploit. Meaningful message forgery would require a valid pending `reqId` or `abortId`, with no known way for another plugin to observe them. `EXECUTE_CODE` is legacy code that cannot run under the iframe's current CSP, so it is not exploitable through this path.

The parent bridge already validates that an incoming message originates from the corresponding iframe; the guest bridge was missing the equivalent check. This change simply brings the two sides in line.
