### PR TITLE
feat(chat): add adjustable chat width size setting

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -788,6 +788,7 @@ export const languageEnglish = {
     noPluginSelected: "Model selected as plugin, but no plugin selected.",
     text: "Text",
     UISize: "Chat Text Size",
+    chatLimitSize: "Chat Width Size",
     newVersion: "Update found, do you want to install?",
     remindLaterQuestion: "When should I remind you?",
     remindIgnore: "Ignore",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -650,6 +650,7 @@ export const languageKorean = {
     "noPluginSelected": "플러그인이 선택되었지만, 플러그인이 없습니다.",
     "text": "텍스트",
     "UISize": "채팅 텍스트 크기",
+    "chatLimitSize": "채팅 넓이 크기",
     "newVersion": "업데이트가 발견되었습니다. 설치하시겠습니까?",
     "remindLaterQuestion": "며칠 뒤에 다시 알려드릴까요?",
     "remindIgnore": "무시",

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -326,6 +326,29 @@
 
         chat.bookmarks = [...chat.bookmarks];
     }
+
+    function getMaxWidth(): string {
+        switch (DBState.db.chatLimitSize) {
+            //Unlimited
+            case -1:
+                return '100%'
+            
+            //Small
+            case 0:
+               return '600px'
+
+            //Normal
+            case 1:
+                return '800px'
+            
+            //Huge
+            case 2:
+               return '1200px'
+            
+            default:
+                return '100%'
+        }
+    }
 </script>
 
 
@@ -1059,12 +1082,12 @@
 {#if disabled === true}
 <div class="w-full border-t-2 border-dashed border-blue-500"></div>
 {/if}
-<div class="flex max-w-full justify-center risu-chat"
+<div class="flex max-w-full justify-center risu-chat items-center"
      data-chat-index={idx}
      data-chat-id={DBState.db.characters?.[selIdState.selId]?.chats?.[DBState.db.characters?.[selIdState.selId]?.chatPage]?.message?.[idx]?.chatId ?? ''}
-     style={isLastMemory ? `border-top:${DBState.db.memoryLimitThickness}px solid rgba(98, 114, 164, 0.7);` : ''}
+     style:border-top={isLastMemory ? `${DBState.db.memoryLimitThickness}px solid rgba(98, 114, 164, 0.7)` : ''}
      onclickcapture={handleButtonTriggerWithin}>
-    <div class="text-textcolor mt-1 ml-4 mr-4 mb-1 p-2 bg-transparent grow border-t-gray-900 border-opacity/30 border-transparent flexium items-start max-w-full" >
+    <div class="text-textcolor mt-1 ml-4 mr-4 mb-1 p-2 bg-transparent grow border-t-gray-900 border-opacity/30 border-transparent flexium items-start" style:max-width={getMaxWidth()}>
         {#if DBState.db.theme === 'mobilechat' && !blankMessage}
             <div class={role === 'user' ? "flex items-start w-full justify-end" : "flex items-start"}>
                 {#if role !== 'user'}

--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -326,29 +326,6 @@
 
         chat.bookmarks = [...chat.bookmarks];
     }
-
-    function getMaxWidth(): string {
-        switch (DBState.db.chatLimitSize) {
-            //Unlimited
-            case -1:
-                return '100%'
-            
-            //Small
-            case 0:
-               return '600px'
-
-            //Normal
-            case 1:
-                return '800px'
-            
-            //Huge
-            case 2:
-               return '1200px'
-            
-            default:
-                return '100%'
-        }
-    }
 </script>
 
 
@@ -1087,7 +1064,7 @@
      data-chat-id={DBState.db.characters?.[selIdState.selId]?.chats?.[DBState.db.characters?.[selIdState.selId]?.chatPage]?.message?.[idx]?.chatId ?? ''}
      style:border-top={isLastMemory ? `${DBState.db.memoryLimitThickness}px solid rgba(98, 114, 164, 0.7)` : ''}
      onclickcapture={handleButtonTriggerWithin}>
-    <div class="text-textcolor mt-1 ml-4 mr-4 mb-1 p-2 bg-transparent grow border-t-gray-900 border-opacity/30 border-transparent flexium items-start" style:max-width={getMaxWidth()}>
+    <div class="text-textcolor mt-1 ml-4 mr-4 mb-1 p-2 bg-transparent grow border-t-gray-900 border-opacity/30 border-transparent flexium items-start">
         {#if DBState.db.theme === 'mobilechat' && !blankMessage}
             <div class={role === 'user' ? "flex items-start w-full justify-end" : "flex items-start"}>
                 {#if role !== 'user'}

--- a/src/lib/ChatScreens/ChatScreen.svelte
+++ b/src/lib/ChatScreens/ChatScreen.svelte
@@ -69,7 +69,7 @@
     <div class="grow h-full min-w-0 relative justify-center flex">
         <SideBarArrow />
         <BackgroundDom />
-        <div style={bgImg} class="h-full w-full" style:max-width={getMaxWidth()}>
+        <div style={bgImg} class="h-full w-full" style:max-width={$selectedCharID >= 0 ? getMaxWidth() : undefined}>
             {#if $selectedCharID >= 0}
                 {#if DBState.db.characters[$selectedCharID].viewScreen !== 'none' && (DBState.db.characters[$selectedCharID].type === 'group' || (!DBState.db.characters[$selectedCharID].inlayViewScreen))}
                     <ResizeBox />

--- a/src/lib/ChatScreens/ChatScreen.svelte
+++ b/src/lib/ChatScreens/ChatScreen.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getCustomBackground, getEmotion } from "../../ts/util";
+    import { getCustomBackground, getEmotion, getMaxWidth } from "../../ts/util";
     
     import { DBState } from 'src/ts/stores.svelte';
     import { CharEmotion, selectedCharID } from "../../ts/stores.svelte";
@@ -69,7 +69,7 @@
     <div class="grow h-full min-w-0 relative justify-center flex">
         <SideBarArrow />
         <BackgroundDom />
-        <div style={bgImg} class="h-full w-full" class:max-w-6xl={DBState.db.classicMaxWidth}>
+        <div style={bgImg} class="h-full w-full" style:max-width={getMaxWidth()}>
             {#if $selectedCharID >= 0}
                 {#if DBState.db.characters[$selectedCharID].viewScreen !== 'none' && (DBState.db.characters[$selectedCharID].type === 'group' || (!DBState.db.characters[$selectedCharID].inlayViewScreen))}
                     <ResizeBox />

--- a/src/lib/ChatScreens/ChatScreen.svelte
+++ b/src/lib/ChatScreens/ChatScreen.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getCustomBackground, getEmotion, getMaxWidth } from "../../ts/util";
+    import { getCustomBackground, getEmotion } from "../../ts/util";
     
     import { DBState } from 'src/ts/stores.svelte';
     import { CharEmotion, selectedCharID } from "../../ts/stores.svelte";
@@ -11,6 +11,7 @@
     import BackgroundDom from "./BackgroundDom.svelte";
     import SideBarArrow from "../UI/GUI/SideBarArrow.svelte";
     import ModuleChatMenu from "../Setting/Pages/Module/ModuleChatMenu.svelte";
+  import { getMaxWidth } from "src/ts/chatWidth";
     let openChatList = $state(false)
     let openModuleList = $state(false)
 

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -674,16 +674,19 @@
                     </button>
                 {/if}
                 {#if DBState.db.characters[$selectedCharID]?.chaId !== '§playground'}
-                    <button
+                        <button
                             onclick={(e) => {
-                            openMenu = !openMenu
-                            e.stopPropagation()
-                        }}
+                                openMenu = !openMenu
+                                e.stopPropagation()
+                            }}
                             class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
                             style:height={inputHeight}
-                    >
-                        <MenuIcon />
-                    </button>
+                        >
+                            <MenuIcon />
+                        </button>
+                        {#if openMenu}
+                            {@render chatMenu()}
+                        {/if}
                 {:else}
                     <div onclick={(e) => {
                         DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.push({
@@ -892,8 +895,8 @@
 
             {/if}
 
-            {#if openMenu}
-                <div class="{DBState.db.fixedChatTextarea ? 'fixed' : 'absolute'} right-2 bottom-16 p-5 bg-darkbg flex flex-col gap-3 text-textcolor rounded-md" onclick={(e) => {
+            {#snippet chatMenu()}
+                <div class="absolute right-2 bottom-16 p-5 bg-darkbg flex flex-col gap-3 text-textcolor rounded-md" onclick={(e) => {
                     e.stopPropagation()
                 }}>
                     {#if DBState.db.characters[$selectedCharID].type === 'group'}
@@ -1043,7 +1046,7 @@
                     {/if}
                 </div>
 
-            {/if}
+            {/snippet}
         </div>
 
     {/if}

--- a/src/ts/chatWidth.ts
+++ b/src/ts/chatWidth.ts
@@ -1,0 +1,36 @@
+import { DBState } from "./storage/databaseState.svelte"
+
+export enum ChatWidthPreset {
+    Unlimited = -1,
+    Small = 0,
+    Normal = 1,
+    Huge = 2,
+}
+
+interface ChatWidthPresetInfo {
+    label: string
+    maxWidth: string
+}
+
+export const CHAT_WIDTH_PRESET_INFO: Record<ChatWidthPreset, ChatWidthPresetInfo> = {
+    [ChatWidthPreset.Unlimited]: {
+        label: 'Unlimited',
+        maxWidth: '100%',
+    },
+    [ChatWidthPreset.Small]: {
+        label: 'Small',
+        maxWidth: '600px'
+    },
+    [ChatWidthPreset.Normal]: {
+        label: 'Normal',
+        maxWidth: '800px'
+    },
+    [ChatWidthPreset.Huge]: {
+        label: 'Huge',
+        maxWidth: '1200px'
+    }
+}
+
+export function getMaxWidth(): string {
+    return CHAT_WIDTH_PRESET_INFO[DBState.db.chatLimitSize].maxWidth
+}

--- a/src/ts/setting/displaySettingsData.svelte.ts
+++ b/src/ts/setting/displaySettingsData.svelte.ts
@@ -141,6 +141,33 @@ export const displayThemeSettingsItems: SettingItem[] = [
 
 export const displaySizeSettingsItems: SettingItem[] = [
     {
+        id: 'display.chatLimitSize',
+        type: 'slider',
+        labelKey: 'chatLimitSize',
+        bindKey: 'chatLimitSize',
+        options: {
+            min: -1,
+            max: 2,
+            step: 1,
+            customText: (value) => {
+               switch (value) {
+                    case -1:
+                        return "Unlimited"
+                    case 0:
+                        return "Small"
+                    case 1:
+                        return "Normal"
+                    case 2:
+                        return "Huge"
+                    default:
+                        return "Unlimited"
+                    
+                }
+            }
+        },
+        keywords: ['chat', 'size', 'limit'],
+    },
+    {
         id: 'display.zoomsize',
         type: 'slider',
         labelKey: 'UISize',

--- a/src/ts/setting/displaySettingsData.svelte.ts
+++ b/src/ts/setting/displaySettingsData.svelte.ts
@@ -10,6 +10,7 @@ import { updateAnimationSpeed } from '../gui/animation';
 import { guiSizeText, updateGuisize } from '../gui/guisize';
 import { updateTextThemeAndCSS } from '../gui/colorscheme';
 import { CustomGUISettingMenuStore } from '../stores.svelte';
+import { CHAT_WIDTH_PRESET_INFO, ChatWidthPreset } from '../chatWidth';
 
 export const displayThemeSettingsItems: SettingItem[] = [
     {
@@ -149,21 +150,7 @@ export const displaySizeSettingsItems: SettingItem[] = [
             min: -1,
             max: 2,
             step: 1,
-            customText: (value) => {
-               switch (value) {
-                    case -1:
-                        return "Unlimited"
-                    case 0:
-                        return "Small"
-                    case 1:
-                        return "Normal"
-                    case 2:
-                        return "Huge"
-                    default:
-                        return "Unlimited"
-                    
-                }
-            }
+            customText: (value) => CHAT_WIDTH_PRESET_INFO[value as ChatWidthPreset]?.label ?? CHAT_WIDTH_PRESET_INFO[ChatWidthPreset.Unlimited].label
         },
         keywords: ['chat', 'size', 'limit'],
     },

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -386,6 +386,7 @@ export function setDatabase(data:Database){
     data.nanogptUseSubscriptionEndpoint ??= false
     data.NAIsettings ??= safeStructuredClone(prebuiltNAIpresets)
     data.assetWidth ??= -1
+    data.chatLimitSize ??= -1
     data.animationSpeed ??= 0.4
     data.colorScheme ??= safeStructuredClone(defaultColorScheme)
     data.colorSchemeName ??= 'default'
@@ -954,6 +955,7 @@ export interface Database{
     personas:RisuPersona[]
     personaNote:boolean
     assetWidth:number
+    chatLimitSize: number
     animationSpeed:number
     botSettingAtStart:false
     NAIsettings:NAISettings

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -387,7 +387,7 @@ export function setDatabase(data:Database){
     data.nanogptUseSubscriptionEndpoint ??= false
     data.NAIsettings ??= safeStructuredClone(prebuiltNAIpresets)
     data.assetWidth ??= -1
-    data.chatLimitSize ??= -1
+    data.chatLimitSize ??= ChatWidthPreset.Unlimited
     data.animationSpeed ??= 0.4
     data.colorScheme ??= safeStructuredClone(defaultColorScheme)
     data.colorSchemeName ??= 'default'
@@ -957,7 +957,7 @@ export interface Database{
     personas:RisuPersona[]
     personaNote:boolean
     assetWidth:number
-    chatLimitSize: number
+    chatLimitSize: ChatWidthPreset
     animationSpeed:number
     botSettingAtStart:false
     NAIsettings:NAISettings
@@ -2289,6 +2289,7 @@ import type { SerializableHypaV3Data } from '../process/memory/hypav3';
 import { defaultHotkeys, type Hotkey } from '../defaulthotkeys';
 import type { OpenAIChat } from '../process/index.svelte';
 import type { Loadout } from '../loadout';
+import { ChatWidthPreset } from '../chatWidth';
 
 export async function downloadPreset(id:number, type:'json'|'risupreset'|'return' = 'json'){
     saveCurrentPreset()

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -373,6 +373,7 @@ export function setDatabase(data:Database){
         note: data.userNote,
         largePortrait: false
     }]
+    // Legacy option no longer in use
     data.classicMaxWidth ??= false
     data.ooba ??= safeStructuredClone(defaultOoba)
     data.ainconfig ??= safeStructuredClone(defaultAIN)
@@ -930,6 +931,7 @@ export interface Database{
         useSync?:boolean
         kei?:boolean
     },
+    // Legacy option no longer in use
     classicMaxWidth: boolean,
     useChatSticker:boolean,
     useAdditionalAssetsPreview:boolean,

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -1335,3 +1335,26 @@ export function base64url(source: Uint8Array | ArrayBuffer): string {
         .replace(/\//g, "_");
     return encodedSource;
 }
+
+export function getMaxWidth(): string {
+        switch (DBState.db.chatLimitSize) {
+            //Unlimited
+            case -1:
+                return '100%'
+            
+            //Small
+            case 0:
+               return '600px'
+
+            //Normal
+            case 1:
+                return '800px'
+            
+            //Huge
+            case 2:
+               return '1200px'
+            
+            default:
+                return '100%'
+        }
+    }

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -1335,26 +1335,3 @@ export function base64url(source: Uint8Array | ArrayBuffer): string {
         .replace(/\//g, "_");
     return encodedSource;
 }
-
-export function getMaxWidth(): string {
-        switch (DBState.db.chatLimitSize) {
-            //Unlimited
-            case -1:
-                return '100%'
-            
-            //Small
-            case 0:
-               return '600px'
-
-            //Normal
-            case 1:
-                return '800px'
-            
-            //Huge
-            case 2:
-               return '1200px'
-            
-            default:
-                return '100%'
-        }
-    }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [ ] Have you tested your changes?
    - [ ] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

In Display & Audio > Size and Speed, add the new option "Chat Width Size."
<img width="1218" height="120" alt="image" src="https://github.com/user-attachments/assets/70cd08c2-1d8b-4873-9afe-13c21cfb5082" />
This option can help make it easier to read in desktop environments (generally when using widescreen displays).



<table>
  <tr align="center">
    <td><img width="2784" height="1556" alt="스크린샷_20260802_062759" src="https://github.com/user-attachments/assets/480a1eed-6e34-439f-8fbf-f55f80165681" /> </td>
    <td><img width="2784" height="1556" alt="스크린샷_20260802_062810" src="https://github.com/user-attachments/assets/c3f1221e-964a-4e04-b1e6-4492f6d2ca58" /></td>
  </tr>
  <tr align="center">
    <td>Unlimited</td>
    <td>Small</td>
  </tr>
  <tr align="center">
    <td>
<img width="2784" height="1556" alt="스크린샷_20260802_062817" src="https://github.com/user-attachments/assets/7081dc52-15b5-4783-99e2-fed67170189e" />

</td>
    <td>
<img width="2784" height="1556" alt="스크린샷_20260802_062824" src="https://github.com/user-attachments/assets/1cbfdc52-b208-4256-b6e5-eedc87fb0411" />

</td>
  </tr>
  <tr align="center">
    <td>Normal</td>
    <td>Huge</td>
  </tr>
</table>

## Related Issues

None

## Changes

Adds configurable `chatLimitSize` option to control chat container max width, with presets for unlimited, small (600px), normal (800px), and huge (1200px) to let users customize chat layout. Includes English and Korean translations, registers the setting in display size options, implements width application logic in the Chat component, and updates style attributes to use Svelte style directives for improved reactivity.

## Impact

The default value is set to Unlimited, so it has little impact on users and only affects them when they change the option.

## Additional Notes

I'm reviewing compatibility, and it's currently in draft PR status.