### PR TITLE
feat(display): add option to allow textarea resizing

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1707,6 +1707,7 @@ export const languageEnglish = {
     convertToModule: "Convert to Module",
     skipSavingAssetsOnWebSync: "Skip Saving Assets on Web Sync",
     applyAdditionalParamsToAll: "Apply Additional Parameters to All Models",
+    resizeTextarea: "Allow Textarea Resizing"
 } satisfies I18nTranslation;
 
 type I18nTranslationFunction = (...args: any[]) => string;

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1520,4 +1520,5 @@ export const languageKorean = {
     nanoGPTSelectFromList: "목록에서 선택",
     nanoGPTManualInput: "수동 입력",
     nanoGPTManualModelSelect: "수동 모델 선택",
+    "resizeTextarea": "textarea 크기 조절 허용"
 } satisfies DeepPartial<typeof import('./en').languageEnglish>

--- a/src/lib/UI/GUI/TextAreaInput.svelte
+++ b/src/lib/UI/GUI/TextAreaInput.svelte
@@ -33,6 +33,9 @@
     class:mb-2={margin === 'both'}
     class:mt-4={margin === 'top'}
     class:mt-2={margin === 'both'}
+    class:resize-y={DBState.db.resizeTextarea}
+    class:shrink-0={DBState.db.resizeTextarea}
+    class:overflow-hidden={DBState.db.resizeTextarea}
     bind:this={highlightDom}
     onfocusout={() => {
         hideAutoComplete()

--- a/src/ts/setting/displaySettingsData.svelte.ts
+++ b/src/ts/setting/displaySettingsData.svelte.ts
@@ -349,6 +349,7 @@ export const displayOtherSettingsItems: SettingItem[] = [
     { id: 'display.betaMobileGUI', type: 'check', labelKey: 'betaMobileGUI', helpKey: 'betaMobileGUI', bindKey: 'betaMobileGUI', keywords: ['beta', 'mobile', 'gui'] },
     { id: 'display.menuSideBar', type: 'check', labelKey: 'menuSideBar', bindKey: 'menuSideBar', keywords: ['menu', 'sidebar'] },
     { id: 'display.notification', type: 'custom', componentId: 'NotificationToggle', keywords: ['notification'] },
+    { id: 'display.resizeTextarea', type: 'check', labelKey: "resizeTextarea", bindKey: 'resizeTextarea', keywords: ["textarea", 'resize']},
     {
         id: 'display.useChatSticker',
         type: 'check',

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -713,6 +713,7 @@ export function setDatabase(data:Database){
     data.customSidebarItems ??= []
     data.moveInsteadOfCopyOnCMPConvert ??= false
     data.skipSavingAssetsOnWebSync ??= true
+    data.resizeTextarea ??= false
     data.coldstorage ??= data?.plugins?.length === 0
     for(const char of data.characters){
         for(const chat of char.chats ?? []){
@@ -1274,6 +1275,7 @@ export interface Database{
     lastLoadedLoadoutName: string
     moveInsteadOfCopyOnCMPConvert?:boolean
     skipSavingAssetsOnWebSync?:boolean
+    resizeTextarea?: boolean
 }
 
 export interface CustomSideBarItem{


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This is a simple PR adding functionality to make the textarea resizable. I added this because I thought it would be convenient to be able to adjust the size of the textarea when editing prompts.

## Related Issues

None

## Changes

Added a new variable 'resizeTextarea' to the database.
Added the name 'resizeTextarea' to the en.ts and ko.ts files.
Added a checkbox to displaySettingsData.svelite.ts to determine whether the textarea should be resizable.
Updated TextAreaInput.svelite so that if the resizeTextarea value is true, the classes 'resize-y', 'shrink-0', and 'overflow-hidden' are added to the parent div.

## Impact

If the relevant option is enabled, users will be able to resize the textarea area.

## Additional Notes
<img width="1338" height="1292" alt="스크린샷_20260801_102002" src="https://github.com/user-attachments/assets/a3af756b-ef1d-4822-b5a9-0f1212d53cf3" />


[스크린캐스트_20260801_102045.webm](https://github.com/user-attachments/assets/5cc30292-9d03-4834-b57a-5f8dd2e93e8f)
