### PR TITLE
fix: prevent setDatabase plugin round trip from clearing installed plugins

### DIFF
--- a/src/ts/plugins/plugins.svelte.ts
+++ b/src/ts/plugins/plugins.svelte.ts
@@ -768,7 +768,8 @@ export const getV2PluginAPIs = () => {
             for (const key of Object.keys(newDb)) {
                 if (key === 'plugins') {
                     console.warn('[WARN] Plugin attempted to access plugin directly. this would be blocked in future versions. Instead, use the provided APIs to manage plugins. Attempting to handle plugin installation via plugin for new plugins in the provided database object.')
-                    newDb[key] = await handlePluginInstallViaPlugin(newDb.plugins)
+                    const approvedPlugins = await handlePluginInstallViaPlugin(newDb.plugins)
+                    newDb[key] = (db.plugins ?? []).filter((plugin) => !approvedPlugins.some((approved) => approved.name === plugin.name)).concat(approvedPlugins)
                 }
                 
                 if (allowedDbKeys.includes(key)) {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Fixes the plugin API `setDatabase` clearing the installed plugin list on an ordinary read-modify-write round trip.

When a plugin passes a database object containing `plugins` to `setDatabase`, the value is replaced with the return of `handlePluginInstallViaPlugin`, which returns only newly approved v3.0 entries and skips everything already installed. Passing back the current list — exactly what the documented `getDatabase()` → mutate → `setDatabase(db)` flow does, and `getDatabase()` includes `plugins` by default — therefore assigns an empty array and silently uninstalls every plugin. The `console.warn` that hints at the plugin-key handling is stripped in production builds, so users see nothing. The path is reachable from both V2 plugin scripts and V3 plugins (the V3 API exposes the same `setDatabase`).

## Changes

**`src/ts/plugins/plugins.svelte.ts`**
- `setDatabase` now merges the approved result into the stored list instead of replacing it: stored entries whose name is not among the newly approved entries are kept, and approved entries are concatenated
- An approved same-name entry (an update the user confirmed) replaces the stored entry of that name, avoiding duplicate names since plugin identity is `name`-based
- `db.plugins ?? []` guards the merge base so a previously corrupted `undefined` value recovers instead of throwing

## Impact

- An unchanged round trip preserves the installed list exactly; no confirmation dialogs fire.
- Genuinely new v3.0 plugins still go through the existing per-plugin confirmation and are appended only when approved; denied entries are not added.
- Plugins still cannot remove or modify installed plugins through this path, matching the intent of the existing guard — before this change the same attempt wiped the whole list instead.
- `handlePluginInstallViaPlugin`'s return contract (approved new entries only) is unchanged, so its other caller is unaffected.
- V3 plugins only ever see structured clones across the iframe bridge; no live references escape.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

Also verified the merge behavior with a temporary mocked vitest suite (unchanged round trip, approve/deny of a new plugin, same-name update, removal attempt, corrupted `undefined` list), including a control run against the unfixed code where all scenarios reproduce the wipe.
