### PR TITLE
Allow Lua image generation to set NovelAI orientation

### DIFF
--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -7,7 +7,7 @@ import { get } from "svelte/store";
 import { DBState, ReloadChatPointer, ReloadGUIPointer, selectedCharID } from "../stores.svelte";
 import { alertSelect, alertError, alertInput, alertNormal, alertConfirm } from "../alert";
 import { HypaProcesser } from "./memory/hypamemory";
-import { generateAIImage } from "./stableDiff";
+import { generateAIImage, type ImageGenerationOptions } from "./stableDiff";
 import { writeInlayImage, getInlayAsset } from "./files/inlays";
 import type { OpenAIChat, MultiModal } from "./index.svelte";
 import { requestChatData, type StreamResponseChunk } from "./request/request";
@@ -389,11 +389,16 @@ export async function runScripted(code:string, arg:{
                 }
             })
 
-            declareAPI('generateImage', async (id:string, value:string, negValue:string = '') => {
+            declareAPI('generateImage', async (id:string, value:string, negValue:string = '', options?:ImageGenerationOptions) => {
                 if(!ScriptingLowLevelIds.has(id)){
                     return
                 }
-                const gen = await generateAIImage(value, char as character, negValue, 'inlay')
+                const orientation = options?.orientation
+                if(orientation !== undefined && orientation !== 'landscape' && orientation !== 'portrait'){
+                    return 'Error: Image orientation must be landscape or portrait, received ' + orientation
+                }
+
+                const gen = await generateAIImage(value, char as character, negValue, 'inlay', options)
                 if(!gen){
                     return 'Error: Image generation failed'
                 }

--- a/src/ts/process/stableDiff.test.ts
+++ b/src/ts/process/stableDiff.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../alert', () => ({ alertError: vi.fn() }))
+vi.mock('../globalApi.svelte', () => ({ globalFetch: vi.fn(), readImage: vi.fn() }))
+vi.mock('../kei/kei', () => ({ keiServerURL: '' }))
+vi.mock('../storage/database.svelte', () => ({ getDatabase: vi.fn() }))
+vi.mock('../stores.svelte', () => ({ CharEmotion: { set: vi.fn() } }))
+vi.mock('./processzip', () => ({ processZip: vi.fn() }))
+vi.mock('./request/request', () => ({ requestChatData: vi.fn() }))
+
+import { applyImageOrientation } from './stableDiff'
+
+describe('applyImageOrientation', () => {
+  test('keeps configured dimensions without an orientation', () => {
+    expect(applyImageOrientation(1024, 640)).toEqual({ height: 640, width: 1024 })
+  })
+
+  test('places the longer edge on the width for landscape', () => {
+    expect(applyImageOrientation(640, 1024, 'landscape')).toEqual({ height: 640, width: 1024 })
+  })
+
+  test('places the longer edge on the height for portrait', () => {
+    expect(applyImageOrientation(1024, 640, 'portrait')).toEqual({ height: 1024, width: 640 })
+  })
+})

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -61,7 +61,7 @@ export async function stableDiff(currentChar:character,prompt:string){
     return await generateAIImage(genPrompt, currentChar, neg, '')
 }
 
-export async function generateAIImage(genPrompt:string, currentChar:character, neg:string, returnSdData:string):Promise<string|false>{
+export async function generateAIImage(genPrompt:string, currentChar:character, neg:string, returnSdData:string, options?:ImageGenerationOptions):Promise<string|false>{
     const db = getDatabase()
     console.log(db.sdProvider)
     if(db.sdProvider === 'webui'){
@@ -121,6 +121,8 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
         }
     }
     if(db.sdProvider === 'novelai'){
+        const dimensions = applyImageOrientation(db.NAIImgConfig.width, db.NAIImgConfig.height, options?.orientation)
+
         genPrompt = genPrompt
             .replaceAll('\\(', "♧")
             .replaceAll('\\)', "♤")
@@ -142,8 +144,8 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
                     "controlnet_strength": 1,
                     "dynamic_thresholding": db.NAIImgModel.includes('nai-diffusion-3') || db.NAIImgModel.includes('nai-diffusion-furry-3') || db.NAIImgModel.includes('nai-diffusion-2') ? db.NAIImgConfig.decrisp : false,
                     "n_samples": 1,
-                    "width": db.NAIImgConfig.width,
-                    "height": db.NAIImgConfig.height,
+                    "width": dimensions.width,
+                    "height": dimensions.height,
                     "sampler": db.NAIImgConfig.sampler,
                     "steps": db.NAIImgConfig.steps,
                     "scale": db.NAIImgConfig.scale,
@@ -945,4 +947,34 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
         }
     }
     return ''
+}
+
+export type ImageOrientation = 'landscape' | 'portrait'
+
+export interface ImageGenerationOptions {
+    orientation?: ImageOrientation
+}
+
+/**
+ * Places the longer edge on the width for landscape and on the height for portrait.
+ */
+export function applyImageOrientation(width: number, height: number, orientation?: ImageOrientation) {
+    if (!orientation) {
+        return { height, width }
+    }
+
+    const longerEdge = Math.max(height, width)
+    const shorterEdge = Math.min(height, width)
+
+    if (orientation === 'landscape') {
+        return {
+            height: shorterEdge,
+            width: longerEdge,
+        }
+    }
+
+    return {
+        height: longerEdge,
+        width: shorterEdge,
+    }
 }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Lua `generateImage()` may set its own `orientation`.

To prevent troll scripts draining NAI credits, the script can't modify dimension but only its orientation.

- If w/h set to 1000/500 (landscape)
  - No orientation (default, backward compat) => 1000/500
  - Portrait => 500/1000
  - Landscape => 1000/500

## Related Issues

None

## Changes

Lua `generateImage()` now expects up to 4 parameters.

NAI branch of `stableDiff.ts` calls a new function, `applyImageOrientation()`.

## Impact

None, backward compatible.
