### PR TITLE
feat(apiV3): add allow-clipboard-write to iframe sandbox

### DIFF
--- a/src/ts/plugins/apiV3/factory.ts
+++ b/src/ts/plugins/apiV3/factory.ts
@@ -782,9 +782,10 @@ export class SandboxHost {
         this.iframe.setAttribute('allowTransparency', 'true');
 
         this.iframe.sandbox.add('allow-scripts');
-        this.iframe.sandbox.add('allow-modals')
-        this.iframe.sandbox.add('allow-downloads')
-
+        this.iframe.sandbox.add('allow-modals');
+        this.iframe.sandbox.add('allow-downloads');
+        this.iframe.sandbox.add('allow-clipboard-write');
+        
         this.iframe.setAttribute('csp', this.csp);
 
         const messageHandler = async (event: MessageEvent) => {


### PR DESCRIPTION
Added missing semicolons and `allow-clipboard-write` permission to sandbox to enable clipboard access in sandboxed iframe.

## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

I added the relevant code to fix the issue where clipboard copying was not possible in the plugin because `allow-clipboard-write` was not included in the iframe sandbox allowlist.

## Related Issues

None

## Changes

By adding the `this.iframe.sandbox.add('allow-clipboard-write');` code, we enabled clipboard copying within the plugin.

## Impact


## Additional Notes
