### PR TITLE
Allow Lua axLLM to use other aux models

### DIFF
--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -933,14 +933,22 @@ export async function runScripted(code:string, arg:{
                     }
                 }
 
-                const options = parseLuaOptions(optionsStr) as { streaming?: boolean }
+                const options = parseLuaOptions(optionsStr) as { mode?: string, streaming?: boolean }
+                const modes = new Set(['emotion', 'memory', 'otherAx', 'submodel', 'translate'])
+                const mode = options.mode ?? 'otherAx'
+                if (!modes.has(mode)) {
+                    return JSON.stringify({
+                        result: 'Error: Invalid axLLM mode: ' + mode,
+                        success: false
+                    })
+                }
                 const result = await requestChatData({
                     formated: promptbody,
                     bias: {},
                     useStreaming: options.streaming === true,
                     forceStreaming: options.streaming === true,
                     noMultiGen: true,
-                }, 'otherAx')
+                }, mode as 'emotion' | 'memory' | 'otherAx' | 'submodel' | 'translate')
 
                 if(result.type === 'fail'){
                     return JSON.stringify({


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [ x Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Allows Lua codes to request to models that is not otherAx.

## Related Issues

None.

## Changes

`axLLM()` is currently limited to a single model defined as `otherAx`, but various modules may require different model characteristics.

`axLLM()`'s last parameter would receive `mode: 'emotion' | 'memory' | 'otherAx' | 'submodel' | 'translate'`. This way, users can utilize models they don't use. Mainly `emotion`, sometimes `translate`.

This is the smallest change I can propose without overwriting the whole model config. Another candidate involves `axLLM()`, a some kind of identifier, and plugins intercepting it.

## Impact

None yet.
