### PR TITLE
feat(tts): add native MiniMax text-to-speech provider

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -961,6 +961,9 @@
     <span class="text-textcolor">fish-speech API Key</span>
     <TextInput size="sm" marginBottom bind:value={DBState.db.fishSpeechKey}/>
 
+    <span class="text-textcolor">MiniMax API Key</span>
+    <TextInput size="sm" marginBottom bind:value={DBState.db.minimaxTTSKey}/>
+
 </Accordion>
 {/if}
 

--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -1063,11 +1063,6 @@
                 {/each}
             </SelectInput>
 
-            <span class="text-textcolor">API Key (overrides global)</span>
-            <TextInput className="mb-4 mt-2" hideText={DBState.db.hideApiKey}
-                bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.apiKey}
-                placeholder="Leave empty to use the global MiniMax API key" />
-
             <span class="text-textcolor">Model</span>
             <SelectInput className="mb-4 mt-2" bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.model}>
                 {#each minimaxTTSModels as model}

--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -15,6 +15,7 @@
     import Help from "../Others/Help.svelte";
     import { exportChar } from "src/ts/characterCards";
     import { getElevenTTSVoices, getWebSpeechTTSVoices, getVOICEVOXVoices, oaiVoices, getNovelAIVoices } from "src/ts/process/tts";
+    import { defaultMinimaxTTSConfig, minimaxTTSEmotions, minimaxTTSFormats, minimaxTTSModels, minimaxTTSRegions, minimaxTTSVoiceLimits } from "src/ts/process/ttsMinimax";
     import { getFileSrc } from "src/ts/globalApi.svelte";
     import { addGroupChar, rmCharFromGroup } from "src/ts/process/group";
     import TextInput from "../UI/GUI/TextInput.svelte";
@@ -171,6 +172,12 @@
                 enabled: false,
                 format: 'mp3',
             };
+        }
+    });
+
+    $effect.pre(() => {
+        if (DBState.db.characters[$selectedCharID].ttsMode === 'minimax' && (DBState.db.characters[$selectedCharID] as character).minimaxTTSConfig === undefined) {
+            (DBState.db.characters[$selectedCharID] as character).minimaxTTSConfig = defaultMinimaxTTSConfig();
         }
     });
 
@@ -773,6 +780,7 @@
             <OptionInput value="vits">VITS</OptionInput>
             <OptionInput value="gptsovits">GPT-SoVITS</OptionInput>
             <OptionInput value="fishspeech">fish-speech</OptionInput>
+            <OptionInput value="minimax">MiniMax</OptionInput>
         </SelectInput>
         
 
@@ -1047,6 +1055,59 @@
 
             <span class="mt-2 text-textcolor">Normalize</span>
             <Check className="mb-4 mt-2" bind:check={DBState.db.characters[$selectedCharID].fishSpeechConfig.normalize}/>
