### PR TITLE
fix: scope and enforce plugin permissions

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -1428,6 +1428,7 @@ export const languageChinese = {
     "mainDomAccessConsent": "插件 {} 正在请求访问主文档，这可能会泄露敏感信息。是否允许？",
     "getFullDatabaseConsent": "插件 {} 正在请求访问完整数据库，这可能会泄露敏感信息。是否允许？",
     "fetchLogConsent": "插件 {} 正在请求获取日志，这可能会泄露敏感信息。是否允许？",
+    "providerPermissionDenied": "用户拒绝了插件的服务商访问权限。",
     "enableScrollToActiveChar": "启用滚动至当前角色",
     "trimStartNewChat": "修剪“开始新对话”消息",
     "hamburgerButtonBottom": "将菜单按钮移至侧边栏底部",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1427,6 +1427,7 @@ export const languageGerman = {
     "fetchLogConsent": "Plugin {} möchte Protokolle abrufen, was sensible Informationen offenlegen könnte. Möchten Sie dies zulassen?",
     "getFullDatabaseConsent": "Das Plugin {} möchte auf die gesamte Datenbank zugreifen, was zur Offenlegung sensibler Informationen führen kann. Möchten Sie dies zulassen?",
     "mainDomAccessConsent": "Plugin {} möchte auf das Hauptdokument zugreifen, wodurch sensible Informationen offengelegt werden könnten. Möchten Sie dies zulassen?",
+    "providerPermissionDenied": "Der Benutzer hat dem Plugin den Zugriff auf den Anbieter verweigert.",
     "enableScrollToActiveChar": "Scrollen zum aktiven Charakter aktivieren",
     "newMessageButtonRightCenter": "Mitte rechts",
     "trimStartNewChat": "„Neuen Chat starten“-Nachrichten kürzen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1602,6 +1602,7 @@ export const languageEnglish = {
     mainDomAccessConsent: "Plugin {} is requesting to access the main Document, which may expose sensitive information. Do you want to allow this?",
     replacerPermissionConsent: "Plugin {} is requesting permission to replace content in the chat, which may be used to manipulate the conversation. Do you want to allow this?",
     providerPermissionConsent: "Plugin {} is requesting permission to access the provider, which may allow it to make unauthorized API calls. Do you want to allow this?",
+    providerPermissionDenied: "Plugin provider permission denied by user.",
     sendChatConsent: "Plugin {} is requesting permission to send chat messages on your behalf, which will trigger AI responses. Do you want to allow this?",
     pluginV2Warning: "Plugin V2 and V2.1 is considered unsafe and will stop working in future versions. **Please do not use these versions of plugins.**. If you are the developer of this plugin, please update to V3 as soon as possible.",
     createFolderOnBranch: "Create Folder on Branch",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1428,6 +1428,7 @@ export const languageSpanish = {
     "trimStartNewChat": "Recortar mensajes de «Iniciar nuevo chat»",
     "getFullDatabaseConsent": "El plugin {} está solicitando acceso a la base de datos completa, lo que podría exponer información confidencial. ¿Desea permitir esto?",
     "fetchLogConsent": "El complemento {} está solicitando obtener registros, lo cual podría exponer información confidencial. ¿Desea permitir esto?",
+    "providerPermissionDenied": "El usuario ha denegado al plugin el permiso para acceder al proveedor.",
     "disableAbove": "Mensajes cortados para la IA",
     "hamburgerButtonBottom": "Mover el botón de menú a la parte inferior de la barra lateral",
     "nanoGPTLoadingAccountInfo": "Cargando información de la cuenta…",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1478,6 +1478,7 @@ export const languageKorean = {
         "save": "저장",
         "cancel": "취소",
     },
+    "providerPermissionDenied": "사용자가 플러그인의 제공자 접근 권한을 거부했습니다.",
     "hamburgerButtonBottom": "메뉴 버튼을 사이드바 하단으로 이동",
     "nanoGPTLoadingAccountInfo": "계정 정보 불러오는 중…",
     "nanoGPTCreditBalance": "크레딧 잔액:",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -1423,6 +1423,7 @@ export const languageVietnamese = {
     "newMessageButtonBottomLeft": "Phía dưới bên trái",
     "newMessageButtonBottomCenter": "Dưới cùng ở giữa (Mặc định)",
     "fetchLogConsent": "Plugin {} đang yêu cầu truy xuất nhật ký, hành động này có thể làm lộ thông tin nhạy cảm. Bạn có muốn cho phép điều này không?",
+    "providerPermissionDenied": "Người dùng đã từ chối quyền truy cập nhà cung cấp của plugin.",
     "newMessageButtonTopBar": "Thanh trên cùng",
     "pluginDevelopMode": "Chế độ phát triển Plugin",
     "mainDomAccessConsent": "Plugin {} đang yêu cầu truy cập vào Tài liệu chính, điều này có thể làm lộ thông tin nhạy cảm. Bạn có muốn cho phép không?",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -1417,6 +1417,7 @@ export const languageChineseTraditional = {
     "mainDomAccessConsent": "外掛 {} 正在請求存取主文件，此操作可能暴露敏感資訊。是否允許？",
     "replacerPermissionConsent": "外掛 {} 正在請求替換對話內容的權限，此操作可能被用於操縱對話。是否允許？",
     "providerPermissionConsent": "外掛 {} 正在請求存取提供商的權限，此操作可能允許未授權的 API 呼叫。是否允許？",
+    "providerPermissionDenied": "使用者已拒絕外掛存取提供商的權限。",
     "sendChatConsent": "外掛 {} 正在請求以您的名義發送對話訊息的權限，這將觸發 AI 回應。是否允許？",
     "pluginV2Warning": "外掛 V2 與 V2.1 版本被視為不安全，並將於未來版本中停用。**請勿使用此版本的外掛。**若您是外掛開發者，請盡快更新至 V3。",
     "createFolderOnBranch": "在分支上建立資料夾",

--- a/src/ts/plugins/apiV3/pluginPermissionCache.test.ts
+++ b/src/ts/plugins/apiV3/pluginPermissionCache.test.ts
@@ -1,8 +1,31 @@
 import { describe, expect, it } from 'vitest'
 import {
+    createPluginScriptHashGetter,
     getPluginPermissionKey,
     PluginPermissionSessionCache,
 } from './pluginPermissionCache'
+
+describe('createPluginScriptHashGetter', () => {
+    it('hashes the loaded plugin script only once', async () => {
+        let hashCalls = 0
+        const getScriptHash = createPluginScriptHashGetter('plugin-script', async (data) => {
+            hashCalls++
+            expect(new TextDecoder().decode(data)).toBe('plugin-script')
+            return 'script-hash'
+        })
+
+        expect(hashCalls).toBe(0)
+
+        const hashes = await Promise.all([
+            getScriptHash(),
+            getScriptHash(),
+            getScriptHash(),
+        ])
+
+        expect(hashes).toEqual(['script-hash', 'script-hash', 'script-hash'])
+        expect(hashCalls).toBe(1)
+    })
+})
 
 describe('PluginPermissionSessionCache', () => {
     it('keeps permission decisions isolated by permission', () => {

--- a/src/ts/plugins/apiV3/pluginPermissionCache.test.ts
+++ b/src/ts/plugins/apiV3/pluginPermissionCache.test.ts
@@ -1,9 +1,38 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
     createPluginScriptHashGetter,
     getPluginPermissionKey,
     PluginPermissionSessionCache,
+    runWithPluginPermission,
 } from './pluginPermissionCache'
+
+describe('runWithPluginPermission', () => {
+    it('does not invoke the protected callback when permission is denied', async () => {
+        const onAllowed = vi.fn(async () => 'allowed')
+
+        const result = await runWithPluginPermission(
+            async () => false,
+            onAllowed,
+            'denied',
+        )
+
+        expect(result).toBe('denied')
+        expect(onAllowed).not.toHaveBeenCalled()
+    })
+
+    it('invokes the protected callback when permission is granted', async () => {
+        const onAllowed = vi.fn(async () => 'allowed')
+
+        const result = await runWithPluginPermission(
+            async () => true,
+            onAllowed,
+            'denied',
+        )
+
+        expect(result).toBe('allowed')
+        expect(onAllowed).toHaveBeenCalledOnce()
+    })
+})
 
 describe('createPluginScriptHashGetter', () => {
     it('hashes the loaded plugin script only once', async () => {

--- a/src/ts/plugins/apiV3/pluginPermissionCache.test.ts
+++ b/src/ts/plugins/apiV3/pluginPermissionCache.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+    getPluginPermissionKey,
+    PluginPermissionSessionCache,
+} from './pluginPermissionCache'
+
+describe('PluginPermissionSessionCache', () => {
+    it('keeps permission decisions isolated by permission', () => {
+        const cache = new PluginPermissionSessionCache()
+
+        cache.set('script-hash', 'fetchLogs', true)
+
+        expect(cache.get('script-hash', 'fetchLogs')).toBe(true)
+        expect(cache.get('script-hash', 'db')).toBeUndefined()
+    })
+
+    it('keeps denied permissions from blocking other permissions', () => {
+        const cache = new PluginPermissionSessionCache()
+
+        cache.set('script-hash', 'mainDom', false)
+
+        expect(cache.get('script-hash', 'mainDom')).toBe(false)
+        expect(cache.get('script-hash', 'sendChat')).toBeUndefined()
+    })
+
+    it('invalidates session decisions when the plugin script changes', () => {
+        const cache = new PluginPermissionSessionCache()
+
+        cache.set('old-script-hash', 'db', true)
+
+        expect(cache.get('old-script-hash', 'db')).toBe(true)
+        expect(cache.get('new-script-hash', 'db')).toBeUndefined()
+    })
+
+    it('preserves the existing persistent permission key format', () => {
+        expect(getPluginPermissionKey('script-hash', 'provider')).toBe('script-hash_provider')
+    })
+})

--- a/src/ts/plugins/apiV3/pluginPermissionCache.ts
+++ b/src/ts/plugins/apiV3/pluginPermissionCache.ts
@@ -2,6 +2,18 @@ export type PluginPermission = 'fetchLogs' | 'db' | 'mainDom' | 'replacer' | 'pr
 
 type PluginScriptHasher = (data: Uint8Array) => Promise<string>
 
+export async function runWithPluginPermission<T>(
+    requestPermission: () => Promise<boolean>,
+    onAllowed: () => Promise<T>,
+    deniedResult: T,
+): Promise<T> {
+    if (!(await requestPermission())) {
+        return deniedResult
+    }
+
+    return onAllowed()
+}
+
 export function createPluginScriptHashGetter(script: string, hasher: PluginScriptHasher): () => Promise<string> {
     let scriptHash: Promise<string> | undefined
 

--- a/src/ts/plugins/apiV3/pluginPermissionCache.ts
+++ b/src/ts/plugins/apiV3/pluginPermissionCache.ts
@@ -1,0 +1,17 @@
+export type PluginPermission = 'fetchLogs' | 'db' | 'mainDom' | 'replacer' | 'provider' | 'sendChat'
+
+export function getPluginPermissionKey(scriptHash: string, permission: PluginPermission): string {
+    return `${scriptHash}_${permission}`
+}
+
+export class PluginPermissionSessionCache {
+    private decisions = new Map<string, boolean>()
+
+    get(scriptHash: string, permission: PluginPermission): boolean | undefined {
+        return this.decisions.get(getPluginPermissionKey(scriptHash, permission))
+    }
+
+    set(scriptHash: string, permission: PluginPermission, granted: boolean): void {
+        this.decisions.set(getPluginPermissionKey(scriptHash, permission), granted)
+    }
+}

--- a/src/ts/plugins/apiV3/pluginPermissionCache.ts
+++ b/src/ts/plugins/apiV3/pluginPermissionCache.ts
@@ -1,5 +1,16 @@
 export type PluginPermission = 'fetchLogs' | 'db' | 'mainDom' | 'replacer' | 'provider' | 'sendChat'
 
+type PluginScriptHasher = (data: Uint8Array) => Promise<string>
+
+export function createPluginScriptHashGetter(script: string, hasher: PluginScriptHasher): () => Promise<string> {
+    let scriptHash: Promise<string> | undefined
+
+    return () => {
+        scriptHash ??= hasher(new TextEncoder().encode(script))
+        return scriptHash
+    }
+}
+
 export function getPluginPermissionKey(scriptHash: string, permission: PluginPermission): string {
     return `${scriptHash}_${permission}`
 }

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -1,5 +1,6 @@
 import { allowedDbKeys, customProviderStore, getV2PluginAPIs, handlePluginInstallViaPlugin, pluginV2, type PluginV2ProviderArgument, type PluginV2ProviderOptions, type RisuPlugin } from "../plugins.svelte";
 import { SandboxHost } from "./factory";
+import { getPluginPermissionKey, PluginPermissionSessionCache, type PluginPermission } from "./pluginPermissionCache";
 import { getDatabase } from "src/ts/storage/database.svelte";
 import { SafeLocalPluginStorage, tagWhitelist } from "../pluginSafeClass";
 import DOMPurify from 'dompurify';
@@ -551,8 +552,7 @@ const unloadV3Plugin = async (pluginName: string) => {
     }
 }
 
-const permissionGivenPlugins: Set<string> = new Set();
-const permissionDeniedPlugins: Set<string> = new Set();
+const permissionSessionCache = new PluginPermissionSessionCache();
 const permissionForage = localforage.createInstance({
     name: 'plugin_permissions',
     storeName: 'plugin_permissions'
@@ -564,15 +564,18 @@ type PluginV3ProviderOptions = PluginV2ProviderOptions & {
 
 export const customV3ProviderMetaStore:LLMModel[] = []
 
-const getPluginPermission = async (pluginName: string, permissionDesc: 'fetchLogs'|'db'|'mainDom'|'replacer'|'provider'|'sendChat', reconfirm: boolean|'periodically' = false) => {
-    if(permissionGivenPlugins.has(pluginName)){
-        return true;
-    }
-    if(permissionDeniedPlugins.has(pluginName)){
-        return false;
+const getPluginPermission = async (pluginName: string, permissionDesc: PluginPermission, reconfirm: boolean|'periodically' = false) => {
+    const scriptHash = await hasher(
+        new TextEncoder().encode(
+            DBState.db.plugins.find(p => p.name === pluginName)?.script
+        )
+    )
+    const cachedPermission = permissionSessionCache.get(scriptHash, permissionDesc)
+    if(cachedPermission !== undefined){
+        return cachedPermission;
     }
 
-    let pluginHash = ''
+    const permissionKey = getPluginPermissionKey(scriptHash, permissionDesc)
 
     let requiresReconfirm = false;
 
@@ -587,14 +590,8 @@ const getPluginPermission = async (pluginName: string, permissionDesc: 'fetchLog
         requiresReconfirm = true;
     }
 
-    pluginHash = await hasher(
-        new TextEncoder().encode(
-            DBState.db.plugins.find(p => p.name === pluginName)?.script
-        )
-    ) + `_${permissionDesc}`;
-
-    if(!requiresReconfirm &&await permissionForage.getItem(pluginHash)){
-        permissionGivenPlugins.add(pluginName);
+    if(!requiresReconfirm && await permissionForage.getItem(permissionKey)){
+        permissionSessionCache.set(scriptHash, permissionDesc, true)
         return true;
     }   
     
@@ -611,15 +608,15 @@ const getPluginPermission = async (pluginName: string, permissionDesc: 'fetchLog
         return false;
     }
     const conf = await alertConfirm(alertTitle)
-    if(conf && pluginHash){
-        permissionGivenPlugins.add(pluginName);
-        await permissionForage.setItem(pluginHash, true);
+    if(conf && permissionKey){
+        permissionSessionCache.set(scriptHash, permissionDesc, true)
+        await permissionForage.setItem(permissionKey, true);
         if(reconfirm === 'periodically'){
             await permissionForage.setItem(pluginName + '_' + permissionDesc + '_lastGrantTime', Date.now());
         }
         return true;
     }
-    permissionDeniedPlugins.add(pluginName);
+    permissionSessionCache.set(scriptHash, permissionDesc, false)
     return false;
 }
 

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -1,6 +1,6 @@
 import { allowedDbKeys, customProviderStore, getV2PluginAPIs, handlePluginInstallViaPlugin, pluginV2, type PluginV2ProviderArgument, type PluginV2ProviderOptions, type RisuPlugin } from "../plugins.svelte";
 import { SandboxHost } from "./factory";
-import { getPluginPermissionKey, PluginPermissionSessionCache, type PluginPermission } from "./pluginPermissionCache";
+import { createPluginScriptHashGetter, getPluginPermissionKey, PluginPermissionSessionCache, type PluginPermission } from "./pluginPermissionCache";
 import { getDatabase } from "src/ts/storage/database.svelte";
 import { SafeLocalPluginStorage, tagWhitelist } from "../pluginSafeClass";
 import DOMPurify from 'dompurify';
@@ -564,12 +564,7 @@ type PluginV3ProviderOptions = PluginV2ProviderOptions & {
 
 export const customV3ProviderMetaStore:LLMModel[] = []
 
-const getPluginPermission = async (pluginName: string, permissionDesc: PluginPermission, reconfirm: boolean|'periodically' = false) => {
-    const scriptHash = await hasher(
-        new TextEncoder().encode(
-            DBState.db.plugins.find(p => p.name === pluginName)?.script
-        )
-    )
+const getPluginPermission = async (pluginName: string, scriptHash: string, permissionDesc: PluginPermission, reconfirm: boolean|'periodically' = false) => {
     const cachedPermission = permissionSessionCache.get(scriptHash, permissionDesc)
     if(cachedPermission !== undefined){
         return cachedPermission;
@@ -635,6 +630,10 @@ const authorizationHeaders = [
 const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
 
     const oldApis = getV2PluginAPIs();
+    const getPluginScriptHash = createPluginScriptHashGetter(plugin.script, hasher)
+    const getPermission = async (permissionDesc: PluginPermission, reconfirm: boolean|'periodically' = false) => {
+        return getPluginPermission(plugin.name, await getPluginScriptHash(), permissionDesc, reconfirm)
+    }
     return {
 
         //Old APIs from v2.1
@@ -678,7 +677,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             let provs = get(customProviderStore)
             provs.push(name)
             pluginV2.providers.set(name, async (arg, abortSignal) => {
-               await getPluginPermission(plugin.name, 'provider', 'periodically');
+               await getPermission('provider', 'periodically');
                //mode is overridden to v3, due to vulnerabilities using mode.
                //Alternative to mode will be added in future
                arg.mode = 'v3'
@@ -717,7 +716,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
         removeRisuScriptHandler: oldApis.removeRisuScriptHandler,
         addRisuReplacer: async (name:string,func:Function) => {
             //permission check for replacer
-            const conf = await getPluginPermission(plugin.name, 'replacer', 'periodically');
+            const conf = await getPermission('replacer', 'periodically');
             if(!conf){
                 return;
             }
@@ -734,7 +733,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
         saveAsset: oldApis.saveAsset,
         //Same functionality, but new implementation
         getDatabase: async (includeOnly:string[]|'all' = 'all') => {
-            const conf = await getPluginPermission(plugin.name, 'db', 'periodically');
+            const conf = await getPermission('db', 'periodically');
             if(!conf){
                 return null;
             }
@@ -932,7 +931,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             iframe.style.display = "none";
         },
         getRootDocument: async () => {
-            const conf = await getPluginPermission(plugin.name, 'mainDom');
+            const conf = await getPermission('mainDom');
             if(!conf){
                 return null;
             }
@@ -977,7 +976,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
         },
         registerBodyIntercepter: async (callback: (body: any, type: string) => any) => {
 
-            if(await getPluginPermission(plugin.name, 'replacer') === false){
+            if(await getPermission('replacer') === false){
                 return null;
             }
             
@@ -1144,7 +1143,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
         },
         getFetchLogs: async () => {
             const unsafeFetchLog = getFetchLogs()
-            const conf = await getPluginPermission(plugin.name, 'fetchLogs');
+            const conf = await getPermission('fetchLogs');
             if(!conf){
                 return null;
             }
@@ -1187,7 +1186,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
         },
         checkCharOrder: checkCharOrder,
         requestPluginPermission: (permission:string) => {
-            return getPluginPermission(plugin.name, permission as any);
+            return getPermission(permission as any);
         },
         //Internal use APIs
         _getOldKeys: () => {
@@ -1265,7 +1264,7 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             }, options.mode)
         },
         sendChat: async (message: string) => {
-            const conf = await getPluginPermission(plugin.name, 'sendChat');
+            const conf = await getPermission('sendChat');
             if(!conf){
                 return false;
             }

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -1,6 +1,6 @@
 import { allowedDbKeys, customProviderStore, getV2PluginAPIs, handlePluginInstallViaPlugin, pluginV2, type PluginV2ProviderArgument, type PluginV2ProviderOptions, type RisuPlugin } from "../plugins.svelte";
 import { SandboxHost } from "./factory";
-import { createPluginScriptHashGetter, getPluginPermissionKey, PluginPermissionSessionCache, type PluginPermission } from "./pluginPermissionCache";
+import { createPluginScriptHashGetter, getPluginPermissionKey, PluginPermissionSessionCache, runWithPluginPermission, type PluginPermission } from "./pluginPermissionCache";
 import { getDatabase } from "src/ts/storage/database.svelte";
 import { SafeLocalPluginStorage, tagWhitelist } from "../pluginSafeClass";
 import DOMPurify from 'dompurify';
@@ -676,12 +676,20 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             console.warn(`[WARN] addProvider is a powerful API that can potentially be unsafe if used incorrectly. addProvider's functionality might be limited or changed in future updates to ensure security. please use other APIs if possible.`);
             let provs = get(customProviderStore)
             provs.push(name)
-            pluginV2.providers.set(name, async (arg, abortSignal) => {
-               await getPermission('provider', 'periodically');
-               //mode is overridden to v3, due to vulnerabilities using mode.
-               //Alternative to mode will be added in future
-               arg.mode = 'v3'
-               return await func(arg, abortSignal);
+            pluginV2.providers.set(name, (arg, abortSignal) => {
+                return runWithPluginPermission(
+                    () => getPermission('provider', 'periodically'),
+                    async () => {
+                        //mode is overridden to v3, due to vulnerabilities using mode.
+                        //Alternative to mode will be added in future
+                        arg.mode = 'v3'
+                        return func(arg, abortSignal);
+                    },
+                    {
+                        success: false,
+                        content: language.providerPermissionDenied,
+                    },
+                )
             }),
             pluginV2.providerOptions.set(name, options ?? {})
             customProviderStore.set(provs)


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it will not break existing features?

## Summary

Scope cached plugin permission decisions to both the plugin script and the requested permission, and ensure a denied provider permission prevents provider invocation.

## Related Issues

None.

## Changes

- Replace plugin-name-wide session allow and deny sets with a permission-aware session cache.
- Key session decisions by the loaded plugin script hash and permission name.
- Lazily compute each loaded plugin instance's script hash once and reuse it on cache hits.
- Stop V3 provider callbacks from running when provider permission is denied.
- Preserve the existing persistent permission key format.
- Add focused tests for permission isolation, denied permissions, script changes, persistent key compatibility, lazy hash reuse, and provider permission enforcement.

## Impact

Granting or denying one plugin permission no longer implicitly grants or denies every other permission requested by that plugin. Updating a plugin script also invalidates its in-memory permission decisions for the session. Existing persisted grants remain compatible.

A denied provider permission now returns a failed provider response without invoking the plugin callback. Allowed provider requests are unchanged.

## Additional Notes

This changes model request behavior only when the user explicitly denies provider permission; previously, the denied result was ignored and the provider callback still ran.

Validation:

- `pnpm check`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/ts/plugins/apiV3/pluginPermissionCache.test.ts` (7 tests)
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (235 passed, 3 skipped)
- `git diff --check upstream/main...HEAD`
