### PR TITLE
feat: support NovelAI Diffusion V5 image generation

### DIFF
--- a/src/ts/process/novelaiImage.test.ts
+++ b/src/ts/process/novelaiImage.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import {
+    buildNovelAiRequestBody,
+    fitNaiGenerationResolution,
+    formatNovelAiPrompt,
+    isNovelAiV5Model,
+    novelAiModelCapabilities,
+    type NovelAiGenerationConfig,
+} from './novelaiImage'
+
+const baseConfig: NovelAiGenerationConfig = {
+    prompt: '1girl, portrait',
+    negativePrompt: 'blurry',
+    model: 'nai-diffusion-4-5-full',
+    width: 1024,
+    height: 1024,
+    sampler: 'k_euler_ancestral',
+    steps: 28,
+    scale: 5,
+    cfgRescale: 0,
+    noiseSchedule: 'native',
+    seed: 123,
+    extraNoiseSeed: 456,
+    decrisp: false,
+    sm: false,
+    smDyn: false,
+    legacyUc: false,
+    varietyPlus: false,
+}
+
+describe('NovelAI model capabilities', () => {
+    it('recognizes V5 and disables unsupported legacy features', () => {
+        expect(isNovelAiV5Model('nai-diffusion-5-curated')).toBe(true)
+        expect(isNovelAiV5Model('nai-diffusion-4-5-full')).toBe(false)
+        expect(novelAiModelCapabilities('nai-diffusion-5-full')).toEqual({
+            vibes: false,
+            characterReferences: false,
+            variety: false,
+            noiseScheduleSelection: false,
+            transparency: true,
+            maxCharacters: 32,
+        })
+    })
+})
+
+describe('NovelAI resolution fitting', () => {
+    it('snaps dimensions to multiples of 64', () => {
+        expect(fitNaiGenerationResolution(1000, 1000)).toEqual({ width: 1024, height: 1024 })
+    })
+
+    it('preserves the last-edited dimension under the 3 Mi pixel limit', () => {
+        expect(fitNaiGenerationResolution(2560, 1440, 'height')).toEqual({
+            width: 2112,
+            height: 1472,
+        })
+        expect(fitNaiGenerationResolution(2560, 1440, 'width')).toEqual({
+            width: 2560,
+            height: 1216,
+        })
+    })
+
+    it('allows dimensions above 2048 when their total area is valid', () => {
+        expect(fitNaiGenerationResolution(3200, 768, 'width')).toEqual({
+            width: 3200,
+            height: 768,
+        })
+    })
+})
+
+describe('NovelAI prompt formatting', () => {
+    it('keeps escaped parentheses and converts emphasis parentheses', () => {
+        expect(formatNovelAiPrompt('girl, (smile), \\(literal\\)')).toBe(
+            'girl, {smile}, (literal)'
+        )
+    })
+})
+
+describe('NovelAI payload building', () => {
+    it('preserves the existing V4.5 request contract', () => {
+        const body = buildNovelAiRequestBody(baseConfig)
+
+        expect(body).toMatchObject({
+            action: 'generate',
+            input: '1girl, portrait',
+            model: 'nai-diffusion-4-5-full',
+            parameters: {
+                params_version: 3,
+                width: 1024,
+                height: 1024,
+                negative_prompt: 'blurry',
+                noise_schedule: 'native',
+                ucPreset: 3,
+                qualityToggle: false,
+                legacy_uc: false,
+                reference_image_multiple: [],
+                reference_strength_multiple: [],
+                skip_cfg_above_sigma: null,
+            },
+        })
+        expect(body.parameters).not.toHaveProperty('tag_hint_qt')
+        expect(body.parameters).not.toHaveProperty('characterPrompts')
+    })
+
+    it('uses the V5 payload version, hints, fixed noise schedule, and no legacy capabilities', () => {
+        const body = buildNovelAiRequestBody({
+            ...baseConfig,
+            model: 'nai-diffusion-5-curated',
+            varietyPlus: true,
+        })
+
+        expect(body).toMatchObject({
+            model: 'nai-diffusion-5-curated',
+            parameters: {
+                params_version: 4,
+                noise_schedule: 'karras',
+                tag_hint_qt: 0,
+                tag_hint_uc_preset: 4,
+                image_format: 'png',
+                characterPrompts: [],
+            },
+        })
+        expect(body.parameters).not.toHaveProperty('legacy_uc')
+        expect(body.parameters).not.toHaveProperty('reference_image_multiple')
+        expect(body.parameters).not.toHaveProperty('director_reference_images')
+        expect(body.parameters).not.toHaveProperty('skip_cfg_above_sigma')
+        expect(body.parameters).not.toHaveProperty('extra_noise_seed')
+    })
+
+    it('merges V5 presets and keeps all character coordinate representations aligned', () => {
+        const body = buildNovelAiRequestBody({
+            ...baseConfig,
+            model: 'nai-diffusion-5-full',
+            prompt: '1girl\n# local note',
+            qualityPreset: 'light',
+            ucPreset: 4,
+            useCoords: true,
+            characterPrompts: [
+                {
+                    prompt: 'blue hair',
+                    negativePrompt: 'hat',
+                    center: { x: 0.17, y: 0.81 },
+                },
+                { prompt: '   ', center: { x: 0, y: 0 } },
+            ],
+        })
+
+        expect(body.input).toBe('1girl, very aesthetic, amazing quality, no text')
+        expect(body.parameters.negative_prompt).toBe('blurry')
+        expect(body.parameters.v4_prompt.caption.char_captions[0].centers[0]).toEqual({
+            x: 0.17,
+            y: 0.81,
+        })
+        expect(body.parameters.v4_negative_prompt.caption.char_captions[0].centers[0]).toEqual(
+            { x: 0.17, y: 0.81 }
+        )
+        expect(body.parameters.characterPrompts[0].center).toEqual({ x: 0.17, y: 0.81 })
+        expect(body.parameters.characterPrompts).toHaveLength(1)
+    })
+
+    it('adds the V5 transparent-background prompt and alpha hints only when enabled', () => {
+        const body = buildNovelAiRequestBody({
+            ...baseConfig,
+            model: 'nai-diffusion-5-curated',
+            transparentBackground: true,
+        })
+
+        expect(body.input).toBe('1girl, portrait, transparent background')
+        expect(body.parameters.straight_alpha).toBe(true)
+        expect(body.parameters.tag_hint_transparent_background).toBe(true)
+    })
+
+    it('clamps character coordinates and limits V5 to 32 active characters', () => {
+        const body = buildNovelAiRequestBody({
+            ...baseConfig,
+            model: 'nai-diffusion-5-curated',
+            useCoords: true,
+            characterPrompts: Array.from({ length: 33 }, (_, index) => ({
+                prompt: `character ${index}`,
+                center: { x: -1, y: 2 },
+            })),
+        })
+
+        expect(body.parameters.characterPrompts).toHaveLength(32)
+        expect(body.parameters.characterPrompts[0].center).toEqual({ x: 0, y: 1 })
+    })
+})

