### PR TITLE
fix: lua setFullChat wiping message metadata

### DIFF
--- a/src/ts/process/scriptings.test.ts
+++ b/src/ts/process/scriptings.test.ts
@@ -90,3 +90,100 @@ test('keeps explicit false as the generation stop signal', async () => {
   expect(result.res).toBe(false)
   expect(result.stopSending).toBe(true)
 })
+
+test('setFullChat preserves message metadata on an identity round-trip', async () => {
+  const message = [
+    {
+      role: 'user',
+      data: 'hello',
+      chatId: 'id-user',
+      time: 100,
+      name: 'alice',
+      otherUser: true,
+    },
+    {
+      role: 'char',
+      data: 'hi',
+      chatId: 'id-char',
+      time: 200,
+      saying: 'char-a',
+      generationInfo: { generationId: 'gen-1', model: 'model-x' },
+      promptInfo: { promptText: [] },
+    },
+  ]
+
+  const result = await runScripted(
+    `
+      function onStart(id)
+        setFullChat(id, getFullChat(id))
+      end
+    `,
+    {
+      char: {} as never,
+      chat: { message: structuredClone(message) } as never,
+      mode: 'start',
+    }
+  )
+
+  expect(result.chat.message).toEqual(message)
+})
+
+test('setFullChat matches messages by chatId and only overwrites role and data', async () => {
+  const result = await runScripted(
+    `
+      function onStart(id)
+        local chat = getFullChat(id)
+        chat[1].data = "edited"
+        chat[2].role = "user"
+        chat[2].time = 999
+        table.insert(chat, 1, { role = "char", data = "prepended" })
+        setFullChat(id, chat)
+      end
+    `,
+    {
+      char: {} as never,
+      chat: {
+        message: [
+          { role: 'user', data: 'first', chatId: 'id-1', time: 1 },
+          { role: 'char', data: 'second', chatId: 'id-2', time: 2, generationInfo: { generationId: 'gen-2' } },
+        ],
+      } as never,
+      mode: 'start',
+    }
+  )
+
+  expect(result.chat.message).toEqual([
+    { role: 'char', data: 'prepended' },
+    { role: 'user', data: 'edited', chatId: 'id-1', time: 1 },
+    { role: 'user', data: 'second', chatId: 'id-2', time: 2, generationInfo: { generationId: 'gen-2' } },
+  ])
+})
+
+test('setFullChat drops messages that are no longer present and does not alias duplicated chatIds', async () => {
+  const result = await runScripted(
+    `
+      function onStart(id)
+        local chat = getFullChat(id)
+        table.remove(chat, 1)
+        table.insert(chat, { role = chat[1].role, data = "copy", chatId = chat[1].chatId })
+        setFullChat(id, chat)
+      end
+    `,
+    {
+      char: {} as never,
+      chat: {
+        message: [
+          { role: 'user', data: 'first', chatId: 'id-1', time: 1 },
+          { role: 'char', data: 'second', chatId: 'id-2', time: 2 },
+        ],
+      } as never,
+      mode: 'start',
+    }
+  )
+
+  expect(result.chat.message).toEqual([
+    { role: 'char', data: 'second', chatId: 'id-2', time: 2 },
+    { role: 'char', data: 'copy' },
+  ])
+  expect(result.chat.message[0]).not.toBe(result.chat.message[1])
+})

--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -2,7 +2,7 @@ import { asBuffer } from 'src/ts/util';
 import { getChatVar, getGlobalChatVar, setChatVar } from "../parser/chatVar.svelte";
 import { hasher, type simpleCharacterArgument, risuChatParser } from "../parser/parser.svelte";
 import { LuaEngine, LuaFactory } from "wasmoon";
