### PR TITLE
feat: add OrcaRouter as a named provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Risuai, or Risu for short, is a cross platform AI chatting software / web applic
 
 ## Features
 
-- **Multiple API Supports**: Supports OpenAI, Claude, Gemini, DeepInfra, Ooba, OpenRouter... and More!
+- **Multiple API Supports**: Supports OpenAI, Claude, Gemini, DeepInfra, Ooba, OpenRouter, OrcaRouter... and More!
 - **Emotion Images**: Display the image of the current character, according to his/her expressions!
 - **Group Chats**: Multiple characters in one chat.
 - **Plugins**: Add your features and providers, and simply share.

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -358,6 +358,8 @@ export const languageEnglish = {
         ],
         setupOpenRouter:
             "To use OpenRouter, you need to get an API key. \n1. Go to https://openrouter.ai/keys\n2. Click 'Create Key'\n3. Set key name whatever you want.\n4. Copy the key in the website\n5. Go back to Risuai\n6. Paste it, and click send button.",
+        setupOrcaRouter:
+            "To use OrcaRouter, you need to get an API key. \n1. Go to https://www.orcarouter.ai\n2. Create an account and generate a key\n3. Copy the key in the website\n4. Go back to Risuai\n5. Paste it, and click send button.",
         allDone: "All Done! Please wait a moment.",
         setupLaterMessage: "Welcome {username}! Do you want me to guide you to setup or do it yourself?",
         setupMessageOption1: "Guide me to setup",

--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -22,6 +22,7 @@
     import CheckInput from "src/lib/UI/GUI/CheckInput.svelte";
     import SegmentedControl from "src/lib/UI/GUI/SegmentedControl.svelte";
     import { getOpenRouterModels, toModelGridItem as orToGridItem } from "src/ts/model/openrouter";
+    import { getOrcaRouterModels, toModelGridItem as ocarToGridItem } from "src/ts/model/orcarouter";
     import { getNanoGPTModels, getNanoGPTSubscriptionModels, toModelGridItem as ngToGridItem } from "src/ts/model/nanogpt";
     import { getOllamaModels } from "src/ts/model/ollama";
     import ModelGrid from "src/lib/UI/ModelGrid.svelte";
@@ -31,6 +32,7 @@
     import OobaSettings from "./OobaSettings.svelte";
     import Accordion from "src/lib/UI/Accordion.svelte";
     import OpenrouterSettings from "./OpenrouterSettings.svelte";
+    import OrcarouterSettings from "./OrcarouterSettings.svelte";
     import ChatFormatSettings from "./ChatFormatSettings.svelte";
     import PromptSettings from "./PromptSettings.svelte";
     import { openPresetList } from "src/ts/stores.svelte";
@@ -45,6 +47,11 @@
     const openrouterPinnedItems: ModelGridPinnedItem[] = [
         { id: 'risu/free',       displayName: 'Free Auto',       providerName: 'Risu'       },
         { id: 'openrouter/auto', displayName: 'OpenRouter Auto', providerName: 'OpenRouter' },
+    ]
+
+    const orcarouterPinnedItems: ModelGridPinnedItem[] = [
+        { id: 'orcarouter/auto', displayName: 'OrcaRouter Auto', providerName: 'OrcaRouter' },
+        { id: 'orcarouter/free', displayName: 'Free Auto',       providerName: 'OrcaRouter' },
     ]
 
     // Reset model selection and display name when subscription mode toggles
@@ -390,7 +397,18 @@
             <ModelGrid bind:value={DBState.db.openrouterRequestModel} items={(m ?? []).map(orToGridItem)} pinnedItems={openrouterPinnedItems} />
         {/await}
     {/if}
