### PR TITLE
perf: avoid full database snapshot for plugin storage reads

### DIFF
--- a/src/ts/plugins/plugins.svelte.ts
+++ b/src/ts/plugins/plugins.svelte.ts
@@ -727,9 +727,8 @@ export const getV2PluginAPIs = () => {
         },
         pluginStorage: {
             getItem: (key: string) => {
-                const db = getDatabase({ snapshot: true });
-                db.pluginCustomStorage ??= {}
-                return db.pluginCustomStorage[key] || null;
+                const value = getDatabase().pluginCustomStorage?.[key];
+                return value ? $state.snapshot(value) : null;
             },
             setItem: (key: string, value: string) => {
                 const db = getDatabase();


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`pluginStorage.getItem()` was snapshotting the entire database before reading a single value from `pluginCustomStorage`. This changes the read path so only the requested value is snapshotted.

For users with large databases, plugin storage reads no longer need to copy unrelated characters, chats, presets, and other database state just to return one plugin value.

## Related Issues

None

## Changes

- Read the requested `pluginCustomStorage` key directly from the live database.
- Apply `$state.snapshot()` only to the requested value instead of the complete database.
- Keep the existing return behavior for falsy or missing values.
- Keep object and array results detached from the live database state, so plugins do not receive the database proxy itself.

## Impact

There is no database format change and no intended plugin API behavior change. The main difference is the amount of data copied during `pluginStorage.getItem()`: the work now scales with the requested stored value instead of the size of the whole database.

This should mainly benefit long-term users with large character and chat histories, especially when plugins read their storage frequently.

## Additional Notes

This does not change model prompting or response handling. The type-definition checklist item is not applicable because the public API signature is unchanged.

Tested with dummy plugin. [plugin-storage-value-snapshot-test.js](https://github.com/user-attachments/files/30848058/plugin-storage-value-snapshot-test.js)