--- a/src/ts/process/novelaiImage.test.ts
+++ b/src/ts/process/novelaiImage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+    applyNovelAiImg2Img,
     buildNovelAiRequestBody,
     fitNaiGenerationResolution,
     formatNovelAiPrompt,
@@ -182,5 +183,29 @@ describe('NovelAI payload building', () => {
 
         expect(body.parameters.characterPrompts).toHaveLength(32)
         expect(body.parameters.characterPrompts[0].center).toEqual({ x: 0, y: 1 })
+    })
+
+    it('adds the V5 img2img fields without changing the legacy text-to-image contract', () => {
+        const body = applyNovelAiImg2Img(
+            buildNovelAiRequestBody({
+                ...baseConfig,
+                model: 'nai-diffusion-5-curated',
+            }),
+            {
+                imageBase64: 'source-image',
+                strength: 0.7,
+                noise: 0.1,
+                extraNoiseSeed: 789,
+            }
+        )
+
+        expect(body.action).toBe('img2img')
+        expect(body.parameters).toMatchObject({
+            image: 'source-image',
+            strength: 0.7,
+            noise: 0.1,
+            extra_noise_seed: 789,
+            color_correct: false,
+        })
     })
 })

--- a/src/ts/process/novelaiImage.ts
+++ b/src/ts/process/novelaiImage.ts
@@ -1,0 +1,368 @@
+export const NAI_V5_CURATED = 'nai-diffusion-5-curated'
+
+export const NAI_RESOLUTION_STEP = 64
+export const NAI_MIN_RESOLUTION = 64
+export const NAI_MAX_GENERATION_PIXELS = 3 * 1024 * 1024
+
+export type NaiUcPreset = 0 | 1 | 3 | 4
+export type NaiQualityPreset = 'none' | 'standard' | 'light'
+export type NaiResolutionDimension = 'width' | 'height'
+
+export interface NaiCharacterPrompt {
+    prompt: string
+    negativePrompt?: string
+    enabled?: boolean
+    center?: {
+        x: number
+        y: number
+    }
+}
+
+export interface NovelAiGenerationConfig {
+    prompt: string
+    negativePrompt: string
+    model: string
+    width: number
+    height: number
+    sampler: string
+    steps: number
+    scale: number
+    cfgRescale: number
+    noiseSchedule: string
+    seed: number
+    extraNoiseSeed: number
+    decrisp: boolean
+    sm: boolean
+    smDyn: boolean
+    legacyUc: boolean
+    varietyPlus: boolean
+    qualityPreset?: NaiQualityPreset
+    ucPreset?: NaiUcPreset
+    transparentBackground?: boolean
+    characterPrompts?: NaiCharacterPrompt[]
+    useCoords?: boolean
+}
+
+export interface NovelAiRequestBody {
+    action: 'generate' | 'img2img'
+    input: string
+    model: string
+    parameters: Record<string, any>
+}
+
+export interface NaiModelCapabilities {
+    vibes: boolean
+    characterReferences: boolean
+    variety: boolean
+    noiseScheduleSelection: boolean
+    transparency: boolean
+    maxCharacters: number
+}
+
+const QUALITY_SUFFIX_STANDARD = ', very aesthetic, masterpiece, no text'
+const QUALITY_SUFFIX_LIGHT = ', very aesthetic, amazing quality, no text'
+
+const UC_HEAVY =
+    'nsfw, lowres, artistic error, film grain, scan artifacts, worst quality, bad quality, jpeg artifacts, very displeasing, chromatic aberration, dithering, halftone, screentone, multiple views, logo, too many watermarks, negative space, blank page'
+const V5_UC_HEAVY = UC_HEAVY.replace(/^nsfw, /, '')
+
+const V5_UC_PRESETS: Record<NaiUcPreset, string> = {
+    0: V5_UC_HEAVY,
+    1: 'lowres, bad hands, bad anatomy, artistic error, sepia, white haze, worst quality, very displeasing, jpeg artifacts, 0::ai-generated::',
+    3: V5_UC_HEAVY + ', @_@, mismatched pupils, glowing eyes, bad anatomy',
+    4: '',
+}
+
+const QUALITY_HINT: Record<NaiQualityPreset, number> = {
+    none: 0,
+    standard: 1,
+    light: 3,
+}
+
+const UC_HINT: Record<NaiUcPreset, number> = {
+    0: 2,
+    1: 3,
+    3: 4,
+    4: 0,
+}
+
+export function isNovelAiV5Model(model: string): boolean {
+    return model.startsWith('nai-diffusion-5-')
+}
+
+export function novelAiModelCapabilities(model: string): NaiModelCapabilities {
+    if (isNovelAiV5Model(model)) {
+        return {
+            vibes: false,
+            characterReferences: false,
+            variety: false,
+            noiseScheduleSelection: false,
+            transparency: true,
+            maxCharacters: 32,
+        }
+    }
+
+    return {
+        vibes: true,
+        characterReferences: true,
+        variety: true,
+        noiseScheduleSelection: true,
+        transparency: false,
+        maxCharacters: 6,
+    }
+}
+
+export function snapNaiDimension(value: number): number {
+    if (!Number.isFinite(value)) {
+        return Number.NaN
+    }
+    return Math.max(NAI_MIN_RESOLUTION, Math.round(value / NAI_RESOLUTION_STEP) * NAI_RESOLUTION_STEP)
+}
+
+export function fitNaiGenerationResolution(
+    inputWidth: number,
+    inputHeight: number,
+    preservedDimension: NaiResolutionDimension = 'height'
+): { width: number; height: number } | null {
+    let width = snapNaiDimension(inputWidth)
+    let height = snapNaiDimension(inputHeight)
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+        return null
+    }
+    if (width * height <= NAI_MAX_GENERATION_PIXELS) {
+        return { width, height }
+    }
+
+    const maxPreservedDimension = NAI_MAX_GENERATION_PIXELS / NAI_MIN_RESOLUTION
+    if (preservedDimension === 'width') {
+        width = Math.min(width, maxPreservedDimension)
+        height = Math.max(
+            NAI_MIN_RESOLUTION,
+            Math.floor(NAI_MAX_GENERATION_PIXELS / width / NAI_RESOLUTION_STEP) * NAI_RESOLUTION_STEP
+        )
+    } else {
+        height = Math.min(height, maxPreservedDimension)
+        width = Math.max(
+            NAI_MIN_RESOLUTION,
+            Math.floor(NAI_MAX_GENERATION_PIXELS / height / NAI_RESOLUTION_STEP) * NAI_RESOLUTION_STEP
+        )
+    }
+
+    return { width, height }
+}
+
+export function formatNovelAiPrompt(prompt: string): string {
+    return prompt
+        .replaceAll('\\(', '♧')
+        .replaceAll('\\)', '♤')
+        .replaceAll('(', '{')
+        .replaceAll(')', '}')
+        .replaceAll('♧', '(')
+        .replaceAll('♤', ')')
+}
+
+export function removeNovelAiPromptComments(prompt: string): string {
+    return prompt
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .join('\n')
+}
+
+function applyQualityPreset(prompt: string, preset: NaiQualityPreset): string {
+    if (preset === 'standard') {
+        return prompt + QUALITY_SUFFIX_STANDARD
+    }
+    if (preset === 'light') {
+        return prompt + QUALITY_SUFFIX_LIGHT
+    }
+    return prompt
+}
+
+function applyV5UcPreset(negativePrompt: string, preset: NaiUcPreset): string {
+    const presetText = V5_UC_PRESETS[preset]
+    return presetText
+        ? negativePrompt
+            ? `${presetText}, ${negativePrompt}`
+            : presetText
+        : negativePrompt
+}
+
+function normalizeCenter(center: NaiCharacterPrompt['center']): { x: number; y: number } {
+    const x = Number.isFinite(center?.x) ? center!.x : 0.5
+    const y = Number.isFinite(center?.y) ? center!.y : 0.5
+    return {
+        x: Math.min(1, Math.max(0, x)),
+        y: Math.min(1, Math.max(0, y)),
+    }
+}
+
+function activeCharacterPrompts(config: NovelAiGenerationConfig): Array<Required<NaiCharacterPrompt>> {
+    const maxCharacters = novelAiModelCapabilities(config.model).maxCharacters
+    return (config.characterPrompts ?? [])
+        .map((character) => ({
+            prompt: removeNovelAiPromptComments(character.prompt),
+            negativePrompt: removeNovelAiPromptComments(character.negativePrompt ?? ''),
+            enabled: character.enabled ?? true,
+            center: normalizeCenter(character.center),
+        }))
+        .filter((character) => character.enabled && character.prompt.trim())
+        .slice(0, maxCharacters)
+}
+
+function varietySigma(config: NovelAiGenerationConfig): number | null {
+    if (!config.varietyPlus) {
+        return null
+    }
+    if (config.model.includes('nai-diffusion-4-5')) {
+        return Math.sqrt(config.width * config.height) * 0.05766
+    }
+    if (
+        config.model.includes('nai-diffusion-4-full') ||
+        config.model.includes('nai-diffusion-4-curated') ||
+        config.model.includes('nai-diffusion-3') ||
+        config.model.includes('nai-diffusion-furry-3')
+    ) {
+        return Math.sqrt(config.width * config.height) * 0.01889
+    }
+    return null
+}
+
+export function buildNovelAiRequestBody(config: NovelAiGenerationConfig): NovelAiRequestBody {
+    const v5 = isNovelAiV5Model(config.model)
+    const capabilities = novelAiModelCapabilities(config.model)
+    const qualityPreset = config.qualityPreset ?? 'none'
+    const ucPreset = config.ucPreset ?? 3
+    const useCoords = config.useCoords ?? false
+    const formattedPrompt = formatNovelAiPrompt(config.prompt)
+    const formattedNegative = formatNovelAiPrompt(config.negativePrompt)
+    const userPrompt = v5 ? removeNovelAiPromptComments(formattedPrompt) : formattedPrompt
+    const transparentPrompt =
+        v5 && config.transparentBackground
+            ? userPrompt
+                ? `${userPrompt}, transparent background`
+                : 'transparent background'
+            : userPrompt
+    const prompt = v5 ? applyQualityPreset(transparentPrompt, qualityPreset) : userPrompt
+    const negativePrompt = v5
+        ? applyV5UcPreset(removeNovelAiPromptComments(formattedNegative), ucPreset)
+        : formattedNegative
+    const resolution = v5
+        ? (fitNaiGenerationResolution(config.width, config.height) ?? {
+              width: NAI_MIN_RESOLUTION,
+              height: NAI_MIN_RESOLUTION,
+          })
+        : { width: config.width, height: config.height }
+    const characters = activeCharacterPrompts(config)
+    const center = (character: Required<NaiCharacterPrompt>) =>
+        useCoords ? character.center : { x: 0.5, y: 0.5 }
+
+    const parameters: Record<string, any> = {
+        params_version: v5 ? 4 : 3,
+        add_original_image: true,
+        cfg_rescale: config.cfgRescale,
+        controlnet_strength: 1,
+        dynamic_thresholding: v5
+            ? false
+            : config.model.includes('nai-diffusion-3') ||
+                config.model.includes('nai-diffusion-furry-3') ||
+                config.model.includes('nai-diffusion-2')
+              ? config.decrisp
+              : false,
+        n_samples: 1,
+        width: resolution.width,
+        height: resolution.height,
+        sampler: config.sampler,
+        steps: config.steps,
+        scale: config.scale,
+        negative_prompt: negativePrompt,
+        noise_schedule: v5 ? 'karras' : config.noiseSchedule,
+        normalize_reference_strength_multiple: true,
+        ucPreset,
+        qualityToggle: qualityPreset !== 'none',
+        legacy_v3_extend: false,
+        legacy: false,
+        autoSmea: false,
+        use_coords: useCoords,
+        seed: config.seed,
+        prefer_brownian: true,
+        deliberate_euler_ancestral_bug: false,
+        v4_prompt: {
+            caption: {
+                base_caption: prompt,
+                char_captions: characters.map((character) => ({
+                    char_caption: character.prompt,
+                    centers: [center(character)],
+                })),
+            },
+            use_coords: useCoords,
+            use_order: true,
+        },
+        v4_negative_prompt: {
+            caption: {
+                base_caption: negativePrompt,
+                char_captions: characters.map((character) => ({
+                    char_caption: character.negativePrompt,
+                    centers: [center(character)],
+                })),
+            },
+        },
+    }
+
+    if (v5) {
+        parameters.tag_hint_qt = QUALITY_HINT[qualityPreset]
+        parameters.tag_hint_uc_preset = UC_HINT[ucPreset]
+        parameters.inpaintImg2ImgStrength = 1
+        parameters.characterPrompts = characters.map((character) => ({
+            prompt: character.prompt,
+            uc: character.negativePrompt,
+            center: center(character),
+            enabled: true,
+        }))
+        parameters.image_format = 'png'
+        if (config.transparentBackground) {
+            parameters.straight_alpha = true
+            parameters.tag_hint_transparent_background = true
+        }
+    } else {
+        parameters.extra_noise_seed = config.extraNoiseSeed
+        parameters.sm =
+            config.model.includes('nai-diffusion-3') ||
+            config.model.includes('nai-diffusion-furry-3') ||
+            config.model.includes('nai-diffusion-2')
+                ? config.sm
+                : undefined
+        parameters.sm_dyn =
+            config.model.includes('nai-diffusion-3') ||
+            config.model.includes('nai-diffusion-furry-3')
+                ? config.smDyn
+                : undefined
+        parameters.uncond_scale = 1
+        parameters.legacy_uc = config.legacyUc
+        parameters.v4_negative_prompt.legacy_uc = config.legacyUc
+        parameters.reference_image_multiple = []
+        parameters.reference_strength_multiple = []
+        parameters.image = undefined
+        parameters.strength = undefined
+        parameters.noise = undefined
+        parameters.skip_cfg_above_sigma = capabilities.variety ? varietySigma(config) : null
+        parameters.director_reference_images = []
+        parameters.director_reference_descriptions = []
+        parameters.director_reference_information_extracted = []
+        parameters.director_reference_strength_values = []
+        if (characters.length) {
+            parameters.characterPrompts = characters.map((character) => ({
+                prompt: character.prompt,
+                uc: character.negativePrompt,
+                center: center(character),
+                enabled: true,
+            }))
+        }
+    }
+
+    return {
+        action: 'generate',
+        input: prompt,
+        model: config.model,
+        parameters,
+    }
+}