+        {:else if DBState.db.characters[$selectedCharID].ttsMode === 'minimax'}
+            <span class="text-textcolor">Endpoint</span>
+            <SelectInput className="mb-4 mt-2" bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.region}>
+                {#each minimaxTTSRegions as region}
+                    <OptionInput value={region.id}>{region.name}</OptionInput>
+                {/each}
+            </SelectInput>
+
+            <span class="text-textcolor">API Key (overrides global)</span>
+            <TextInput className="mb-4 mt-2" hideText={DBState.db.hideApiKey}
+                bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.apiKey}
+                placeholder="Leave empty to use the global MiniMax API key" />
+
+            <span class="text-textcolor">Model</span>
+            <SelectInput className="mb-4 mt-2" bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.model}>
+                {#each minimaxTTSModels as model}
+                    <OptionInput value={model}>{model}</OptionInput>
+                {/each}
+            </SelectInput>
+
+            <span class="text-textcolor">Voice ID</span>
+            <TextInput className="mb-4 mt-2" bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.voiceId}/>
+
+            <span class="text-textcolor">Emotion</span>
+            <SelectInput className="mb-4 mt-2" bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.emotion}>
+                <OptionInput value="">Auto</OptionInput>
+                {#each minimaxTTSEmotions as emotion}
+                    <OptionInput value={emotion}>{emotion}</OptionInput>
+                {/each}
+            </SelectInput>
+
+            <span class="text-textcolor">Speed</span>
+            <SliderInput min={minimaxTTSVoiceLimits.speed.min} max={minimaxTTSVoiceLimits.speed.max} step={0.05} fixed={2}
+                bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.speed}/>
+
+            <span class="text-textcolor">Volume</span>
+            <SliderInput min={minimaxTTSVoiceLimits.vol.min} max={minimaxTTSVoiceLimits.vol.max} step={0.1} fixed={1}
+                bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.vol}/>
+
+            <span class="text-textcolor">Pitch</span>
+            <SliderInput min={minimaxTTSVoiceLimits.pitch.min} max={minimaxTTSVoiceLimits.pitch.max} step={1}
+                bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.pitch}/>
+
+            <span class="text-textcolor">Audio Format</span>
+            <SelectInput className="mb-4 mt-2" bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.format}>
+                {#each minimaxTTSFormats as format}
+                    <OptionInput value={format}>{format}</OptionInput>
+                {/each}
+            </SelectInput>
+
+            <span class="text-textcolor">Language Boost</span>
+            <TextInput className="mb-4 mt-2" bind:value={DBState.db.characters[$selectedCharID].minimaxTTSConfig.languageBoost}
+                placeholder="Leave empty to let the model decide" />
         {/if}
         {#if DBState.db.characters[$selectedCharID].ttsMode}
             <div class="flex items-center mt-2">

--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -8,6 +8,7 @@ import { getImageType } from "./media";
 import { DBState, MobileGUIStack, OpenRealmStore, selectedCharID } from "./stores.svelte";
 import { AppendableBuffer, changeChatTo, checkCharOrder, downloadFile, getFileSrc, requiresFullEncoderReload } from "./globalApi.svelte";
 import { updateInlayScreen } from "./process/inlayScreen";
+import { defaultMinimaxTTSConfig } from "./process/ttsMinimax";
 import { parseMarkdownSafe } from "./parser/parser.svelte";
 import { translateHTML } from "./translator/translator";
 import { doingChat } from "./process/index.svelte";
@@ -596,6 +597,9 @@ export function characterFormatUpdate(indexOrCharacter:number|character, arg:{
         cha.hfTTS ??= {
             model: '',
             language: 'en'
+        }
+        if (cha.ttsMode === 'minimax') {
+            cha.minimaxTTSConfig ??= defaultMinimaxTTSConfig()
         }
         cha.backgroundHTML ??= ''
         cha.backgroundCSS ??= ''

--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -427,7 +427,7 @@ export async function sayTTS(character:character,text:string) {
                 }
 
                 const cfg = character.minimaxTTSConfig ?? {}
-                const apiKey = (cfg.apiKey || db.minimaxTTSKey || '').trim()
+                const apiKey = (db.minimaxTTSKey || '').trim()
                 if(apiKey === ''){
                     throw new Error('MiniMax API key is not set')
                 }

--- a/src/ts/process/tts.ts
+++ b/src/ts/process/tts.ts
@@ -14,6 +14,11 @@ import {
     type AfterTTSContext,
     type AfterTTSResult,
 } from "./ttsHooks";
+import {
+    buildMinimaxTTSRequest,
+    decodeMinimaxTTSAudio,
+    minimaxTTSMimeType,
+} from "./ttsMinimax";
 
 let sourceNode:AudioBufferSourceNode = null
 
@@ -414,6 +419,39 @@ export async function sayTTS(character:character,text:string) {
                     const text = Buffer.from(textBuffer).toString('utf-8')
                     throw new Error(text);
                 }
+                break;
+            }
+            case 'minimax':{
+                if(text === ''){
+                    break;
+                }
+
+                const cfg = character.minimaxTTSConfig ?? {}
+                const apiKey = (cfg.apiKey || db.minimaxTTSKey || '').trim()
+                if(apiKey === ''){
+                    throw new Error('MiniMax API key is not set')
+                }
+
+                const request = buildMinimaxTTSRequest(text, cfg)
+
+                // The endpoint answers with a JSON envelope, so the parsed
+                // response is used instead of rawResponse bytes here.
+                const response = await globalFetch(request.url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${apiKey}`,
+                    },
+                    body: request.body,
+                })
+
+                if(!response.ok){
+                    const data = response.data
+                    throw new Error(typeof data === 'string' ? data : JSON.stringify(data))
+                }
+
+                const audio = decodeMinimaxTTSAudio(response.data)
+                await playAudio(audio, minimaxTTSMimeType(cfg.format), { ttsMode: character.ttsMode ?? '', characterId: character.chaId })
                 break;
             }
         }

--- a/src/ts/process/ttsMinimax.test.ts
+++ b/src/ts/process/ttsMinimax.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import {
+    buildMinimaxTTSRequest,
+    decodeMinimaxTTSAudio,
+    defaultMinimaxTTSConfig,
+    minimaxTTSDefaultModel,
+    minimaxTTSEndpoint,
+    minimaxTTSMimeType,
+    minimaxTTSModels,
+    minimaxTTSRegions,
+} from './ttsMinimax'
+
+describe('minimax speech models and endpoints', () => {
+    it('exposes the current speech models with the HD default', () => {
+        expect([...minimaxTTSModels]).toEqual([
+            'speech-2.8-hd',
+            'speech-2.8-turbo',
+            'speech-2.6-hd',
+            'speech-2.6-turbo',
+            'speech-02-hd',
+            'speech-02-turbo',
+            'speech-01-hd',
+            'speech-01-turbo',
+        ])
+        expect(minimaxTTSDefaultModel).toBe('speech-2.8-hd')
+    })
+
+    it('exposes the global and CN endpoints', () => {
+        expect(minimaxTTSRegions.map((region) => region.id)).toEqual(['global_en', 'cn_zh'])
+        expect(minimaxTTSEndpoint('global_en')).toBe('https://api.minimax.io/v1/t2a_v2')
+        expect(minimaxTTSEndpoint('cn_zh')).toBe('https://api.minimaxi.com/v1/t2a_v2')
+    })
+
+    it('falls back to the global endpoint for an unknown region', () => {
+        expect(minimaxTTSEndpoint(undefined)).toBe('https://api.minimax.io/v1/t2a_v2')
+        expect(minimaxTTSEndpoint('somewhere-else')).toBe('https://api.minimax.io/v1/t2a_v2')
+    })
+
+    it('maps audio formats to playable mime types', () => {
+        expect(minimaxTTSMimeType('mp3')).toBe('audio/mpeg')
+        expect(minimaxTTSMimeType('wav')).toBe('audio/wav')
+        expect(minimaxTTSMimeType('flac')).toBe('audio/flac')
+        expect(minimaxTTSMimeType(undefined)).toBe('audio/mpeg')
+        expect(minimaxTTSMimeType('not-a-format')).toBe('audio/mpeg')
+    })
+
+    it('produces a usable default config', () => {
+        const config = defaultMinimaxTTSConfig()
+        expect(config.region).toBe('global_en')
+        expect(config.model).toBe(minimaxTTSDefaultModel)
+        expect(config.format).toBe('mp3')
+        expect(config.speed).toBe(1)
+        expect(config.vol).toBe(1)
+        expect(config.pitch).toBe(0)
+    })
+})
+
+describe('buildMinimaxTTSRequest', () => {
+    it('builds a hex request against the selected regional endpoint', () => {
+        const request = buildMinimaxTTSRequest('hello there', {
+            region: 'cn_zh',
+            model: 'speech-2.6-turbo',
+            voiceId: 'my-voice',
+            format: 'wav',
+        })
+
+        expect(request.url).toBe('https://api.minimaxi.com/v1/t2a_v2')
+        expect(request.body).toEqual({
+            model: 'speech-2.6-turbo',
+            text: 'hello there',
+            stream: false,
+            output_format: 'hex',
+            voice_setting: {
+                voice_id: 'my-voice',
+                speed: 1,
+                vol: 1,
+                pitch: 0,
+            },
+            audio_setting: { format: 'wav' },
+        })
+    })
+
+    it('applies model and format defaults', () => {
+        const request = buildMinimaxTTSRequest('hi', { voiceId: 'v' })
+
+        expect(request.url).toBe('https://api.minimax.io/v1/t2a_v2')
+        expect(request.body.model).toBe(minimaxTTSDefaultModel)
+        expect(request.body.audio_setting.format).toBe('mp3')
+    })
+
+    it('falls back to mp3 for an unsupported format', () => {
+        const request = buildMinimaxTTSRequest('hi', { voiceId: 'v', format: 'ogg' as never })
+
+        expect(request.body.audio_setting.format).toBe('mp3')
+    })
+
+    it('clamps voice settings into the accepted ranges', () => {
+        const tooHigh = buildMinimaxTTSRequest('hi', { voiceId: 'v', speed: 9, vol: 50, pitch: 40 })
+        expect(tooHigh.body.voice_setting.speed).toBe(2)
+        expect(tooHigh.body.voice_setting.vol).toBe(10)
+        expect(tooHigh.body.voice_setting.pitch).toBe(12)
+
+        const tooLow = buildMinimaxTTSRequest('hi', { voiceId: 'v', speed: 0, vol: 0, pitch: -40 })
+        expect(tooLow.body.voice_setting.speed).toBe(0.5)
+        expect(tooLow.body.voice_setting.vol).toBe(0.1)
+        expect(tooLow.body.voice_setting.pitch).toBe(-12)
+    })
+
+    it('rounds pitch to a whole step and ignores non numeric settings', () => {
+        const request = buildMinimaxTTSRequest('hi', {
+            voiceId: 'v',
+            pitch: 3.6,
+            speed: Number.NaN,
+            vol: undefined,
+        })
+
+        expect(request.body.voice_setting.pitch).toBe(4)
+        expect(request.body.voice_setting.speed).toBe(1)
+        expect(request.body.voice_setting.vol).toBe(1)
+    })
+
+    it('omits optional fields when they are empty', () => {
+        const request = buildMinimaxTTSRequest('hi', { voiceId: 'v', emotion: '', languageBoost: '   ' })
+
+        expect(request.body.voice_setting.emotion).toBeUndefined()
+        expect(request.body.language_boost).toBeUndefined()
+    })
+
+    it('passes the emotion and language hint through when set', () => {
+        const request = buildMinimaxTTSRequest('hi', { voiceId: 'v', emotion: 'happy', languageBoost: 'English' })
+
+        expect(request.body.voice_setting.emotion).toBe('happy')
+        expect(request.body.language_boost).toBe('English')
+    })
+
+    it('refuses a missing voice id or empty text', () => {
+        expect(() => buildMinimaxTTSRequest('hi', { voiceId: '  ' })).toThrow(/voice ID is not set/)
+        expect(() => buildMinimaxTTSRequest('hi', {})).toThrow(/voice ID is not set/)
+        expect(() => buildMinimaxTTSRequest('   ', { voiceId: 'v' })).toThrow(/text is empty/)
+    })
+})
+
+describe('decodeMinimaxTTSAudio', () => {
+    it('decodes the hex encoded audio payload', () => {
+        const audio = decodeMinimaxTTSAudio({
+            data: { audio: '00ff102A', status: 2 },
+            base_resp: { status_code: 0, status_msg: 'success' },
+        })
+
+        expect(Array.from(new Uint8Array(audio))).toEqual([0, 255, 16, 42])
+        expect(audio.byteLength).toBe(4)
+    })
+
+    it('accepts a response without a base_resp envelope', () => {
+        const audio = decodeMinimaxTTSAudio({ data: { audio: 'abcd' } })
+
+        expect(Array.from(new Uint8Array(audio))).toEqual([171, 205])
+    })
+
+    it('reports a failure carried in base_resp', () => {
+        expect(() => decodeMinimaxTTSAudio({
+            data: null,
+            base_resp: { status_code: 1004, status_msg: 'authentication failed' },
+        })).toThrow(/1004.*authentication failed/)
+    })
+
+    it('reports a failure without a status message', () => {
+        expect(() => decodeMinimaxTTSAudio({ base_resp: { status_code: 1002 } })).toThrow(/1002.*unknown error/)
+    })
+
+    it('rejects a response without audio', () => {
+        expect(() => decodeMinimaxTTSAudio({ data: null })).toThrow(/did not contain audio data/)
+        expect(() => decodeMinimaxTTSAudio({ data: { audio: '' } })).toThrow(/did not contain audio data/)
+        expect(() => decodeMinimaxTTSAudio({})).toThrow(/did not contain audio data/)
+    })
+
+    it('rejects malformed hex audio', () => {
+        expect(() => decodeMinimaxTTSAudio({ data: { audio: 'abc' } })).toThrow(/malformed audio data/)
+        expect(() => decodeMinimaxTTSAudio({ data: { audio: 'zzzz' } })).toThrow(/malformed audio data/)
+    })
+
+    it('rejects a non object response', () => {
+        expect(() => decodeMinimaxTTSAudio('not json')).toThrow(/not valid JSON/)
+        expect(() => decodeMinimaxTTSAudio(null)).toThrow(/not valid JSON/)
+    })
+})

--- a/src/ts/process/ttsMinimax.ts
+++ b/src/ts/process/ttsMinimax.ts
@@ -70,8 +70,6 @@ export const minimaxTTSVoiceLimits = {
 export interface MinimaxTTSConfig {
     /** Regional endpoint to call. Falls back to the global endpoint. */
     region?: MinimaxTTSRegion
-    /** Per character API key. Falls back to the global MiniMax speech key. */
-    apiKey?: string
     /** Speech model id. Falls back to the newest HD model. */
     model?: string
     /** Voice id to render with. Required by the endpoint, so an empty value is refused early. */

--- a/src/ts/process/ttsMinimax.ts
+++ b/src/ts/process/ttsMinimax.ts
@@ -1,0 +1,261 @@
+/**
+ * MiniMax native text-to-speech support.
+ *
+ * The synchronous speech endpoint takes a JSON body and answers with a JSON
+ * envelope instead of raw audio bytes: the rendered audio arrives as a hex
+ * string in `data.audio`, and transport level failures are reported inside
+ * `base_resp` while the HTTP status stays 200. Request building and response
+ * decoding therefore live here as dependency free pure functions so the
+ * provider case in tts.ts stays a thin wiring layer and both halves can be
+ * unit tested without an AudioContext.
+ */
+
+/** Regional variants of the same speech endpoint. */
+export const minimaxTTSRegions = [
+    { id: 'global_en', name: 'Global', url: 'https://api.minimax.io/v1/t2a_v2' },
+    { id: 'cn_zh', name: 'Mainland China', url: 'https://api.minimaxi.com/v1/t2a_v2' },
+] as const
+
+export type MinimaxTTSRegion = (typeof minimaxTTSRegions)[number]['id']
+
+export const minimaxTTSDefaultRegion: MinimaxTTSRegion = 'global_en'
+
+/** Speech models accepted by the endpoint, newest first. */
+export const minimaxTTSModels = [
+    'speech-2.8-hd',
+    'speech-2.8-turbo',
+    'speech-2.6-hd',
+    'speech-2.6-turbo',
+    'speech-02-hd',
+    'speech-02-turbo',
+    'speech-01-hd',
+    'speech-01-turbo',
+] as const
+
+export type MinimaxTTSModel = (typeof minimaxTTSModels)[number]
+
+export const minimaxTTSDefaultModel: MinimaxTTSModel = 'speech-2.8-hd'
+
+export const minimaxTTSFormats = ['mp3', 'wav', 'flac', 'pcm'] as const
+
+export type MinimaxTTSFormat = (typeof minimaxTTSFormats)[number]
+
+export const minimaxTTSDefaultFormat: MinimaxTTSFormat = 'mp3'
+
+/** Emotions the voice setting accepts; an empty value leaves the choice to the model. */
+export const minimaxTTSEmotions = [
+    'happy',
+    'sad',
+    'angry',
+    'fearful',
+    'disgusted',
+    'surprised',
+    'calm',
+] as const
+
+export type MinimaxTTSEmotion = (typeof minimaxTTSEmotions)[number]
+
+/**
+ * Bounds documented for the voice setting fields. Values are clamped instead of
+ * rejected so a stale character card cannot make every request fail with an
+ * invalid parameter error.
+ */
+export const minimaxTTSVoiceLimits = {
+    speed: { min: 0.5, max: 2, default: 1 },
+    vol: { min: 0.1, max: 10, default: 1 },
+    pitch: { min: -12, max: 12, default: 0 },
+} as const
+
+/** Per character MiniMax speech settings. Every field falls back to a documented default. */
+export interface MinimaxTTSConfig {
+    /** Regional endpoint to call. Falls back to the global endpoint. */
+    region?: MinimaxTTSRegion
+    /** Per character API key. Falls back to the global MiniMax speech key. */
+    apiKey?: string
+    /** Speech model id. Falls back to the newest HD model. */
+    model?: string
+    /** Voice id to render with. Required by the endpoint, so an empty value is refused early. */
+    voiceId?: string
+    /** Playback rate, clamped to the documented range. */
+    speed?: number
+    /** Loudness multiplier, clamped to the documented range. */
+    vol?: number
+    /** Pitch offset in semitones, clamped and rounded to a whole step. */
+    pitch?: number
+    /** Optional emotion hint; an empty value omits the field. */
+    emotion?: string
+    /** Container of the returned audio. Falls back to mp3. */
+    format?: MinimaxTTSFormat
+    /** Optional language hint passed straight through, e.g. 'English' or 'auto'. */
+    languageBoost?: string
+}
+
+/** Shape of the request body the speech endpoint expects. */
+export interface MinimaxTTSRequestBody {
+    model: string
+    text: string
+    stream: false
+    output_format: 'hex'
+    voice_setting: {
+        voice_id: string
+        speed: number
+        vol: number
+        pitch: number
+        emotion?: string
+    }
+    audio_setting: {
+        format: MinimaxTTSFormat
+    }
+    language_boost?: string
+}
+
+export interface MinimaxTTSRequest {
+    url: string
+    body: MinimaxTTSRequestBody
+}
+
+/**
+ * Raw PCM is offered because the endpoint renders it, but it has no container,
+ * so only the framed formats can be handed to AudioContext.decodeAudioData.
+ */
+const minimaxTTSMimeTypes: Record<MinimaxTTSFormat, string> = {
+    mp3: 'audio/mpeg',
+    wav: 'audio/wav',
+    flac: 'audio/flac',
+    pcm: 'audio/L16',
+}
+
+export function minimaxTTSMimeType(format?: string): string {
+    return minimaxTTSMimeTypes[format as MinimaxTTSFormat] ?? minimaxTTSMimeTypes[minimaxTTSDefaultFormat]
+}
+
+/** Resolve a stored region id to its endpoint URL, falling back to the global one. */
+export function minimaxTTSEndpoint(region?: string): string {
+    const found = minimaxTTSRegions.find((candidate) => candidate.id === region)
+    return (found ?? minimaxTTSRegions[0]).url
+}
+
+function clamp(value: number | undefined, limit: { min: number; max: number; default: number }): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return limit.default
+    }
+    return Math.min(limit.max, Math.max(limit.min, value))
+}
+
+/** Default config used when a character has no MiniMax speech settings yet. */
+export function defaultMinimaxTTSConfig(): MinimaxTTSConfig {
+    return {
+        region: minimaxTTSDefaultRegion,
+        model: minimaxTTSDefaultModel,
+        voiceId: '',
+        speed: minimaxTTSVoiceLimits.speed.default,
+        vol: minimaxTTSVoiceLimits.vol.default,
+        pitch: minimaxTTSVoiceLimits.pitch.default,
+        emotion: '',
+        format: minimaxTTSDefaultFormat,
+        languageBoost: '',
+    }
+}
+
+/**
+ * Build the endpoint URL and request body for one utterance.
+ *
+ * Throws when the text or the voice id is missing, because the endpoint rejects
+ * both and a thrown error surfaces as a readable TTS alert.
+ */
+export function buildMinimaxTTSRequest(text: string, config: MinimaxTTSConfig = {}): MinimaxTTSRequest {
+    if (!text || text.trim() === '') {
+        throw new Error('MiniMax TTS text is empty')
+    }
+
+    const voiceId = (config.voiceId ?? '').trim()
+    if (voiceId === '') {
+        throw new Error('MiniMax TTS voice ID is not set')
+    }
+
+    const format = minimaxTTSFormats.includes(config.format as MinimaxTTSFormat)
+        ? (config.format as MinimaxTTSFormat)
+        : minimaxTTSDefaultFormat
+
+    const voiceSetting: MinimaxTTSRequestBody['voice_setting'] = {
+        voice_id: voiceId,
+        speed: clamp(config.speed, minimaxTTSVoiceLimits.speed),
+        vol: clamp(config.vol, minimaxTTSVoiceLimits.vol),
+        pitch: Math.round(clamp(config.pitch, minimaxTTSVoiceLimits.pitch)),
+    }
+
+    const emotion = (config.emotion ?? '').trim()
+    if (emotion !== '') {
+        voiceSetting.emotion = emotion
+    }
+
+    const body: MinimaxTTSRequestBody = {
+        model: (config.model ?? '').trim() || minimaxTTSDefaultModel,
+        text,
+        // Hex output keeps the response a single JSON envelope, which is what
+        // decodeMinimaxTTSAudio below is written against.
+        stream: false,
+        output_format: 'hex',
+        voice_setting: voiceSetting,
+        audio_setting: { format },
+    }
+
+    const languageBoost = (config.languageBoost ?? '').trim()
+    if (languageBoost !== '') {
+        body.language_boost = languageBoost
+    }
+
+    return { url: minimaxTTSEndpoint(config.region), body }
+}
+
+function hexToAudioBuffer(hex: string): ArrayBuffer {
+    const cleaned = hex.trim()
+    if (cleaned === '') {
+        throw new Error('MiniMax TTS response contained empty audio data')
+    }
+    if (cleaned.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(cleaned)) {
+        throw new Error('MiniMax TTS response contained malformed audio data')
+    }
+
+    // The buffer is allocated at its exact size so it can be handed to the
+    // audio pipeline without an extra slice.
+    const buffer = new ArrayBuffer(cleaned.length / 2)
+    const bytes = new Uint8Array(buffer)
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16)
+    }
+    return buffer
+}
+
+/**
+ * Turn a decoded JSON response into playable audio bytes.
+ *
+ * The endpoint answers with HTTP 200 even for authentication or quota failures
+ * and reports them through `base_resp.status_code`, so that envelope is checked
+ * before the audio field is read. `data` itself may be null on failure.
+ */
+export function decodeMinimaxTTSAudio(response: unknown): ArrayBuffer {
+    if (!response || typeof response !== 'object') {
+        throw new Error('MiniMax TTS response was not valid JSON')
+    }
+
+    const envelope = response as {
+        data?: { audio?: unknown } | null
+        base_resp?: { status_code?: unknown; status_msg?: unknown } | null
+    }
+
+    const statusCode = envelope.base_resp?.status_code
+    if (typeof statusCode === 'number' && statusCode !== 0) {
+        const statusMessage = typeof envelope.base_resp?.status_msg === 'string' && envelope.base_resp.status_msg !== ''
+            ? envelope.base_resp.status_msg
+            : 'unknown error'
+        throw new Error(`MiniMax TTS request failed (${statusCode}): ${statusMessage}`)
+    }
+
+    const audio = envelope.data?.audio
+    if (typeof audio !== 'string' || audio === '') {
+        throw new Error('MiniMax TTS response did not contain audio data')
+    }
+
+    return hexToAudioBuffer(audio)
+}

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -10,6 +10,7 @@ import type { NAISettings } from '../process/models/nai';
 import { prebuiltNAIpresets, prebuiltPresets } from '../process/templates/templates';
 import { defaultColorScheme, type ColorScheme } from '../gui/colorscheme';
 import type { PromptItem, PromptSettings } from '../process/prompt';
+import type { MinimaxTTSConfig } from '../process/ttsMinimax';
 import type { OobaChatCompletionRequestParams } from '../model/ooba';
 import { type HypaV3Settings, type HypaV3Preset, createHypaV3Preset } from '../process/memory/hypav3'
 import { normalizeTranslatorPresetState, type TranslatorPreset } from '../translator/presets'
@@ -421,6 +422,7 @@ export function setDatabase(data:Database){
     data.gptVisionQuality ??= 'low'
     data.huggingfaceKey ??= ''
     data.fishSpeechKey ??= ''
+    data.minimaxTTSKey ??= ''
     data.presetRegex ??= []
     data.reverseProxyOobaArgs ??= {
         mode: 'instruct'
@@ -992,6 +994,7 @@ export interface Database{
     reverseProxyOobaArgs: OobaChatCompletionRequestParams
     huggingfaceKey:string
     fishSpeechKey:string
+    minimaxTTSKey:string
     allowAllExtentionFiles?:boolean
     translatorPrompt:string
     translatorMaxResponse:number
@@ -1455,6 +1458,8 @@ export interface character{
         /** Response format. Falls back to 'mp3'. */
         format?: 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm'
     }
+    /** Native MiniMax speech settings; see src/ts/process/ttsMinimax.ts for the fallback of each field. */
+    minimaxTTSConfig?: MinimaxTTSConfig
     virtualscript?:string
     scriptstate?:{[key:string]:string|number|boolean}
     depth_prompt?: { depth: number, prompt: string }
@@ -1557,6 +1562,7 @@ export interface groupChat{
     vits?: OnnxModelFiles
     gptSoVitsConfig?:any
     fishSpeechConfig?:any
+    minimaxTTSConfig?:any
     ttsReadOnlyQuoted?:boolean
     exampleMessage?:string
     systemPrompt?:string


### PR DESCRIPTION
Reason: Add native MiniMax text-to-speech support for global and CN /v1/t2a_v2 endpoints, current speech models and voice settings, and data.audio response decoding.

## Summary

RisuAI had no native MiniMax speech option, so a character could not be voiced through the MiniMax speech endpoint. This adds `minimax` as a TTS provider.

The endpoint differs from the other TTS providers already wired into `sayTTS`: it answers with a JSON envelope rather than raw audio bytes, carries the rendered audio as a hex string in `data.audio`, and reports authentication or quota failures in `base_resp.status_code` while the HTTP status stays 200. Request building and response decoding are therefore kept as pure functions in a new module so the provider case stays thin and both halves are unit testable without an `AudioContext`.

## Changes

- Add `src/ts/process/ttsMinimax.ts` with the global and CN `/v1/t2a_v2` endpoints, the eight current speech models (default `speech-2.8-hd`), the supported audio formats, and the documented voice-setting bounds.
- Build the request body with `model`, `text`, `stream: false`, `output_format: 'hex'`, `voice_setting` and `audio_setting`, adding `emotion` and `language_boost` only when they are set.
- Clamp `speed`, `vol` and `pitch` into their documented ranges and round `pitch` to a whole step, so a stale character card cannot make every request fail with an invalid-parameter error.
- Refuse an empty voice ID or empty text up front, since the endpoint rejects both, and surface the reason as a readable TTS alert.
- Decode `data.audio` from hex into an exactly sized `ArrayBuffer`, checking `base_resp.status_code` first and handling a null `data` object.
- Add the `minimax` case to `sayTTS`, reading the per-character key with a fallback to the new global key and mapping the chosen format to a mime type for playback.
- Add `minimaxTTSConfig` to the character schema (mirrored on `groupChat`), the global `minimaxTTSKey` with its default, the provider entry and settings panel in the character TTS tab, the global API key field, and a per-character config default on character load.
- Add `src/ts/process/ttsMinimax.test.ts` covering the endpoints and model list, request building, clamping, optional-field omission, validation, and hex/error response decoding.

## Verification

- `pnpm exec vitest run src/ts/process/ttsMinimax.test.ts`: 20 passed.
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test`: 239 passed, 3 skipped.
- `pnpm check`: 0 errors and 0 warnings.
- `git diff --check`.
