### PR TITLE
Update retired Claude model ids in onboarding and preset defaults

### DIFF
--- a/src/lib/Others/WelcomeRisu.svelte
+++ b/src/lib/Others/WelcomeRisu.svelte
@@ -101,8 +101,8 @@
                 }
 
                 if(provider === 'claude'){
-                    DBState.db.aiModel = 'claude-3-5-sonnet-20241022'
-                    DBState.db.subModel = 'claude-3-5-sonnet-20241022'
+                    DBState.db.aiModel = 'claude-sonnet-4-6'
+                    DBState.db.subModel = 'claude-sonnet-4-6'
                 }
 
                 if(provider === 'openai'){

--- a/src/ts/process/templates/templates.ts
+++ b/src/ts/process/templates/templates.ts
@@ -243,7 +243,7 @@ export const prebuiltPresets = {
       "globalNote",
       "authorNote"
     ],
-    "aiModel": "claude-3-5-sonnet-20240620",
+    "aiModel": "claude-sonnet-4-6",
     "subModel": "gemini-3-flash-preview",
     "currentPluginProvider": "",
     "textgenWebUIStreamURL": "",
@@ -298,7 +298,7 @@ export const prebuiltPresets = {
       "stoptokens": "",
       "top_k": 140
     },
-    "proxyRequestModel": "claude-3-5-sonnet-20240620",
+    "proxyRequestModel": "claude-sonnet-4-6",
     "openrouterRequestModel": "anthropic/claude-2",
     "NAISettings": {
       "topK": 12,
@@ -385,7 +385,7 @@ export const prebuiltPresets = {
     "NAIadventure": false,
     "NAIappendName": true,
     "autoSuggestPrompt": "",
-    "customProxyRequestModel": "claude-3-5-sonnet-20240620",
+    "customProxyRequestModel": "claude-sonnet-4-6",
     "reverseProxyOobaArgs": {
       "mode": "instruct"
     },


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? No new types. This is five string literals inside structures that are already typed.
    - [x] Have you tested your changes? `pnpm check` reports 0 errors and 0 warnings. See Additional Notes for what I did not test.
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models:
    - [x] Have you checked if it works normally in all models? The new id is already an entry in `AnthropicModels`, so it resolves the same way any other listed model does.
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? The touched values are shared constants with no platform branch.
- [x] If your PR is highly AI generated:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change? Five lines.

## Summary

The Claude defaults in onboarding and in the OAI2 prebuilt preset point at model ids that Anthropic retired on 28 October 2025. A new user who picks Claude in the welcome flow gets `claude-3-5-sonnet-20241022` written straight into `DBState.db.aiModel`.

## Related Issues

None.

## Changes

| File | Line | Field | Was | Now |
| --- | --- | --- | --- | --- |
| `src/lib/Others/WelcomeRisu.svelte` | 104 | `aiModel` | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |
| `src/lib/Others/WelcomeRisu.svelte` | 105 | `subModel` | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |
| `src/ts/process/templates/templates.ts` | 246 | `aiModel` | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` |
| `src/ts/process/templates/templates.ts` | 301 | `proxyRequestModel` | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` |
| `src/ts/process/templates/templates.ts` | 388 | `customProxyRequestModel` | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` |

Retirement dates come from Anthropic's deprecations page, https://platform.claude.com/docs/en/about-claude/model-deprecations

I picked `claude-sonnet-4-6` because it is already in your catalogue at `src/ts/model/providers/anthropic.ts:64` with `recommended: true`, and because the values being replaced were Sonnet, so this keeps the tier the same. Swap it for whichever entry you would rather ship as the default and I will amend.

Four places that a careless pass would also have rewritten are left alone.

`src/ts/model/providers/anthropic.ts` holds sixteen retired ids and should keep every one of them. That file is the selectable list, each id is paired with its own display name, and a user whose save points at `claude-3-opus-20240229` needs that entry to stay resolvable.

`src/ts/model/modellist.ts` is the Bedrock catalogue and the same reasoning applies.

`src/ts/cbs.ts:657` mentions `claude-3-opus` inside a docstring example of what `{{model}}` returns.

`templates.ts:302` sets `openrouterRequestModel` to `anthropic/claude-2`. That is OpenRouter's namespace rather than Anthropic's and I have not checked what OpenRouter serves today, so I left it for you.

## Impact

Existing saves are untouched. `setPreset` writes `aiModel`, `proxyRequestModel` and `customProxyRequestModel` only when a preset is loaded, so this reaches new users going through the welcome flow and anyone who loads OAI2 from the preset menu after it lands.

## Additional Notes

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run the app against the Anthropic API to reproduce a failed request, so the claim rests on the published retirement dates rather than on a status code I watched come back. What I did run is `pnpm check`, which reports 0 errors and 0 warnings on this branch. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
