### PR TITLE
fix: make SafeElement.addEventListener element-scoped as documented

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -400,19 +400,25 @@ const rects = await element.getClientRects();
 
 #### Event Listeners
 
-Event listeners have security restrictions and return unique IDs:
+Event listeners have security restrictions and return unique IDs. Listeners receive events that reach the element via normal DOM propagation, while non-bubbling events such as scroll fire only on the element itself:
 
 ```javascript
 // Add event listener - returns ID for later removal
 const listenerId = await element.addEventListener('click', async (event) => {
   console.log('Element clicked!');
-
-  // Do something with the event
-  const target = event.target;
 }, { capture: false });
 
 // Remove event listener using the ID
 await element.removeEventListener('click', listenerId);
+```
+
+To listen document-wide, use the `SafeDocument` from `getRootDocument()`:
+
+```javascript
+const rootDoc = await Risuai.getRootDocument();
+const id = await rootDoc.addEventListener('keydown', async (event) => {
+  console.log('Key pressed anywhere!');
+});
 ```
 
 **Allowed Events (Unlimited):**

--- a/src/ts/plugins/apiV3/risuai.d.ts
+++ b/src/ts/plugins/apiV3/risuai.d.ts
@@ -808,6 +808,7 @@ interface SafeElement {
      * - Keyboard: keydown, keyup, keypress
      *
      * listener function receives trimmed event object with common properties only.
+     * listeners receive events that reach the element via normal DOM propagation; for document-wide listening, use the SafeDocument from getRootDocument().
      * 
      * @example
      * ```typescript
@@ -827,9 +828,9 @@ interface SafeElement {
 
     /**
      * Removes an event listener using its ID
-     * @param type - Event type
+     * @param type - Event type (for compatibility; removal is resolved by ID)
      * @param id - Listener ID returned by addEventListener
-     * @param options - Event listener options
+     * @param options - Event listener options (for compatibility)
      */
     removeEventListener(
         type: string,

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -360,6 +360,8 @@ class SafeElement {
     }
 
     public removeEventListener(type:string, id:string, options?: boolean | EventListenerOptions) {
+        // type/options are unused, but are kept in the signature for API compatibility
+        // DOM removal silently no-ops if type/capture don't exactly match the registration, so the stored record is replayed instead
         const tracked = this.#eventIdMap.get(id);
         if(tracked){
             tracked.eventTarget.removeEventListener(tracked.type, tracked.listener, tracked.options);

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -59,13 +59,15 @@ const documentEventListeners: Array<{type: string, listener: EventListenerOrEven
 
 class SafeElement {
     #element: HTMLElement;
+    #eventTarget: EventTarget;  // Differs from #element for SafeDocument
     __classType = 'REMOTE_REQUIRED' as const;
 
-    constructor(element: HTMLElement) {
+    constructor(element: HTMLElement, eventTarget?: EventTarget) {
         if(element.getAttribute('freezed')){
             throw new Error("This element cannot be accessed by SafeELement")
         }
         this.#element = element;
+        this.#eventTarget = eventTarget ?? element;
     }
 
     public appendChild(child: SafeElement) {
@@ -358,7 +360,8 @@ class SafeElement {
 class SafeDocument extends SafeElement {
     __classType = 'REMOTE_REQUIRED' as const;
     constructor(document: Document) {
-        super(document.documentElement);
+        // document-level events (including viewport scroll) are bound to the Document
+        super(document.documentElement, document);
     }
     createElement(tagName: string): SafeElement {
         if(!tagWhitelist.includes(tagName.toLowerCase())) {

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -55,7 +55,13 @@ import {
 */
 
 const pluginChannel = new Map<string, Function>();
-const documentEventListeners: Array<{type: string, listener: EventListenerOrEventListenerObject, options: any}> = [];
+type TrackedEventListener = {
+    eventTarget: EventTarget
+    type: string
+    listener: EventListenerOrEventListenerObject
+    options: AddEventListenerOptions
+};
+const pluginEventListeners: TrackedEventListener[] = [];
 
 class SafeElement {
     #element: HTMLElement;
@@ -241,7 +247,7 @@ class SafeElement {
     public scrollIntoView(options?: boolean | ScrollIntoViewOptions) {
         this.#element.scrollIntoView(options);
     }
-    #eventIdMap = new Map<string, Function>()
+    #eventIdMap = new Map<string, TrackedEventListener>()
 
     public async addEventListener(type:string, listener: (event: any) => void, options?: boolean | AddEventListenerOptions):Promise<string> {
         const realOptions = typeof options === 'boolean' ? { capture: options } : options || {};
@@ -316,9 +322,15 @@ class SafeElement {
             const modifiedListener = (event: any) => {
                 listener(trimEvent(event))
             }
-            this.#eventIdMap.set(id, modifiedListener)
-            documentEventListeners.push({type, listener: modifiedListener as EventListenerOrEventListenerObject, options: realOptions})
-            document.addEventListener(type, modifiedListener, realOptions)
+            const tracked: TrackedEventListener = {
+                eventTarget: this.#eventTarget,
+                type,
+                listener: modifiedListener as EventListenerOrEventListenerObject,
+                options: realOptions,
+            };
+            this.#eventIdMap.set(id, tracked);
+            pluginEventListeners.push(tracked);
+            tracked.eventTarget.addEventListener(tracked.type, tracked.listener, tracked.options);
             return id;
         }
         else if(allowedDelayedEventListeners.includes(type)){
@@ -331,9 +343,15 @@ class SafeElement {
                     listener(trimEvent(event));
                 }, delay);
             }
-            this.#eventIdMap.set(id, modifiedListener)
-            documentEventListeners.push({type, listener: modifiedListener as EventListenerOrEventListenerObject, options: realOptions})
-            document.addEventListener(type, modifiedListener, realOptions);
+            const tracked: TrackedEventListener = {
+                eventTarget: this.#eventTarget,
+                type,
+                listener: modifiedListener as EventListenerOrEventListenerObject,
+                options: realOptions,
+            };
+            this.#eventIdMap.set(id, tracked);
+            pluginEventListeners.push(tracked);
+            tracked.eventTarget.addEventListener(tracked.type, tracked.listener, tracked.options);
             return id;
         }
         else{
@@ -342,12 +360,11 @@ class SafeElement {
     }
 
     public removeEventListener(type:string, id:string, options?: boolean | EventListenerOptions) {
-        const listener = this.#eventIdMap.get(id);
-        if(listener){
-            const realOptions = typeof options === 'boolean' ? { capture: options } : options || {};
-            document.removeEventListener(type, listener as EventListenerOrEventListenerObject, realOptions);
-            const idx = documentEventListeners.findIndex(e => e.listener === listener);
-            if(idx !== -1) documentEventListeners.splice(idx, 1);
+        const tracked = this.#eventIdMap.get(id);
+        if(tracked){
+            tracked.eventTarget.removeEventListener(tracked.type, tracked.listener, tracked.options);
+            const idx = pluginEventListeners.indexOf(tracked);
+            if(idx !== -1) pluginEventListeners.splice(idx, 1);
             this.#eventIdMap.delete(id);
         }
     }
@@ -1389,10 +1406,10 @@ export async function loadV3Plugins(plugins:RisuPlugin[]){
         await unloadV3Plugin(instance.name);
     }));
 
-    for(const entry of documentEventListeners){
-        document.removeEventListener(entry.type, entry.listener, entry.options);
+    for(const entry of pluginEventListeners){
+        entry.eventTarget.removeEventListener(entry.type, entry.listener, entry.options);
     }
-    documentEventListeners.length = 0;
+    pluginEventListeners.length = 0;
 
     const loadPromises = plugins.map(plugin => executePluginV3(plugin));
     await Promise.all(loadPromises);


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Contrary to the documented behavior, `SafeElement.addEventListener` has attached every listener to `document`.

As a result, matching events that reached `document` triggered listeners even when they occurred outside the element's scope: a close button's `click` handler ran on every click, while an element-level `keydown` listener received every keystroke across the app, with each delivery crossing the plugin iframe boundary as an RPC.

This PR makes the implementation match the documented contract: listeners attach to their own element.

## Related Issues

None.

## Changes

- `SafeElement.addEventListener` attaches to the wrapped element. `SafeDocument` attaches to the actual `Document` node, so document-wide listening continues to behave exactly as before (including viewport `scroll` events that target the `Document` itself).
- Each registration is tracked as a `{ eventTarget, type, listener, options }` record shared by the per-instance ID map and the reload cleanup array. Removal and reload cleanup detach using the stored record.
  - This also fixes a pre-existing defect: removing with mismatched `type`/`capture` used to no-op natively while the bookkeeping was deleted anyway, leaving an untracked live listener until page refresh.
- Docs: state the element scope, point document-wide use to `getRootDocument()`, and remove the `event.target` access from the example because `target` is not included in the delivered payload.

## Impact

### Intentional Changes

- Plugins that intentionally use this behavior (most commonly global hotkeys) must **explicitly** migrate to `getRootDocument()` instead of receiving global keyboard events through this indirect behavior (added to the documentation).
- Listeners are bound to a specific DOM node and do not survive the node being replaced (native semantics).

### Improvements

- The most immediately visible misfire is fixed: plugin UI no longer reacts when the user clicks outside the registered element.
- `capture`/`once` apply to the element.
- Element listeners stop receiving app-wide keystrokes. This fixes the unexpectedly broad collection surface created when `keydown` was registered on a non-focusable element.
- Out-of-scope events no longer cross the iframe boundary (an element `mousemove` listener previously produced one RPC per pointer move anywhere in the app)
- Non-bubbling event types now work correctly on elements for the first time.

### Unchanged (pre-existing)

Listener IDs remain usable only on the wrapper instance that issued them.

---

## Considered and Rejected

1. **Keep the `document` attachment, add a containment filter**: `documentElement.contains(document)` is false, so this would silently break SafeDocument viewport `scroll`; native `{once:true}` gets consumed by filtered-out events; non-bubbling whitelist entries (`mouseleave`, element `scroll`, ...) never reach a bubble-phase `document` listener at all, so they would stay broken. This approach would require both a SafeDocument exception and manual emulation of native event behavior.

2. **Deliver `event.target` and let plugins filter**: leaves the keystroke exposure and per-event RPC cost in place, and adds one host-side remote reference per delivered event; the registry-growth problem class addressed in #1536.

## Tested

Verified with four local test plugins on the running app: inside/outside delivery for `click`/`keydown`/`mousemove`; non-bubbling delivery (`mouseleave`, element `scroll`); `{once:true}` consumption; `capture` scoping in both the object and boolean forms; the mismatched-removal orphan (via `getEventListeners`); SafeDocument `click`/`keydown`/`scroll` identical before and after; individual removal and reload cleanup both return listener counts to baseline.

## Additional Notes