-    {#if DBState.db.aiModel === 'openrouter' || DBState.db.aiModel === 'reverse_proxy'}
+    {#if DBState.db.aiModel === 'orcarouter' || DBState.db.subModel === 'orcarouter'}
+        <span class="text-textcolor mt-4">OrcaRouter {language.apiKey}</span>
+        <TextInput hideText={DBState.db.hideApiKey} marginBottom={false} size={"sm"} bind:value={DBState.db.orcarouterKey} />
+
+        <span class="text-textcolor mt-4">OrcaRouter {language.model}</span>
+        {#await getOrcaRouterModels()}
+            <ModelGrid bind:value={DBState.db.orcarouterRequestModel} pinnedItems={orcarouterPinnedItems} loading={true} />
+        {:then m}
+            <ModelGrid bind:value={DBState.db.orcarouterRequestModel} items={(m ?? []).map(ocarToGridItem)} pinnedItems={orcarouterPinnedItems} />
+        {/await}
+    {/if}
+    {#if DBState.db.aiModel === 'openrouter' || DBState.db.aiModel === 'orcarouter' || DBState.db.aiModel === 'reverse_proxy'}
         <span class="text-textcolor">{language.tokenizer}</span>
         <SelectInput bind:value={DBState.db.customTokenizer}>
             {#each tokenizerList as entry}
@@ -612,6 +630,10 @@
 
     {#if DBState.db.aiModel.startsWith('openrouter')}
         <OpenrouterSettings />
+    {/if}
+
+    {#if DBState.db.aiModel.startsWith('orcarouter')}
+        <OrcarouterSettings />
     {/if}
 
     <!-- Separate Parameters - handled by custom component -->

--- a/src/lib/Setting/Pages/OrcarouterSettings.svelte
+++ b/src/lib/Setting/Pages/OrcarouterSettings.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { language } from "src/lang";
+    import Accordion from "src/lib/UI/Accordion.svelte";
+    import Check from "src/lib/UI/GUI/CheckInput.svelte";
+
+    import { DBState } from 'src/ts/stores.svelte';
+    import ChatFormatSettings from "./ChatFormatSettings.svelte";
+</script>
+
+<Accordion name={`OrcaRouter ${language.settings}`} styled>
+    <div class="flex items-center mb-4">
+        <Check bind:check={DBState.db.useInstructPrompt} name={language.useInstructPrompt}/>
+    </div>
+    {#if DBState.db.useInstructPrompt}
+        <ChatFormatSettings />
+    {/if}
+</Accordion>

--- a/src/ts/model/modellist.ts
+++ b/src/ts/model/modellist.ts
@@ -213,6 +213,16 @@ export const LLMModels: LLMModel[] = [
         recommended: true,
         tokenizer: LLMTokenizer.Unknown
     },
+    {
+        name: 'OrcaRouter',
+        id: 'orcarouter',
+        provider: LLMProvider.AsIs,
+        format: LLMFormat.OpenAICompatible,
+        flags: [LLMFlags.hasFullSystemPrompt, LLMFlags.hasImageInput, LLMFlags.hasStreaming],
+        parameters: ['temperature', 'top_p', 'frequency_penalty', 'presence_penalty', 'repetition_penalty', 'min_p', 'top_a', 'top_k'],
+        recommended: true,
+        tokenizer: LLMTokenizer.Unknown
+    },
     // Mistral models
     {
         name: 'Mistral Small Latest',

--- a/src/ts/model/orcarouter.ts
+++ b/src/ts/model/orcarouter.ts
@@ -1,0 +1,52 @@
+import { getDatabase } from "../storage/database.svelte"
+import type { ModelGridItem } from "./modelGrid"
+
+/** A model entry returned by OrcaRouter's OpenAI-compatible /v1/models endpoint. */
+export type OrcaRouterModelInfo = {
+    id: string
+    owned_by: string
+    context_length: number
+}
+
+const ORCAROUTER_MODELS_ENDPOINT = 'https://api.orcarouter.ai/v1/models'
+
+export async function getOrcaRouterModels(): Promise<OrcaRouterModelInfo[]> {
+    try {
+        const db = getDatabase()
+        const headers = {
+            "Authorization": "Bearer " + db.orcarouterKey,
+            "Content-Type": "application/json"
+        }
+
+        const res = await fetch(ORCAROUTER_MODELS_ENDPOINT, { headers })
+        if (!res.ok) {
+            return []
+        }
+
+        const json = await res.json()
+        const models = json?.data ?? []
+        if (!Array.isArray(models)) {
+            return []
+        }
+
+        return models.map((model: any) => ({
+            id: model.id,
+            owned_by: model.owned_by ?? 'orcarouter',
+            context_length: model.context_length ?? 0,
+        })).sort((a: OrcaRouterModelInfo, b: OrcaRouterModelInfo) => a.id.localeCompare(b.id))
+    } catch (error) {
+        return []
+    }
+}
+
+export function toModelGridItem(m: OrcaRouterModelInfo): ModelGridItem {
+    return {
+        id: m.id,
+        displayName: m.id,
+        providerName: m.owned_by,
+        description: '',
+        context_length: m.context_length,
+        sortPrice: Infinity,
+        prices: [],
+    }
+}

--- a/src/ts/process/models/modelString.ts
+++ b/src/ts/process/models/modelString.ts
@@ -7,6 +7,8 @@ export function getGenerationModelString(name?:string){
             return 'custom-' + (db.reverseProxyOobaMode ? 'ooba' : db.customProxyRequestModel)
         case 'openrouter':
             return 'openrouter-' + db.openrouterRequestModel
+        case 'orcarouter':
+            return 'orcarouter-' + db.orcarouterRequestModel
         case 'nanogpt': {
             const modelLabel = db.nanogptRequestModelName || db.nanogptRequestModel
             return 'NanoGPT ' + modelLabel + (db.nanogptUseSubscriptionEndpoint ? ' [SUB]' : '')

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -351,6 +351,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
     } = ({
         model: aiModel === 'nanogpt' ? db.nanogptRequestModel :
             aiModel === 'openrouter' ? openrouterRequestModel :
+            aiModel === 'orcarouter' ? db.orcarouterRequestModel :
             requestModel ===  'gpt35' ? 'gpt-3.5-turbo'
             : requestModel ===  'gpt35_0613' ? 'gpt-3.5-turbo-0613'
             : requestModel ===  'gpt35_16k' ? 'gpt-3.5-turbo-16k'
@@ -511,6 +512,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
 
     let replacerURL = aiModel === 'nanogpt' ? (db.nanogptUseSubscriptionEndpoint ? 'https://nano-gpt.com/api/subscription/v1/chat/completions' : 'https://nano-gpt.com/api/v1/chat/completions') :
         aiModel === 'openrouter' ? "https://openrouter.ai/api/v1/chat/completions" :
+        aiModel === 'orcarouter' ? "https://api.orcarouter.ai/v1/chat/completions" :
         (arg.customURL) ?? ('https://api.openai.com/v1/chat/completions')
 
     if(arg.modelInfo?.endpoint){
@@ -545,7 +547,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
     }
 
     let headers = {
-        "Authorization": "Bearer " + (arg.key ?? (aiModel === 'nanogpt' ? db.nanogptKey : aiModel === 'reverse_proxy' ?  db.proxyKey : (aiModel === 'openrouter' ? db.openrouterKey : db.openAIKey))),
+        "Authorization": "Bearer " + (arg.key ?? (aiModel === 'nanogpt' ? db.nanogptKey : aiModel === 'reverse_proxy' ?  db.proxyKey : (aiModel === 'openrouter' ? db.openrouterKey : aiModel === 'orcarouter' ? db.orcarouterKey : db.openAIKey))),
         "Content-Type": "application/json"
     }
 
@@ -553,6 +555,10 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
         headers["Authorization"] = "Bearer " + db.OaiCompAPIKeys[arg.modelInfo.keyIdentifier]
     }
     if(aiModel === 'openrouter'){
+        headers["X-Title"] = 'RisuAI'
+        headers["HTTP-Referer"] = 'https://risuai.xyz'
+    }
+    if(aiModel === 'orcarouter'){
         headers["X-Title"] = 'RisuAI'
         headers["HTTP-Referer"] = 'https://risuai.xyz'
     }

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -38,10 +38,11 @@ export const seedSetting: SettingItem = {
     type: 'number',
     labelKey: 'seed',
     bindKey: 'generationSeed',
-    condition: (ctx) => 
-        ctx.db.aiModel.startsWith('gpt') || 
-        ctx.db.aiModel === 'reverse_proxy' || 
-        ctx.db.aiModel === 'openrouter',
+    condition: (ctx) =>
+        ctx.db.aiModel.startsWith('gpt') ||
+        ctx.db.aiModel === 'reverse_proxy' ||
+        ctx.db.aiModel === 'openrouter' ||
+        ctx.db.aiModel === 'orcarouter',
     keywords: ['seed', 'random', 'deterministic'],
 };
 

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -375,6 +375,8 @@ export function setDatabase(data:Database){
     data.ainconfig ??= safeStructuredClone(defaultAIN)
     data.openrouterKey ??= ''
     data.openrouterRequestModel ??= 'openai/gpt-3.5-turbo'
+    data.orcarouterKey ??= ''
+    data.orcarouterRequestModel ??= 'orcarouter/auto'
     data.nanogptKey ??= ''
     data.nanogptRequestModel ??= ''
     data.nanogptRequestModelName ??= ''
@@ -944,6 +946,8 @@ export interface Database{
     openrouterRequestModel:string
     openrouterKey:string
     openrouterMiddleOut:boolean
+    orcarouterKey:string
+    orcarouterRequestModel:string
     nanogptKey:string
     nanogptRequestModel:string
     nanogptRequestModelName:string
@@ -1605,6 +1609,7 @@ export interface botPreset{
     bias: [string, number][]
     proxyRequestModel?:string
     openrouterRequestModel?:string
+    orcarouterRequestModel?:string
     proxyKey?:string
     ooba: OobaSettings
     ainconfig: AINsettings
@@ -2071,6 +2076,7 @@ export function saveCurrentPreset(){
         ainconfig: safeStructuredClone(db.ainconfig),
         proxyRequestModel: db.proxyRequestModel,
         openrouterRequestModel: db.openrouterRequestModel,
+        orcarouterRequestModel: db.orcarouterRequestModel,
         NAISettings: safeStructuredClone(db.NAIsettings),
         promptTemplate: normalizePromptTemplate(db.promptTemplate) ?? null,
         NAIadventure: db.NAIadventure ?? false,
@@ -2182,6 +2188,7 @@ export function setPreset(db:Database, newPres: botPreset){
     db.ooba = safeStructuredClone(newPres.ooba ?? db.ooba)
     db.ainconfig = safeStructuredClone(newPres.ainconfig ?? db.ainconfig)
     db.openrouterRequestModel = newPres.openrouterRequestModel ?? db.openrouterRequestModel
+    db.orcarouterRequestModel = newPres.orcarouterRequestModel ?? db.orcarouterRequestModel
     db.proxyRequestModel = newPres.proxyRequestModel ?? db.proxyRequestModel
     db.NAIsettings = newPres.NAISettings ?? db.NAIsettings
     db.autoSuggestPrompt = newPres.autoSuggestPrompt ?? db.autoSuggestPrompt

--- a/src/ts/tokenizer.ts
+++ b/src/ts/tokenizer.ts
@@ -102,7 +102,7 @@ export async function encode(data:string):Promise<(number[]|Uint32Array|Int32Arr
 
     let result: number[] | Uint32Array | Int32Array;
 
-    if(db.aiModel === 'openrouter' || db.aiModel === 'reverse_proxy'){
+    if(db.aiModel === 'openrouter' || db.aiModel === 'orcarouter' || db.aiModel === 'reverse_proxy'){
         switch(db.customTokenizer){
             case 'mistral':
                 result = await tokenizeWebTokenizers(data, 'mistral'); break;


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Risuai is a "cross platform AI chatting software / web application with powerful features such as multiple API support". Today its provider list starts with OpenAI, Claude, Gemini, DeepInfra, Ooba, OpenRouter — and OpenRouter is already a first-class entry in the model picker with its own key field, model grid and settings panel.

This PR adds **[OrcaRouter](https://www.orcarouter.ai)** the same way: as a named provider in the model list, mirroring the existing `openrouter` integration (`LLMProvider.AsIs` + `LLMFormat.OpenAICompatible`, `id: 'orcarouter'`). OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means Risuai users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

## Related Issues

None.

## Changes

- `src/ts/model/modellist.ts`: register the `orcarouter` model entry (`LLMProvider.AsIs`, `LLMFormat.OpenAICompatible`), right next to `openrouter`.
- `src/ts/model/orcarouter.ts` (new): fetch the model catalog from `https://api.orcarouter.ai/v1/models` and adapt it to the shared `ModelGrid`.
- `src/ts/process/request/openAI/requests.ts`: route `aiModel === 'orcarouter'` chat completions to `https://api.orcarouter.ai/v1/chat/completions`, send the request body model from `db.orcarouterRequestModel`, and authenticate with `db.orcarouterKey`.
- `src/ts/storage/database.svelte.ts`: add `orcarouterKey` and `orcarouterRequestModel` (default `orcarouter/auto`) to the database schema, including preset import/export.
- `src/lib/Setting/Pages/BotSettings.svelte` + `src/lib/Setting/Pages/OrcarouterSettings.svelte` (new): API key field, model picker with `orcarouter/auto` and `orcarouter/free` pinned entries, and the same settings accordion pattern OpenRouter uses.
- `src/ts/process/models/modelString.ts`, `src/ts/tokenizer.ts`, `src/ts/setting/botSettingsParamsData.ts`: include `orcarouter` in the same branches as `openrouter` for the generation-model string, custom tokenizer, and seed parameter.
- `src/lang/en.ts`: setup instructions and UI strings.
- `README.md`: mention OrcaRouter in the "Multiple API Supports" feature line.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Impact

No existing behavior changes: `orcarouter` is an additive provider entry. OpenRouter and every other provider keep their current code paths. A new `orcarouterKey`/`orcarouterRequestModel` pair is added to the database with defaults, so existing save files migrate untouched.

## Testing

- `pnpm check` → 0 errors, 0 warnings.
- `pnpm test` → 230 passed, 3 skipped.
- `pnpm build` → succeeds.
- Live tested the new provider code path against the OrcaRouter API (HTTP 200): `POST /v1/chat/completions` with model `orcarouter/auto` returns a valid chat completion, and `GET /v1/models` returns the OpenAI-style model list the picker renders.

## Additional Notes

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.
