### PR TITLE
feat(display): add option to allow textarea resizing

### DIFF
--- a/src/etc/resizeIcon.svg
+++ b/src/etc/resizeIcon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="24"
+     height="24"
+     viewBox="0 0 24 24"
+     fill="none"
+     aria-hidden="true">
+  <path d="M3 21h16a2 2 0 0 0 2-2V3"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"/>
+</svg>

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1707,6 +1707,7 @@ export const languageEnglish = {
     convertToModule: "Convert to Module",
     skipSavingAssetsOnWebSync: "Skip Saving Assets on Web Sync",
     applyAdditionalParamsToAll: "Apply Additional Parameters to All Models",
+    resizeTextarea: "Allow Textarea Resizing"
 } satisfies I18nTranslation;
 
 type I18nTranslationFunction = (...args: any[]) => string;

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1520,4 +1520,5 @@ export const languageKorean = {
     nanoGPTSelectFromList: "목록에서 선택",
     nanoGPTManualInput: "수동 입력",
     nanoGPTManualModelSelect: "수동 모델 선택",
+    "resizeTextarea": "textarea 크기 조절 허용"
 } satisfies DeepPartial<typeof import('./en').languageEnglish>

--- a/src/lib/UI/GUI/TextAreaInput.svelte
+++ b/src/lib/UI/GUI/TextAreaInput.svelte
@@ -1,4 +1,5 @@
 <div 
+bind:this={textareaInput}
     class={"border border-darkborderc relative n-scroll focus-within:border-borderc rounded-md shadow-xs text-textcolor bg-transparent focus-within:ring-borderc focus-within:ring-2 focus-within:outline-hidden transition-colors duration-200 z-20 focus-within:z-40" + ((className) ? (' ' + className) : '')} 
     class:text-sm={size === 'sm' || (size === 'default' && $textAreaTextSize === 1)}
     class:text-md={size === 'md' || (size === 'default' && $textAreaTextSize === 2)}
@@ -33,9 +34,8 @@
     class:mb-2={margin === 'both'}
     class:mt-4={margin === 'top'}
     class:mt-2={margin === 'both'}
-    class:resize-y={DBState.db.resizeTextarea}
     class:shrink-0={DBState.db.resizeTextarea}
-    class:overflow-hidden={DBState.db.resizeTextarea}
+    class:overflow-visible={DBState.db.resizeTextarea}
     bind:this={highlightDom}
     onfocusout={() => {
         hideAutoComplete()
@@ -138,6 +138,11 @@
             }}>{content}</button>
         {/each}
     </div>
