### PR TITLE
Resolve prefillsupported from the model flag for native Claude entries

### DIFF
--- a/src/ts/cbs.ts
+++ b/src/ts/cbs.ts
@@ -2,6 +2,7 @@ import type { Database, character, loreBook } from './storage/database.svelte';
 import type { CbsConditions } from './parser/parser.svelte';
 import type { RisuModule } from './process/modules';
 import type { LLMModel } from './model/modellist';
+import { LLMFlags, LLMFormat } from './model/types';
 import { get } from 'svelte/store';
 import { CurrentTriggerIdStore } from './stores.svelte';
 
@@ -1358,6 +1359,10 @@ export function registerCBS(arg:CBSRegisterArg) {
         name: 'prefillsupported',
         callback: (str, matcherArg, args, vars) => {
             const db = getDatabase()
+            const modelInfo = getModelInfo(db.aiModel)
+            if(modelInfo.format === LLMFormat.Anthropic || modelInfo.format === LLMFormat.AnthropicLegacy){
+                return modelInfo.flags.includes(LLMFlags.hasPrefill) ? '1' : '0'
+            }
             return db.aiModel.startsWith('claude') ? '1' : '0'
         },
         alias: ['prefill_supported', 'prefill'],


### PR DESCRIPTION
Follow-up to #1596, on the prefill half of what we traced there.

`prefillsupported` in `src/ts/cbs.ts` decides on the id prefix, so it returns `'1'` for anything starting with `claude`. Four native entries do not carry `LLMFlags.hasPrefill`: `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7` and `claude-opus-4-8` (`src/ts/model/providers/anthropic.ts:6-79`). On any of those, the trailing `role: "bot"` block that closes the default template (`src/ts/process/templates/templates.ts:379-381`) still goes out.

The change reads the flag off the model entry, but only when the entry resolves to `LLMFormat.Anthropic` or `LLMFormat.AnthropicLegacy`. Everything else keeps the prefix check it has today.

| Model selection | Before | After |
| --- | --- | --- |
| `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8` | `1` | `0` |
| `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929` and older native entries | `1` | `1` |
| Bedrock `anthropic.claude-*` | `0` | `0` |
| DeepSeek entries, Response API variants | `0` | `0` |
| Unknown or custom proxy ids | prefix check | prefix check |

The format gate is there because of what you flagged on #1596. `hasPrefill` sits on the Bedrock 4.6 entry with a comment saying it is kept for compatibility (`src/ts/model/modellist.ts:54`), on the DeepSeek entries (`:465`, `:477`, `:489`, `:500`), and it is appended to every Response API variant at `:591` and `:756`. A flag-only check would have turned all of those on. Gating on the format leaves them where they are.

One consequence worth naming. A user-defined model (`xcustom:::`) that picks an Anthropic format and ticks the `hasPrefill` box now returns `'1'` where it returned `'0'`, since `getModelInfo` passes the user's own format and flags through (`src/ts/model/modellist.ts:832-848`). That reads to me like the toggle finally doing what its label says, but say the word and I will restrict the branch to entries found in `LLMModels`.

I did not touch `templates.ts:388`. You are right that the merged diff already carries `claude-sonnet-4-6` there.

I also want to correct something I wrote on #1596. I said every Anthropic entry declares `parameters: [...ClaudeParameters, ...]`, and that is wrong for the two models where non-default sampling actually gets rejected. `claude-opus-4-7` and `claude-opus-4-8` both declare `parameters: []` (`src/ts/model/providers/anthropic.ts:19` and `:37`), and `applyParameters` is called with `arg.modelInfo.parameters` (`src/ts/process/request/anthropic.ts:351-357`), so nothing sends `temperature` or `top_p` for them. The entries that do declare `ClaudeParameters` are the 4.6 pair and older, which accept those fields. There is no sampling PR to send, and my trace there was overbroad.

`pnpm run check` passes on this branch, 0 errors and 0 warnings. I have not run it against the API, so the prefill claim rests on the flags the repo declares rather than on a response I have seen.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me to this repo in the first place was a checker I maintain that flags retired Claude model ids, which is how #1596 started, so I am saying that up front rather than leaving you to wonder. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
