### PR TITLE
perf: optimize checkCharOrder lookups with Set

### DIFF
--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -1124,28 +1124,28 @@ export function replaceDbResources(db: Database, replacer: { [key: string]: stri
  */
 export function checkCharOrder() {
     DBState.db.characterOrder = DBState.db.characterOrder ?? []
-    let ordered = []
+    const ordered = new Set<string>()
     for (let i = 0; i < DBState.db.characterOrder.length; i++) {
         const folder = DBState.db.characterOrder[i]
         if (typeof (folder) !== 'string' && folder) {
             for (const f of folder.data) {
-                ordered.push(f)
+                ordered.add(f)
             }
         }
         if (typeof (folder) === 'string') {
-            ordered.push(folder)
+            ordered.add(folder)
         }
     }
 
-    let charIdList: string[] = []
+    const charIdSet = new Set<string>()
 
     for (let i = 0; i < DBState.db.characters.length; i++) {
         const char = DBState.db.characters[i]
         const charId = char.chaId
         if (!char.trashTime) {
-            charIdList.push(charId)
+            charIdSet.add(charId)
         }
-        if (!ordered.includes(charId)) {
+        if (!ordered.has(charId)) {
             if (charId !== '§temp' && charId !== '§playground' && !char.trashTime) {
                 DBState.db.characterOrder.push(charId)
             }
@@ -1168,7 +1168,7 @@ export function checkCharOrder() {
             }
             for (let i2 = 0; i2 < data.data.length; i2++) {
                 const data2 = data.data[i2]
-                if (!charIdList.includes(data2)) {
+                if (!charIdSet.has(data2)) {
                     data.data.splice(i2, 1)
                     i2--;
                 }
@@ -1176,7 +1176,7 @@ export function checkCharOrder() {
             DBState.db.characterOrder[i] = data
         }
         else {
-            if (!charIdList.includes(data)) {
+            if (!charIdSet.has(data)) {
                 DBState.db.characterOrder.splice(i, 1)
                 i--;
             }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`checkCharOrder()` currently uses repeated `Array.includes()` calls while matching character IDs against the current order. This is fine for small collections, but the repeated linear scans become unnecessary work as the character list grows.

This PR changes those temporary membership lists to `Set`s so the same checks can use `Set.has()` instead.

## Related Issues

None

## Changes

The temporary `ordered` and character ID lookup collections in `checkCharOrder()` are now `Set<string>` instances. The existing ordering, folder cleanup, trash handling, and special handling for `§temp` / `§playground` are left unchanged.

The current behavior where IDs appended to `characterOrder` during the function are not added back to the initial `ordered` lookup set is also preserved. This keeps the change focused on lookup cost rather than changing any edge-case behavior.

## Impact

There are no database format or API changes. Normal users should see no behavioral difference. The main benefit is avoiding repeated linear membership scans for users with larger character collections or folder structures.

## Additional Notes

The original and updated logic were compared over 50,000 randomized input cases, including duplicate IDs, trashed characters, folders, empty/null order entries, and the special temporary character IDs. The resulting database structure matched in every case.

`pnpm check` completes with no errors or warnings. No model/request behavior is touched by this PR, and no new type definitions are required.
