### PR TITLE
fix: keep database proxy bookkeeping out of Svelte reaction tracking

### DIFF
--- a/src/ts/storage/databaseState.svelte.test.ts
+++ b/src/ts/storage/databaseState.svelte.test.ts
@@ -48,6 +48,53 @@ describe('database proxy layering', () => {
         unsubscribe()
     })
 
+    it('treats plain data descriptors like assignments and connects retained children', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 0 } } }))
+        const storage = DBState.db.pluginCustomStorage
+        const retained = storage.retained
+        delete storage.retained
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        try {
+            storage.defined = retained
+            const assignmentEvent = listener.mock.calls[0][0]
+            delete storage.defined
+            listener.mockClear()
+
+            Object.defineProperty(storage, 'defined', { value: retained })
+
+            expect(listener).toHaveBeenCalledTimes(1)
+            expect(listener.mock.calls[0][0]).toEqual(assignmentEvent)
+            listener.mockClear()
+            retained.value = 1
+            expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+                path: ['pluginCustomStorage', 'defined', 'value'],
+                value: 1,
+                oldValue: 0,
+                type: 'set',
+            }))
+        } finally {
+            unsubscribe()
+        }
+    })
+
+    it('rejects accessor descriptors without changing database state', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { value: 1 } }))
+        const storage = DBState.db.pluginCustomStorage
+        const listener = vi.fn()
+        const unsubscribe = onDatabaseUpdate(listener)
+
+        try {
+            expect(() => Object.defineProperty(storage, 'value', { get: () => 2 }))
+                .toThrowError(/state_descriptors_fixed/)
+            expect(storage.value).toBe(1)
+            expect(listener).not.toHaveBeenCalled()
+        } finally {
+            unsubscribe()
+        }
+    })
+
     it('keeps Svelte reactivity outside the database proxy', () => {
         setDatabaseLite(database({ username: 'before' }))
         let observed = ''
@@ -63,6 +110,72 @@ describe('database proxy layering', () => {
 
         expect(observed).toBe('after')
         dispose()
+    })
+
+    it('does not track reads performed by proxy writes inside effects', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { plugin: { list: [] } } }))
+        let runs = 0
+        const dispose = $effect.root(() => {
+            $effect(() => {
+                runs++
+                if (DBState.db.pluginCustomStorage) {
+                    DBState.db.pluginCustomStorage.plugin.list = []
+                }
+            })
+        })
+
+        flushSync()
+
+        expect(runs).toBe(1)
+        dispose()
+    })
+
+    it('tracks only the requested property when reconnecting a child inside an effect', () => {
+        const storage: Record<string, unknown> = {}
+        setDatabaseLite(database({ pluginCustomStorage: storage }))
+        storage.a = { b: 1, c: { d: 1 } }
+        let observed = 0
+        let runs = 0
+        const dispose = $effect.root(() => {
+            $effect(() => {
+                runs++
+                observed = DBState.db.pluginCustomStorage.a.b
+            })
+        })
+
+        try {
+            flushSync()
+            DBState.db.pluginCustomStorage.a.c.d = 2
+            flushSync()
+
+            expect(runs).toBe(1)
+            DBState.db.pluginCustomStorage.a.b = 2
+            flushSync()
+            expect(runs).toBe(2)
+            expect(observed).toBe(2)
+        } finally {
+            dispose()
+        }
+    })
+
+    it('removes retained proxies from state when first read by a derived', () => {
+        setDatabaseLite(database({ pluginCustomStorage: { retained: { value: 1 } } }))
+        const retained = DBState.db.pluginCustomStorage.retained
+        const container: Record<string, unknown> = {}
+        setDatabaseLite(database({ pluginCustomStorage: { container } }))
+        container.retained = retained
+        const derivedValue = $derived.by(() => DBState.db.pluginCustomStorage.container.retained.value)
+        let observed = 0
+
+        expect(() => {
+            observed = derivedValue
+        }).not.toThrow()
+        expect(observed).toBe(1)
+        expect(Object.getOwnPropertyDescriptor(DBState.db.pluginCustomStorage.container, 'retained')?.value)
+            .not.toBe(retained)
+        const snapshot = $state.snapshot(DBState.db)
+        expect(() => structuredClone(snapshot)).not.toThrow()
+        expect(snapshot.pluginCustomStorage.container.retained).toEqual({ value: 1 })
     })
 
     it('does not add another database proxy when passed the wrapped database again', () => {

--- a/src/ts/storage/databaseState.svelte.ts
+++ b/src/ts/storage/databaseState.svelte.ts
@@ -1,3 +1,4 @@
+import { untrack } from 'svelte'
 import type { Database } from './database.svelte'
 
 type DatabaseUpdatePathKey = string | number | symbol
@@ -139,7 +140,7 @@ function readDatabaseProxyChild(target: object, prop: PropertyKey, receiver: obj
         if (childState) {
             // A new plain container may contain a retained database proxy. Keep
             // the Svelte target in state so tracking proxies are never persisted.
-            Reflect.set(target, prop, childState.target, target)
+            untrack(() => Reflect.set(target, prop, childState.target, target))
             value = Reflect.get(target, prop, receiver)
         }
     }
@@ -151,6 +152,7 @@ function createDatabaseProxy<T>(target: T): T {
     if (!isProxyableDatabaseValue(target)) {
         return target
     }
+    const databaseTarget: object = target
 
     const cached = databaseProxyCache.get(target)
     if (cached) {
@@ -158,9 +160,10 @@ function createDatabaseProxy<T>(target: T): T {
     }
 
     let state: DatabaseProxyState
-    const proxy = new Proxy(target, {
-        get(obj, prop, receiver) {
-            const value = readDatabaseProxyChild(obj, prop, receiver)
+    const proxyTarget = Array.isArray(databaseTarget) ? [] : Object.create(Reflect.getPrototypeOf(databaseTarget))
+    const proxy = new Proxy(proxyTarget, {
+        get(_obj, prop, receiver) {
+            const value = readDatabaseProxyChild(databaseTarget, prop, receiver)
             if (!isProxyableDatabaseValue(value)) {
                 removeDatabaseProxyChild(state, prop)
                 return value
@@ -168,59 +171,129 @@ function createDatabaseProxy<T>(target: T): T {
 
             const child = state.children.get(prop)
             if (child?.state.target !== value) {
-                addDatabaseProxyChild(state, prop, value)
+                untrack(() => addDatabaseProxyChild(state, prop, value))
             }
             return state.children.get(prop)?.state.proxy ?? value
         },
-        set(obj, prop, value, receiver) {
-            const oldValue = readDatabaseProxyChild(obj, prop, receiver)
-            const newValue = unwrapDatabaseProxy(value)
-            const truncatedEntries = Array.isArray(obj) && prop === 'length' &&
-                typeof oldValue === 'number' && typeof value === 'number' &&
-                Number.isInteger(value) && value >= 0 && value < oldValue
-                ? Reflect.ownKeys(obj)
-                    .filter((key): key is string => typeof key === 'string' && /^\d+$/.test(key) && Number(key) >= value)
-                    .map((key) => ({ index: Number(key), oldValue: readDatabaseProxyChild(obj, key) }))
-                    .sort((a, b) => b.index - a.index)
-                : []
-            const result = Reflect.set(obj, prop, newValue, receiver)
-            const assignedValue = result ? readDatabaseProxyChild(obj, prop, receiver) : oldValue
-            if (result && !Object.is(oldValue, assignedValue)) {
-                addDatabaseProxyChild(state, prop, assignedValue)
-                for (const entry of truncatedEntries) {
-                    removeDatabaseProxyChild(state, String(entry.index))
-                    notifyDatabaseProxy(state, {
-                        path: [entry.index],
-                        value: undefined,
-                        oldValue: entry.oldValue,
-                        type: 'delete',
-                    })
-                }
-                notifyDatabaseProxy(state, {
-                    path: [normalizePathKey(obj, prop)],
-                    value: assignedValue,
-                    oldValue,
-                    type: 'set',
-                })
-            }
-            return result
+        set(_obj, prop, value, receiver) {
+            return untrack(() => setDatabaseProxyProperty(prop, value, receiver))
         },
-        deleteProperty(obj, prop) {
-            const existed = Object.prototype.hasOwnProperty.call(obj, prop)
-            const oldValue = readDatabaseProxyChild(obj, prop)
-            const result = Reflect.deleteProperty(obj, prop)
-            if (result && existed) {
-                removeDatabaseProxyChild(state, prop)
+        deleteProperty(_obj, prop) {
+            return untrack(() => deleteDatabaseProxyProperty(prop))
+        },
+        defineProperty(_obj, prop, descriptor) {
+            if ('value' in descriptor &&
+                descriptor.configurable !== false &&
+                descriptor.enumerable !== false &&
+                descriptor.writable !== false
+            ) {
+                return untrack(() => setDatabaseProxyProperty(prop, descriptor.value, proxy))
+            }
+            return untrack(() => Reflect.defineProperty(databaseTarget, prop, descriptor))
+        },
+        preventExtensions() {
+            return untrack(() => preventDatabaseProxyExtensions())
+        },
+        isExtensible() {
+            return Reflect.isExtensible(databaseTarget)
+        },
+        setPrototypeOf(_obj, prototype) {
+            return Reflect.setPrototypeOf(databaseTarget, prototype)
+        },
+        has(_obj, prop) {
+            return Reflect.has(databaseTarget, prop)
+        },
+        ownKeys() {
+            return Reflect.ownKeys(databaseTarget)
+        },
+        getOwnPropertyDescriptor(_obj, prop) {
+            const descriptor = Reflect.getOwnPropertyDescriptor(databaseTarget, prop)
+            if (!descriptor || Array.isArray(proxyTarget) && prop === 'length') {
+                return descriptor
+            }
+            return { ...descriptor, configurable: true }
+        },
+    })
+
+    function preventDatabaseProxyExtensions() {
+        const targetKeys = new Set(Reflect.ownKeys(databaseTarget))
+        for (const prop of Reflect.ownKeys(proxyTarget)) {
+            if (!targetKeys.has(prop) && !Reflect.deleteProperty(proxyTarget, prop)) {
+                return false
+            }
+        }
+        for (const prop of targetKeys) {
+            const descriptor = Reflect.getOwnPropertyDescriptor(databaseTarget, prop)
+            if (descriptor && !Reflect.defineProperty(proxyTarget, prop,
+                Array.isArray(proxyTarget) && prop === 'length'
+                    ? descriptor
+                    : { ...descriptor, configurable: true }
+            )) {
+                return false
+            }
+        }
+        if (!Reflect.preventExtensions(databaseTarget)) {
+            return false
+        }
+        return Reflect.preventExtensions(proxyTarget)
+    }
+
+    if (!Reflect.isExtensible(databaseTarget) && !untrack(() => preventDatabaseProxyExtensions())) {
+        throw new TypeError('Unable to mirror non-extensible database value')
+    }
+
+    function setDatabaseProxyProperty(prop: PropertyKey, value: unknown, receiver: object) {
+        const oldValue = readDatabaseProxyChild(databaseTarget, prop, receiver)
+        const newValue = unwrapDatabaseProxy(value)
+        const truncatedEntries = Array.isArray(databaseTarget) && prop === 'length' &&
+            typeof oldValue === 'number' && typeof value === 'number' &&
+            Number.isInteger(value) && value >= 0 && value < oldValue
+            ? Reflect.ownKeys(databaseTarget)
+                .filter((key): key is string => typeof key === 'string' && /^\d+$/.test(key) && Number(key) >= value)
+                .map((key) => ({ index: Number(key), oldValue: readDatabaseProxyChild(databaseTarget, key) }))
+                .sort((a, b) => b.index - a.index)
+            : []
+        const result = Reflect.set(databaseTarget, prop, newValue, receiver)
+        const assignedValue = result ? readDatabaseProxyChild(databaseTarget, prop, receiver) : oldValue
+        if (result && !Object.is(oldValue, assignedValue)) {
+            addDatabaseProxyChild(state, prop, assignedValue)
+            for (const entry of truncatedEntries) {
+                removeDatabaseProxyChild(state, String(entry.index))
                 notifyDatabaseProxy(state, {
-                    path: [normalizePathKey(obj, prop)],
+                    path: [entry.index],
                     value: undefined,
-                    oldValue,
+                    oldValue: entry.oldValue,
                     type: 'delete',
                 })
             }
-            return result
-        },
-    })
+            notifyDatabaseProxy(state, {
+                path: [normalizePathKey(databaseTarget, prop)],
+                value: assignedValue,
+                oldValue,
+                type: 'set',
+            })
+        }
+        return result
+    }
+
+    function deleteDatabaseProxyProperty(prop: PropertyKey) {
+        const existed = Object.prototype.hasOwnProperty.call(databaseTarget, prop)
+        const oldValue = readDatabaseProxyChild(databaseTarget, prop)
+        const result = Reflect.deleteProperty(databaseTarget, prop)
+        if (result && !Reflect.deleteProperty(proxyTarget, prop)) {
+            return false
+        }
+        if (result && existed) {
+            removeDatabaseProxyChild(state, prop)
+            notifyDatabaseProxy(state, {
+                path: [normalizePathKey(databaseTarget, prop)],
+                value: undefined,
+                oldValue,
+                type: 'delete',
+            })
+        }
+        return result
+    }
 
     state = {
         target,


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes the freeze reported in #1586: since #1233, opening the Other Bots screen crashes with `effect_update_depth_exceeded` on every install, including fresh ones.

The database tracking proxy introduced by #1233 performs reactive reads inside its own traps — old/new value reads in `set`, eager child-subtree connection, synchronous update-listener dispatch — and the engine's post-trap proxy invariant checks additionally read the Svelte `$state` target. Any `$effect` that writes through `DBState.db` therefore subscribes itself to the property it writes. The wavespeed LoRA sync effect writes a fresh array on every run, so it never converges and hits Svelte's 100-iteration flush guard. The same mechanism also caused quieter bugs: settings-writing effects inherited dependencies from the save change tracker (a character switch could rerun the NanoGPT reset effect and clear `nanogptRequestModel`), descriptor-based writes mutated state without triggering saves, and the first read of a retained proxy inside a `$derived` threw `state_unsafe_mutation`.

## Related Issues

Fixes #1586. The commits suspected in the issue thread are not on `main`; the trigger effect predates #1233 and was harmless under plain `$state` (verified by running the same reproduction against the pre-#1233 tree).

## Changes

**`src/ts/storage/databaseState.svelte.ts`**
- The tracking proxy now uses a detached, non-reactive shape target, so ECMAScript proxy invariant checks validate against a mirror instead of reading the reactive Svelte target
- All trap bookkeeping (`set`/`deleteProperty` value reads, child reconnection and eager subtree walks, update-listener dispatch, extensibility sync) runs inside `untrack()`; the actual property read in `get` stays tracked, preserving normal reactivity
- The retained-proxy fix-up write is untracked, so first reads inside deriveds/templates no longer throw `state_unsafe_mutation` while still keeping tracking proxies out of persisted state
- `defineProperty` with a plain data descriptor now routes through the normal notified set pathway (it previously mutated state without emitting `onDatabaseUpdate`, so those writes were never saved); other descriptor shapes keep Svelte's own `$state` rules

**`src/ts/storage/databaseState.svelte.test.ts`**
- Regression tests for each fix: the write-loop case, subtree over-tracking (asserting both no-rerun on unrelated nested writes and rerun on actual replacement), descriptor writes emitting assignment-equivalent events, and derived-time retained-proxy reads staying safe and snapshot-clean

## Impact

- Opening Other Bots no longer freezes; the same fix covers every effect that writes a fresh object through `DBState.db`, not just the wavespeed screen
- `onDatabaseUpdate` payloads, paths, and ordering are unchanged, so the incremental-save performance benefit of #1233 is preserved (the existing proxy test suite locks these semantics)
- Legacy V2 plugins keep working unchanged; data-descriptor writes that previously bypassed the save tracker now persist correctly
- No component files changed; no overlap with open #1550 or #1587

## Additional Notes

Validated with:

- `pnpm test` (238 passed / 3 skipped, including 34 storage-proxy tests; each fix was written red first against the unfixed tree)
- `pnpm check` (0 errors, 0 warnings)
- Manual smoke on the dev build: Other Bots opens normally, character switching no longer clears NanoGPT fields, and root- plus character-level edits persist across a reload
