### PR TITLE
perf: avoid unnecessary database snapshots in account sync checks

### DIFF
--- a/src/ts/storage/autoStorage.test.ts
+++ b/src/ts/storage/autoStorage.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    accountGetItem: vi.fn(),
+    alertSelect: vi.fn(),
+    getDatabase: vi.fn(),
+}))
+
+vi.mock('localforage', () => ({
+    default: {
+        clear: vi.fn(),
+        createInstance: vi.fn(),
+    },
+}))
+
+vi.mock('../globalApi.svelte', () => ({
+    replaceDbResources: vi.fn((db) => db),
+}))
+
+vi.mock('src/ts/platform', () => ({
+    isNodeServer: false,
+}))
+
+vi.mock('./nodeStorage', () => ({
+    NodeStorage: class {},
+}))
+
+vi.mock('./opfsStorage', () => ({
+    OpfsStorage: class {},
+}))
+
+vi.mock('../alert', () => ({
+    alertError: vi.fn(),
+    alertInput: vi.fn(),
+    alertSelect: mocks.alertSelect,
+    alertStore: { set: vi.fn() },
+}))
+
+vi.mock('./database.svelte', () => ({
+    getDatabase: mocks.getDatabase,
+}))
+
+vi.mock('./accountStorage', () => ({
+    AccountStorage: class {
+        getItem = mocks.accountGetItem
+        setItem = vi.fn()
+    },
+}))
+
+vi.mock('./risuSave', () => ({
+    decodeRisuSave: vi.fn(),
+    encodeRisuSaveLegacy: vi.fn(),
+}))
+
+vi.mock('src/lang', () => ({
+    language: {
+        loadDataFromAccount: 'Load from account',
+        saveCurrentDataToAccount: 'Save current data to account',
+    },
+}))
+
+import { AutoStorage } from './autoStorage'
+
+function makeStorage() {
+    const storage = new AutoStorage()
+    storage.realStorage = {
+        keys: vi.fn().mockResolvedValue([]),
+    } as any
+    return storage
+}
+
+beforeEach(() => {
+    localStorage.clear()
+    mocks.accountGetItem.mockReset()
+    mocks.alertSelect.mockReset()
+    mocks.getDatabase.mockReset()
+})
+
+describe('AutoStorage.checkAccountSync', () => {
+    it('does not read or snapshot the database when sync is explicitly avoided', async () => {
+        localStorage.setItem('dosync', 'avoid')
+        const storage = makeStorage()
+
+        await expect(storage.checkAccountSync()).resolves.toBe(false)
+
+        expect(mocks.getDatabase).not.toHaveBeenCalled()
+    })
+
+    it('restores account storage without reading the database when account sync is already active', async () => {
+        localStorage.setItem('accountst', 'able')
+        const storage = makeStorage()
+
+        await expect(storage.checkAccountSync()).resolves.toBe(false)
+
+        expect(storage.isAccount).toBe(true)
+        expect(mocks.getDatabase).not.toHaveBeenCalled()
+    })
+
+    it('checks the live account flag without snapshotting when sync is disabled', async () => {
+        mocks.getDatabase.mockReturnValue({ account: { useSync: false } })
+        const storage = makeStorage()
+
+        await expect(storage.checkAccountSync()).resolves.toBe(false)
+
+        expect(mocks.getDatabase).toHaveBeenCalledTimes(1)
+        expect(mocks.getDatabase).toHaveBeenCalledWith()
+        expect(mocks.getDatabase).not.toHaveBeenCalledWith({ snapshot: true })
+    })
+
+    it('creates a snapshot only after account sync is selected', async () => {
+        const liveDb = { account: { useSync: true } }
+        const snapshotDb = { account: { useSync: true, token: 'snapshot' } }
+        mocks.getDatabase.mockImplementation((options) => options?.snapshot ? snapshotDb : liveDb)
+        mocks.accountGetItem.mockResolvedValue(new Uint8Array([1]))
+        mocks.alertSelect.mockResolvedValue('0')
+        const storage = makeStorage()
+
+        await expect(storage.checkAccountSync()).resolves.toBe(true)
+
+        expect(mocks.getDatabase.mock.calls).toEqual([
+            [],
+            [{ snapshot: true }],
+        ])
+    })
+})

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -38,14 +38,26 @@ export class AutoStorage{
     }
 
     async checkAccountSync(){
-        let db = getDatabase({ snapshot: true })
         if(this.isAccount){
             return true
         }
-        if(localStorage.getItem('dosync') === 'avoid'){
+
+        const syncMode = localStorage.getItem('dosync')
+        if(syncMode === 'avoid'){
             return false
         }
-        if((localStorage.getItem('dosync') === 'sync' || db?.account?.useSync) && (localStorage.getItem('accountst') !== 'able')){
+
+        const accountState = localStorage.getItem('accountst')
+        if(accountState === 'able'){
+            localStorage.setItem('accountst', 'able')
+            this.realStorage = new AccountStorage()
+            this.isAccount = true
+            return false
+        }
+
+        const shouldSync = syncMode === 'sync' || getDatabase().account?.useSync
+        if(shouldSync){
+            const db = getDatabase({ snapshot: true })
             const keys = (await this.realStorage.keys()).filter((key) => {
                 return key !== 'database/database.bin'
                     && !key.startsWith('coldstorage/')
@@ -153,11 +165,6 @@ export class AutoStorage{
             this.isAccount = true
             await localforage.clear()
             return true
-        }
-        else if(localStorage.getItem('accountst') === 'able'){
-            localStorage.setItem('accountst', 'able')
-            this.realStorage = new AccountStorage()
-            this.isAccount = true
         }
         return false
     }


### PR DESCRIPTION

## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`checkAccountSync()` currently snapshots the whole database before it knows whether account sync is needed. This is especially wasteful for long-running users with large character and chat databases, because the common sync-disabled path still pays the cost of copying the full database.

This change moves the full snapshot into the actual sync migration path. The normal check now reads only the live `account.useSync` flag, while the existing stable snapshot is still kept once migration really begins.

## Related Issues

None

## Changes

`checkAccountSync()` now handles the cheap early-exit conditions first and caches the relevant localStorage values for the rest of the check. When sync is disabled, it reads `account.useSync` from the live database without creating a full snapshot. A `{ snapshot: true }` database copy is created only after the function has decided to enter the account migration path.

Regression tests cover the explicit opt-out path, the normal sync-disabled path, and the sync-enabled path to make sure the snapshot stays deferred.

## Impact

There should be no change to account sync behavior or to the data used during migration. The migration path still receives a stable full database snapshot before asynchronous migration work starts.

The main difference is that users who are not syncing no longer copy the entire database just to check whether sync is enabled. The benefit grows with database size and should reduce avoidable startup CPU and memory pressure for long-running users.

## Additional Notes

This intentionally keeps the existing `accountst === 'able'` storage switch and the return semantics of `checkAccountSync()`. That cheap state check is only moved ahead of database access.