--- a/src/ts/process/novelaiImage.ts
+++ b/src/ts/process/novelaiImage.ts
@@ -50,6 +50,13 @@ export interface NovelAiRequestBody {
     parameters: Record<string, any>
 }
 
+export interface NovelAiImg2ImgOptions {
+    imageBase64: string
+    strength: number
+    noise: number
+    extraNoiseSeed: number
+}
+
 export interface NaiModelCapabilities {
     vibes: boolean
     characterReferences: boolean
@@ -365,4 +372,21 @@ export function buildNovelAiRequestBody(config: NovelAiGenerationConfig): NovelA
         model: config.model,
         parameters,
     }
+}
+
+export function applyNovelAiImg2Img(
+    body: NovelAiRequestBody,
+    options: NovelAiImg2ImgOptions
+): NovelAiRequestBody {
+    body.action = 'img2img'
+    body.parameters.image = options.imageBase64
+    body.parameters.strength = options.strength
+    body.parameters.noise = options.noise
+
+    if (isNovelAiV5Model(body.model)) {
+        body.parameters.extra_noise_seed = options.extraNoiseSeed
+        body.parameters.color_correct = false
+    }
+
+    return body
 }

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -8,6 +8,10 @@ import type { OpenAIChat } from "./index.svelte"
 import { processZip } from "./processzip"
 import { keiServerURL } from "../kei/kei"
 import random from "lodash/random"
