### PR TITLE
perf: avoid cloning full chat history for reroll snapshots

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -313,7 +313,7 @@
                 continue:continued
             })
             if(previousLength < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
-                rerolls.push(safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message).slice(previousLength))
+                rerolls.push(safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.slice(previousLength)))
                 rerollid = rerolls.length - 1
             }
         } catch (error) {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This changes the reroll snapshot path so it slices out only the newly appended messages before deep-cloning them.

Previously, a successful generation cloned the entire current chat and then discarded everything before `previousLength`. On long-running chats, that meant reroll bookkeeping could temporarily copy a large amount of old message data even though only the new messages were kept.

## Related Issues

None

## Changes

Changed the reroll snapshot from `clone(all messages) -> slice(new messages)` to `slice(new messages) -> clone(new messages)`.

The stored reroll data is unchanged in shape and still contains the messages appended after `previousLength`; the difference is that older messages are no longer deep-cloned just to be discarded immediately afterward.

## Impact

This should reduce temporary CPU and memory work when generating in long chats, especially when the chat contains many messages or messages with larger nested metadata.

There is no save-format change and no intended change to reroll behavior. Short chats should see little practical difference.

## Additional Notes

This is intentionally kept as a small, isolated optimization rather than introducing a new helper or changing the broader reroll flow.

Validation: `pnpm check` (0 errors and 0 warnings), plus `git diff --check`.
