### PR TITLE
fix(hypav3): derive summary progress from all linked chats

### DIFF
--- a/src/ts/process/memory/contextualEmbeddingCache.test.ts
+++ b/src/ts/process/memory/contextualEmbeddingCache.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+    createContextualChunkCacheKey,
+    mapContextualChunkEmbeddings,
+} from "./contextualEmbeddingCache";
+
+describe("mapContextualChunkEmbeddings", () => {
+    it("keeps identical text associated with distinct chunk objects", () => {
+        const firstChunk = { text: "He closed the door.", summaryId: "first" };
+        const secondChunk = { text: "He closed the door.", summaryId: "second" };
+
+        const vectors = mapContextualChunkEmbeddings(
+            [firstChunk, secondChunk],
+            [[1, 0], [0, 1]]
+        );
+
+        expect(vectors.get(firstChunk)?.embedding).toEqual([1, 0]);
+        expect(vectors.get(secondChunk)?.embedding).toEqual([0, 1]);
+        expect(vectors.size).toBe(2);
+    });
+
+    it("rejects provider responses with a mismatched embedding count", () => {
+        const chunks = [{ text: "first" }, { text: "second" }];
+
+        expect(() => mapContextualChunkEmbeddings(chunks, [[1, 0]])).toThrow(
+            "Contextual embedding count mismatch: expected 2, received 1"
+        );
+    });
+});
+
+describe("createContextualChunkCacheKey", () => {
+    it("distinguishes repeated text by its position in the context group", () => {
+        const suffix = "|voyageContext3|ctx:example";
+
+        const first = createContextualChunkCacheKey("Repeated line", suffix, 0);
+        const second = createContextualChunkCacheKey("Repeated line", suffix, 1);
+
+        expect(first).not.toBe(second);
+    });
+
+    it("distinguishes the same text and position across different contexts", () => {
+        const first = createContextualChunkCacheKey(
+            "Repeated line",
+            "|voyageContext3|ctx:first",
+            0
+        );
+        const second = createContextualChunkCacheKey(
+            "Repeated line",
+            "|voyageContext3|ctx:second",
+            0
+        );
+
+        expect(first).not.toBe(second);
+    });
+
+    it("is stable for the same text, context, and position", () => {
+        const args = ["Repeated line", "|voyageContext3|ctx:example", 3] as const;
+
+        expect(createContextualChunkCacheKey(...args)).toBe(
+            createContextualChunkCacheKey(...args)
+        );
+    });
+
+    it("rejects invalid chunk positions", () => {
+        expect(() =>
+            createContextualChunkCacheKey("text", "|voyageContext3", -1)
+        ).toThrow("Invalid contextual chunk index: -1");
+    });
+});

--- a/src/ts/process/memory/contextualEmbeddingCache.ts
+++ b/src/ts/process/memory/contextualEmbeddingCache.ts
@@ -7,6 +7,24 @@ export interface ContextualMemoryVector {
     embedding: number[] | Float32Array;
 }
 
+export const CONTEXTUAL_CHUNK_CACHE_VERSION = 2;
+
+/**
+ * Includes the chunk position because Voyage contextual embeddings may differ
+ * for repeated text at different positions inside the same context group.
+ */
+export function createContextualChunkCacheKey(
+    text: string,
+    providerCacheKeySuffix: string,
+    chunkIndex: number
+): string {
+    if (!Number.isSafeInteger(chunkIndex) || chunkIndex < 0) {
+        throw new Error(`Invalid contextual chunk index: ${chunkIndex}`);
+    }
+
+    return `${text}${providerCacheKeySuffix}|chunk-cache-v${CONTEXTUAL_CHUNK_CACHE_VERSION}|index:${chunkIndex}`;
+}
+
 /**
  * Associates contextual embeddings with the exact chunk objects that produced
  * them. Chunk identity must be preserved because identical text can receive

--- a/src/ts/process/memory/contextualEmbeddingCache.ts
+++ b/src/ts/process/memory/contextualEmbeddingCache.ts
@@ -1,0 +1,35 @@
+export interface ContextualChunkLike {
+    text: string;
+}
+
+export interface ContextualMemoryVector {
+    content: string;
+    embedding: number[] | Float32Array;
+}
+
+/**
+ * Associates contextual embeddings with the exact chunk objects that produced
+ * them. Chunk identity must be preserved because identical text can receive
+ * different embeddings in different contexts.
+ */
+export function mapContextualChunkEmbeddings<TChunk extends ContextualChunkLike>(
+    chunks: readonly TChunk[],
+    embeddings: readonly (number[] | Float32Array)[]
+): Map<TChunk, ContextualMemoryVector> {
+    if (chunks.length !== embeddings.length) {
+        throw new Error(
+            `Contextual embedding count mismatch: expected ${chunks.length}, received ${embeddings.length}`
+        );
+    }
+
+    const vectors = new Map<TChunk, ContextualMemoryVector>();
+    for (let index = 0; index < chunks.length; index++) {
+        const chunk = chunks[index];
+        vectors.set(chunk, {
+            content: chunk.text,
+            embedding: embeddings[index],
+        });
+    }
+
+    return vectors;
+}

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1,5 +1,6 @@
 import { type memoryVector, HypaProcesser, similarity } from "./hypamemory";
 import { isContextModel, getContextProvider } from "./contextualEmbedding";
