### PR TITLE
feat: add Gemini 3.7 Flash model

### DIFF
--- a/src/ts/model/providers/google.ts
+++ b/src/ts/model/providers/google.ts
@@ -2,7 +2,17 @@ import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, type LLMModel } from '.
 
 export const GoogleModels: LLMModel[] = [
 
-    // ===== Gemini 3.5/3.6 Series (2026) =====
+    // ===== Gemini 3.5/3.6/3.7 Series (2026) =====
+    {
+        name: "Gemini Flash 3.7",
+        id: 'gemini-3.7-flash',
+        provider: LLMProvider.GoogleCloud,
+        format: LLMFormat.GoogleCloud,
+        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.geminiThinkingNoMinimal, LLMFlags.hasFirstSystemPrompt],
+        parameters: ['reasoning_effort'],
+        tokenizer: LLMTokenizer.GoogleCloud,
+        recommended: true
+    },
     {
         name: "Gemini Flash 3.6",
         id: 'gemini-3.6-flash',

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -412,9 +412,9 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     console.log(arg.modelInfo);
 
     const isVertexGlobalOnlyModel = (modelId: string) => {
-        // Gemini 3 preview models and the 3.5/3.6 Flash family are not served from the regions
+        // Gemini 3 preview models and the 3.5/3.6/3.7 Flash family are not served from the regions
         // selectable in settings (us-central1, us-west1); route them through the global endpoint.
-        return /^gemini-3-.*-preview$/.test(modelId) || /^gemini-3\.[56]-flash/.test(modelId)
+        return /^gemini-3-.*-preview$/.test(modelId) || /^gemini-3\.[567]-flash/.test(modelId)
     }
 
     async function generateToken(email:string,key:string){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds the newly released Google model `gemini-3.7-flash` (GA August 13, 2026) as a built-in selectable model.

The existing Vertex derivation loop in `modellist.ts` picks up the entry automatically, so both the Gemini API and Vertex AI variants become available from a single definition.

## Related Issues

None.

## Changes

**`src/ts/model/providers/google.ts`**
- Added the `gemini-3.7-flash` entry with the same multimodal input flags as `gemini-3.6-flash`
- Added `geminiThinkingNoMinimal`, since the model only supports the `low` / `medium` / `high` thinking levels and rejects `minimal`; the request layer maps a minimal setting to `low`
- Limited `parameters` to `reasoning_effort`: Google's documentation states `temperature` / `top_p` / `top_k` are no longer supported from the 3.6 generation onward, and penalty parameters stay omitted as on the sibling 3.5 / 3.6 entries

**`src/ts/process/request/google.ts`**
- Extended `isVertexGlobalOnlyModel` to route the new model through the Vertex AI `global` endpoint, since it is only served from `global` and the `us` / `eu` multi-regions, not from the regions selectable in settings

## Impact

- One new selectable model appears for both the Gemini API and Vertex AI providers. Existing model entries and request behavior are unchanged.
- Users whose saved model is the Dynamic Model Registry's `dynamic_google_gemini-3.7-flash` need to re-select the model once, since the built-in entry now prevents that dynamic ID from being registered.
- Selecting the Minimal thinking effort sends `low` for this model, as the model has no minimal level.
- Google's documentation states requests ending with a model turn are rejected from the 3.6 generation onward, so continue-style prefill is affected on this model. This is pre-existing pipeline behavior and is out of scope here.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`

Capability and routing choices follow Google's official Gemini 3.7 Flash documentation: thinking levels `low` / `medium` / `high` with `minimal` returning an error, sampling parameters unsupported since the 3.6 generation, and Vertex AI serving limited to the `global` endpoint and `us` / `eu` multi-regions.