-import { getCurrentCharacter, getCurrentChat, getDatabase, setDatabase, type Chat, type character, type groupChat, type triggerscript } from "../storage/database.svelte";
+import { getCurrentCharacter, getCurrentChat, getDatabase, setDatabase, type Chat, type character, type groupChat, type Message, type triggerscript } from "../storage/database.svelte";
 import { get } from "svelte/store";
 import { DBState, ReloadChatPointer, ReloadGUIPointer, selectedCharID } from "../stores.svelte";
 import { alertSelect, alertError, alertInput, alertNormal, alertConfirm } from "../alert";
@@ -167,7 +167,8 @@ export async function runScripted(code:string, arg:{
                 const data = {
                     role: chat.role,
                     data: chat.data,
-                    time: chat.time ?? 0
+                    time: chat.time ?? 0,
+                    chatId: chat.chatId
                 }
                 return JSON.stringify(data)
             })
@@ -190,6 +191,7 @@ export async function runScripted(code:string, arg:{
                     role: v.role,
                     data: v.data,
                     time: v.time ?? 0,
+                    chatId: v.chatId,
                 })))
             })
 
@@ -254,7 +256,8 @@ export async function runScripted(code:string, arg:{
                     return {
                         role: v.role,
                         data: v.data,
-                        time: v.time ?? 0
+                        time: v.time ?? 0,
+                        chatId: v.chatId
                     }
                 }))
                 return data
@@ -280,12 +283,24 @@ export async function runScripted(code:string, arg:{
                     return
                 }
                 const realValue = JSON.parse(value)
+                const byChatId = new Map<string, Message>()
+                for(const message of ScriptingEngineState.chat.message){
+                    if(message.chatId){
+                        byChatId.set(message.chatId, message)
+                    }
+                }
 
                 ScriptingEngineState.chat.message = realValue.map((v) => {
-                    return {
-                        role: v.role,
-                        data: v.data
+                    const role:'user'|'char' = v.role === 'user' ? 'user' : 'char'
+                    const data = v.data ?? ''
+                    const original = byChatId.get(v.chatId)
+                    if(!original){
+                        return { role, data }
                     }
+                    byChatId.delete(v.chatId)
+                    original.role = role
+                    original.data = data
+                    return original
                 })
             })
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Lua `setFullChat` rebuilt every message with only `role` and `data`, so even an identity `setFullChat(id, getFullChat(id))` dropped `chatId`, `time`, `generationInfo`, `promptInfo`, `saying` and `name`, breaking bookmarks, the generation info modal and reroll candidates.

`setFullChat` is now an update: messages are matched by `chatId` and only `role` and `data` are overwritten.

한국어 요약: Lua 트리거 스크립트의 setFullChat이 메시지를 role과 data만으로 새로 만들어서 chatId, time같은 메타데이터들이 사라지고 북마크 등이 깨졌습니다. (#1564).
이 PR은 setFullChat을 chatId로 기존 메시지를 찾아 role과 data를 덮어쓰는 방식으로 변경해 스크립트가 메시지를 삽입, 삭제, 순서 변경을 해도 메타데이터가 보존되도록 합니다.

## Related Issues

Fixes #1564

## Changes

- `getChat` / `getRecentChats` / `getFullChat` also expose `chatId`.
- `setFullChatMain` matches each incoming entry to the existing message by `chatId` and mutates it in place, so metadata follows the entry even if the script inserts, removes or reorders messages. Entries without a known (or already used) `chatId` become new `{role, data}` messages; messages missing from the list are dropped as before.
- Tests running the real Lua engine for round-trip, prepend/edit and remove/duplicate cases (all fail on `main`).

Matching by `chatId` instead of index avoids moving metadata onto a neighbouring message when a script edits anywhere but the tail.

## Impact

- `getChat` / `getRecentChats` / `getFullChat` return one extra field (`chatId`).
- `time` is still read-only from Lua.
- No measurable performance change: the merge is in-place and the cost is dominated by the unchanged JSON round-trip in `getFullChat`.

## Additional Notes

`vitest` and `svelte-check` pass.