+import { mapContextualChunkEmbeddings } from "./contextualEmbeddingCache";
 import { TaskRateLimiter } from "./taskRateLimiter";
 import {
     type EmbeddingText,
@@ -1962,25 +1963,25 @@ class HypaProcesserEx extends HypaProcesser {
         }
 
         const groupsToEmbed: SummaryChunk[][] = [];
-        const cachedVectors = new Map<string, memoryVector>();
+        const cachedVectors = new Map<SummaryChunk, memoryVector>();
 
         for (const [, group] of summaryGroups) {
             const groupTexts = group.map(c => c.text);
             let allCached = true;
-            const groupCache = new Map<string, memoryVector>();
+            const groupCache = new Map<SummaryChunk, memoryVector>();
 
             for (const chunk of group) {
                 const cached: memoryVector = await this.forage.getItem(cacheKeyFor(chunk.text, groupTexts));
                 if (cached) {
-                    groupCache.set(chunk.text, cached);
+                    groupCache.set(chunk, cached);
                 } else {
                     allCached = false;
                 }
             }
 
             if (allCached) {
-                for (const [text, vector] of groupCache) {
-                    cachedVectors.set(text, vector);
+                for (const [chunk, vector] of groupCache) {
+                    cachedVectors.set(chunk, vector);
                 }
             } else {
                 groupsToEmbed.push(group);
@@ -1997,24 +1998,25 @@ class HypaProcesserEx extends HypaProcesser {
             for (let i = 0; i < groupsToEmbed.length; i++) {
                 const group = groupsToEmbed[i];
                 const groupTexts = group.map(c => c.text);
-                const embeddings = results[i];
+                const embeddings = results[i] ?? [];
+                const groupVectors = mapContextualChunkEmbeddings(group, embeddings);
 
-                for (let j = 0; j < group.length; j++) {
-                    const chunk = group[j];
-                    const embedding = embeddings[j];
-                    const vector: memoryVector = {
-                        content: chunk.text,
-                        embedding
-                    };
+                for (const chunk of group) {
+                    const vector = groupVectors.get(chunk);
+                    if (!vector) {
+                        throw new Error(
+                            `Failed to map contextual vector for summary chunk:\n${chunk.text}`
+                        );
+                    }
 
                     await this.forage.setItem(cacheKeyFor(chunk.text, groupTexts), vector);
-                    cachedVectors.set(chunk.text, vector);
+                    cachedVectors.set(chunk, vector);
                 }
             }
         }
 
         for (const chunk of chunks) {
-            const vector = cachedVectors.get(chunk.text);
+            const vector = cachedVectors.get(chunk);
             if (!vector) {
                 throw new Error(
                     `Failed to create vector for summary chunk:\n${chunk.text}`

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1,6 +1,9 @@
 import { type memoryVector, HypaProcesser, similarity } from "./hypamemory";
 import { isContextModel, getContextProvider } from "./contextualEmbedding";
-import { mapContextualChunkEmbeddings } from "./contextualEmbeddingCache";
+import {
+    createContextualChunkCacheKey,
+    mapContextualChunkEmbeddings,
+} from "./contextualEmbeddingCache";
 import { TaskRateLimiter } from "./taskRateLimiter";
 import {
     type EmbeddingText,
@@ -1951,8 +1954,12 @@ class HypaProcesserEx extends HypaProcesser {
     private async addSummaryChunksContextual(chunks: SummaryChunk[]): Promise<void> {
         const provider = getContextProvider(this.model);
 
-        const cacheKeyFor = (text: string, groupTexts: string[]) => {
-            return `${text}${provider.getCacheKeySuffix(groupTexts)}`;
+        const cacheKeyFor = (text: string, groupTexts: string[], chunkIndex: number) => {
+            return createContextualChunkCacheKey(
+                text,
+                provider.getCacheKeySuffix(groupTexts),
+                chunkIndex
+            );
         };
 
         const summaryGroups = new Map<Summary, SummaryChunk[]>();
@@ -1970,8 +1977,11 @@ class HypaProcesserEx extends HypaProcesser {
             let allCached = true;
             const groupCache = new Map<SummaryChunk, memoryVector>();
 
-            for (const chunk of group) {
-                const cached: memoryVector = await this.forage.getItem(cacheKeyFor(chunk.text, groupTexts));
+            for (let chunkIndex = 0; chunkIndex < group.length; chunkIndex++) {
+                const chunk = group[chunkIndex];
+                const cached: memoryVector = await this.forage.getItem(
+                    cacheKeyFor(chunk.text, groupTexts, chunkIndex)
+                );
                 if (cached) {
                     groupCache.set(chunk, cached);
                 } else {
@@ -2001,7 +2011,8 @@ class HypaProcesserEx extends HypaProcesser {
                 const embeddings = results[i] ?? [];
                 const groupVectors = mapContextualChunkEmbeddings(group, embeddings);
 
-                for (const chunk of group) {
+                for (let chunkIndex = 0; chunkIndex < group.length; chunkIndex++) {
+                    const chunk = group[chunkIndex];
                     const vector = groupVectors.get(chunk);
                     if (!vector) {
                         throw new Error(
@@ -2009,7 +2020,10 @@ class HypaProcesserEx extends HypaProcesser {
                         );
                     }
 
-                    await this.forage.setItem(cacheKeyFor(chunk.text, groupTexts), vector);
+                    await this.forage.setItem(
+                        cacheKeyFor(chunk.text, groupTexts, chunkIndex),
+                        vector
+                    );
                     cachedVectors.set(chunk, vector);
                 }
             }


### PR DESCRIPTION
## PR Checklist

- Required Checks
  - [x] Have you added type definitions?
  - [x] Have you tested your changes?
  - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
  - [x] Have you checked if it works normally in all models?
  - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
  - [x] Have you understood what the code does?
  - [x] Have you cleaned up any unnecessary or redundant code?
  - [x] Is it not a huge change?
    - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This fixes an issue in HypaMemory V3's contextual embedding path where chunks with the same text could end up sharing the wrong vector.

Contextual embedding models can return different vectors for the same sentence depending on the surrounding summary. However, the results were temporarily stored using only the chunk text as the key. Because of that, when the same sentence appeared in multiple summaries, the later result could overwrite the earlier one.

The vectors are now tied directly to the chunk objects they were generated for, so identical text from different contexts remains separate.

## Related Issues

None.

## Changes

The temporary vector mapping now uses the actual `SummaryChunk` instead of its text.

I also updated the persistent cache key to include the chunk's position within the context. This handles another similar case where the same sentence appears more than once inside a single summary.

The cache key format has been versioned as `chunk-cache-v2`, so older entries created with the ambiguous format will not be reused. They will be regenerated normally when needed.

There is also an additional check for embedding provider responses. If the provider returns a different number of vectors than the number of input chunks, the operation now fails with an explicit error instead of silently connecting the wrong vectors.

Regression tests were added for duplicate text across different summaries, repeated text within one summary, context separation, invalid indices, and mismatched embedding response lengths.

## Impact

This should improve memory retrieval accuracy when using contextual embedding providers such as Voyage Context 3.

Previously, a chunk could receive a vector generated for the same text in a different context. That could change its similarity score and, in some cases, cause HypaMemory V3 to retrieve an unrelated summary.

The non-contextual embedding paths are not changed by this PR.

Existing contextual cache entries are not deleted. Since the new cache keys no longer match the previous format, affected embeddings will simply be regenerated when they are used again. The old entries may remain until the vector cache is cleared through the existing cleanup process.

The change is limited to shared TypeScript logic and does not add separate behavior for web, local, or node-hosted environments.

## Additional Notes

The regression tests are located in:

`src/ts/process/memory/contextualEmbeddingCache.test.ts`