+    {#if DBState.db.resizeTextarea}
+    <div id="resize-handle" class="resize-handle  absolute -right-3 -bottom-3 w-10 h-10 pt-2 pl-2 pb-4 pr-4 z-1000 cursor-ns-resize touch-none [&>svg]:size-full" style:color="var(--risu-theme-darkborderc)" role="separator" bind:this={resizeHandle} onpointerdown={startResize}>
+        {@html resizeIcon}
+    </div>
+    {/if}
 </div>
 <script lang="ts">
     import { textAreaSize, textAreaTextSize } from 'src/ts/gui/guisize'
@@ -147,6 +152,7 @@
   import { DBState, disableHighlight, popUpEditorStore } from 'src/ts/stores.svelte';
   import { isMobile } from 'src/ts/platform'
     import { hotkeyMatches } from 'src/ts/hotkey';
+  import resizeIcon from 'src/etc/resizeIcon.svg?raw'
     interface Props {
         size?: 'xs'|'sm'|'md'|'lg'|'xl'|'default';
         autocomplete?: 'on'|'off';
@@ -192,6 +198,8 @@
     let autoCompleteDom: HTMLDivElement = $state()
     let autocompleteContents:string[] = $state([])
     let inputDom: HTMLDivElement = $state()
+    let textareaInput: HTMLDivElement;
+    let resizeHandle: HTMLDivElement;
 
     const autoComplete = () => {
         if(isMobile){
@@ -349,5 +357,29 @@
     $effect.pre(() => {
         highlightChange(value, highlightId)
     });
+
+    function startResize(event: PointerEvent) {
+        if (event.pointerType === 'mouse' && event.button !== 0) return;
+        
+        const startY = event.clientY;
+        const startHeight = textareaInput.offsetHeight;
+
+        resizeHandle.setPointerCapture(event.pointerId);
+
+        function resize(event: PointerEvent) {
+            const deltaY = event.clientY - startY;
+            textareaInput.style.height = `${startHeight + deltaY}px`;
+        }
+
+         function stopResize() {
+      resizeHandle.removeEventListener('pointermove', resize);
+      resizeHandle.removeEventListener('pointerup', stopResize);
+      resizeHandle.removeEventListener('pointercancel', stopResize);
+    }
+
+    resizeHandle.addEventListener('pointermove', resize);
+    resizeHandle.addEventListener('pointerup', stopResize);
+    resizeHandle.addEventListener('pointercancel', stopResize);
+    }
 
 </script>

--- a/src/lib/UI/GUI/TextAreaInput.svelte
+++ b/src/lib/UI/GUI/TextAreaInput.svelte
@@ -360,7 +360,7 @@ bind:this={textareaInput}
 
     function startResize(event: PointerEvent) {
         if (event.pointerType === 'mouse' && event.button !== 0) return;
-        
+        event.preventDefault();
         const startY = event.clientY;
         const startHeight = textareaInput.offsetHeight;
 

--- a/src/lib/UI/GUI/TextAreaInput.svelte
+++ b/src/lib/UI/GUI/TextAreaInput.svelte
@@ -33,6 +33,9 @@
     class:mb-2={margin === 'both'}
     class:mt-4={margin === 'top'}
     class:mt-2={margin === 'both'}
+    class:resize-y={DBState.db.resizeTextarea}
+    class:shrink-0={DBState.db.resizeTextarea}
+    class:overflow-hidden={DBState.db.resizeTextarea}
     bind:this={highlightDom}
     onfocusout={() => {
         hideAutoComplete()

--- a/src/ts/setting/displaySettingsData.svelte.ts
+++ b/src/ts/setting/displaySettingsData.svelte.ts
@@ -349,6 +349,7 @@ export const displayOtherSettingsItems: SettingItem[] = [
     { id: 'display.betaMobileGUI', type: 'check', labelKey: 'betaMobileGUI', helpKey: 'betaMobileGUI', bindKey: 'betaMobileGUI', keywords: ['beta', 'mobile', 'gui'] },
     { id: 'display.menuSideBar', type: 'check', labelKey: 'menuSideBar', bindKey: 'menuSideBar', keywords: ['menu', 'sidebar'] },
     { id: 'display.notification', type: 'custom', componentId: 'NotificationToggle', keywords: ['notification'] },
+    { id: 'display.resizeTextarea', type: 'check', labelKey: "resizeTextarea", bindKey: 'resizeTextarea', keywords: ["textarea", 'resize']},
     {
         id: 'display.useChatSticker',
         type: 'check',

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -713,6 +713,7 @@ export function setDatabase(data:Database){
     data.customSidebarItems ??= []
     data.moveInsteadOfCopyOnCMPConvert ??= false
     data.skipSavingAssetsOnWebSync ??= true
+    data.resizeTextarea ??= false
     data.coldstorage ??= data?.plugins?.length === 0
     for(const char of data.characters){
         for(const chat of char.chats ?? []){
@@ -1274,6 +1275,7 @@ export interface Database{
     lastLoadedLoadoutName: string
     moveInsteadOfCopyOnCMPConvert?:boolean
     skipSavingAssetsOnWebSync?:boolean
+    resizeTextarea?: boolean
 }
 
 export interface CustomSideBarItem{


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This is a simple PR adding functionality to make the textarea resizable. I added this because I thought it would be convenient to be able to adjust the size of the textarea when editing prompts.

## Related Issues

None

## Changes

Added a new variable 'resizeTextarea' to the database.
Added the name 'resizeTextarea' to the en.ts and ko.ts files.
Added a checkbox to displaySettingsData.svelite.ts to determine whether the textarea should be resizable.
Updated TextAreaInput.svelite so that if the resizeTextarea value is true, the classes 'resize-y', 'shrink-0', and 'overflow-hidden' are added to the parent div.

## Impact

If the relevant option is enabled, users will be able to resize the textarea area.

## Additional Notes
<img width="1338" height="1292" alt="스크린샷_20260801_102002" src="https://github.com/user-attachments/assets/a3af756b-ef1d-4822-b5a9-0f1212d53cf3" />


[스크린캐스트_20260801_102045.webm](https://github.com/user-attachments/assets/5cc30292-9d03-4834-b57a-5f8dd2e93e8f)