+import {
+    buildNovelAiRequestBody,
+    novelAiModelCapabilities,
+} from "./novelaiImage"
 
 export async function stableDiff(currentChar:character,prompt:string){
     let db = getDatabase()
@@ -121,99 +125,37 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
         }
     }
     if(db.sdProvider === 'novelai'){
-        genPrompt = genPrompt
-            .replaceAll('\\(', "♧")
-            .replaceAll('\\)', "♤")
-            .replaceAll('(','{')
-            .replaceAll(')','}')
-            .replaceAll('♧','(')
-            .replaceAll('♤',')')
-
         let reqlist:any = {}
+        const capabilities = novelAiModelCapabilities(db.NAIImgModel)
 
         const commonReq = {
-            body: {
-                "input": genPrompt,
-                "model": db.NAIImgModel,
-                "parameters": {
-                    "params_version": 3,
-                    "add_original_image": true,
-                    "cfg_rescale": db.NAIImgConfig.cfg_rescale,
-                    "controlnet_strength": 1,
-                    "dynamic_thresholding": db.NAIImgModel.includes('nai-diffusion-3') || db.NAIImgModel.includes('nai-diffusion-furry-3') || db.NAIImgModel.includes('nai-diffusion-2') ? db.NAIImgConfig.decrisp : false,
-                    "n_samples": 1,
-                    "width": db.NAIImgConfig.width,
-                    "height": db.NAIImgConfig.height,
-                    "sampler": db.NAIImgConfig.sampler,
-                    "steps": db.NAIImgConfig.steps,
-                    "scale": db.NAIImgConfig.scale,
-                    "negative_prompt": neg,
-                    "sm": db.NAIImgModel.includes('nai-diffusion-3') || db.NAIImgModel.includes('nai-diffusion-furry-3') || db.NAIImgModel.includes('nai-diffusion-2') ? db.NAIImgConfig.sm : undefined,
-                    "sm_dyn": db.NAIImgModel.includes('nai-diffusion-3') || db.NAIImgModel.includes('nai-diffusion-furry-3') ? db.NAIImgConfig.sm_dyn : undefined,
-                    "noise_schedule": db.NAIImgConfig.noise_schedule,
-                    "normalize_reference_strength_multiple":true,
-                    "ucPreset": 3,
-                    "uncond_scale": 1,
-                    "qualityToggle": false,
-                    "legacy_v3_extend": false,
-                    "legacy": false,
-                    //add v4
-                    "autoSmea": false,
-                    "use_coords": false,
-                    "legacy_uc": db.NAIImgConfig.legacy_uc,
-                    "v4_prompt":{
-                        caption:{
-                            base_caption:genPrompt,
-                            char_captions: []
-                        },
-                        use_coords: false,
-                        use_order: true,
-                    },
-                    "v4_negative_prompt":{
-                        caption:{
-                            base_caption:neg,
-                            char_captions: []
-                        },
-                        legacy_uc: db.NAIImgConfig.legacy_uc,
-                    },
-                    "reference_image_multiple" : [],
-                    "reference_strength_multiple" : [],
-                    //add reference image
-                    "image": undefined, 
-                    "strength": undefined,
-                    "noise": undefined,
-                    //add additional parameters
-                    "seed": random(0, 2**32-1),
-                    "extra_noise_seed": random(0, 2**32-1),
-                    "prefer_brownian": true,
-                    "deliberate_euler_ancestral_bug": false,
-                    "skip_cfg_above_sigma": null,
-                    //add character reference
-                    "director_reference_images": [],
-                    "director_reference_descriptions": [],
-                    "director_reference_information_extracted": [],
-                    "director_reference_strength_values": [],
-                }
-            },
+            body: buildNovelAiRequestBody({
+                prompt: genPrompt,
+                negativePrompt: neg,
+                model: db.NAIImgModel,
+                width: db.NAIImgConfig.width,
+                height: db.NAIImgConfig.height,
+                sampler: db.NAIImgConfig.sampler,
+                steps: db.NAIImgConfig.steps,
+                scale: db.NAIImgConfig.scale,
+                cfgRescale: db.NAIImgConfig.cfg_rescale,
+                noiseSchedule: db.NAIImgConfig.noise_schedule,
+                seed: random(0, 2**32-1),
+                extraNoiseSeed: random(0, 2**32-1),
+                decrisp: db.NAIImgConfig.decrisp,
+                sm: db.NAIImgConfig.sm,
+                smDyn: db.NAIImgConfig.sm_dyn,
+                legacyUc: db.NAIImgConfig.legacy_uc,
+                varietyPlus: db.NAIImgConfig.variety_plus,
+            }),
             headers:{
                 "Authorization": "Bearer " + db.NAIApiKey
             },
             rawResponse: true
         }
 
-        // Add Variety+ option 
-        if(db.NAIImgConfig.variety_plus) {
-            if(db.NAIImgModel.includes('nai-diffusion-4-full') || db.NAIImgModel.includes('nai-diffusion-4-curated')
-            || db.NAIImgModel.includes('nai-diffusion-3') || db.NAIImgModel.includes('nai-diffusion-furry-3')) {
-                commonReq.body.parameters.skip_cfg_above_sigma = Math.sqrt(db.NAIImgConfig.width * db.NAIImgConfig.height) * 0.01889;
-            }
-            if(db.NAIImgModel.includes('nai-diffusion-4-5-full') || db.NAIImgModel.includes('nai-diffusion-4-5-curated')) {
-                commonReq.body.parameters.skip_cfg_above_sigma = Math.sqrt(db.NAIImgConfig.width * db.NAIImgConfig.height) * 0.05766;
-            }
-        }
-
         // Add vibe reference_image_multiple if exists
-        if(db.NAIImgConfig.reference_mode === 'vibe' && db.NAIImgConfig.vibe_data) {
+        if(capabilities.vibes && db.NAIImgConfig.reference_mode === 'vibe' && db.NAIImgConfig.vibe_data) {
             const vibeData = db.NAIImgConfig.vibe_data;
             // Determine which model to use based on vibe_model_selection or fallback to current model
             const modelKey = db.NAIImgConfig.vibe_model_selection || 
@@ -252,7 +194,7 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
             }
         }
 
-        if(db.NAIImgConfig.reference_mode === 'character' &&
+        if(capabilities.characterReferences && db.NAIImgConfig.reference_mode === 'character' &&
             (db.NAIImgModel.includes('nai-diffusion-4-5-full') || db.NAIImgModel.includes('nai-diffusion-4-5-curated'))
         ) {
             let base64img = ''
@@ -321,8 +263,6 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
         }
 
         if(db.NAII2I){
-            let seed = random(0, 1000000000);
-
             let base64img = ''
             if(!db.NAIImgConfig.image || db.NAIImgConfig.image === ''){
                 const charimg = currentChar.image;

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -9,6 +9,7 @@ import { processZip } from "./processzip"
 import { keiServerURL } from "../kei/kei"
 import random from "lodash/random"
 import {
+    applyNovelAiImg2Img,
     buildNovelAiRequestBody,
     novelAiModelCapabilities,
 } from "./novelaiImage"
@@ -278,10 +279,12 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
             
             if(base64img) {
                 reqlist = commonReq;
-                reqlist.body.action = "img2img";
-                reqlist.body.parameters.image = base64img;
-                reqlist.body.parameters.strength = db.NAIImgConfig.strength || 0.7;
-                reqlist.body.parameters.noise = db.NAIImgConfig.noise || 0;
+                applyNovelAiImg2Img(reqlist.body, {
+                    imageBase64: base64img,
+                    strength: db.NAIImgConfig.strength || 0.7,
+                    noise: db.NAIImgConfig.noise || 0,
+                    extraNoiseSeed: random(0, 2**32-1),
+                })
             }
             
             console.log({img2img:reqlist});


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add the core request contracts required for NovelAI Diffusion V5 Full and Curated image generation while preserving the existing V4 and V4.5 paths.

## Related Issues

None.

## Changes

- Add a dedicated NovelAI image request builder with V5 model capability detection.
- Send V5 requests with the V5 parameter version, prompt hints, supported feature set, and PNG output contract.
- Normalize V5 resolutions to 64-pixel steps and keep generation area within the 3 Mi-pixel limit.
- Support the V5 text-to-image and image-to-image request fields.
- Prevent unsupported legacy Vibe Transfer, Character Reference, Variety+, and noise-schedule behavior from leaking into V5 requests.
- Add focused tests for V5 Full, V5 Curated, image-to-image, resolution fitting, prompt formatting, character coordinates, transparency, and the preserved V4.5 contract.

## Impact

Users can use the existing NovelAI V5 Full and Curated model selections for image generation instead of sending those models the legacy request shape. Existing NovelAI V4, V4.5, V3, and V2 request behavior remains supported.

This PR provides the core request layer only. Dedicated UI controls for V5 quality presets, UC presets, transparent backgrounds, and multi-character positioning are not exposed yet.

## Additional Notes

Validated with the focused NovelAI image test suite (11 tests), `pnpm check`, and `git diff --check`. Authenticated generation against the live NovelAI service and packaged desktop runtime validation have not been performed.
