### PR TITLE
feat: add Gemini 3.8 Flash model

### DIFF
--- a/src/ts/model/providers/google.ts
+++ b/src/ts/model/providers/google.ts
@@ -2,7 +2,17 @@ import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, type LLMModel } from '.
 
 export const GoogleModels: LLMModel[] = [
 
-    // ===== Gemini 3.5/3.6/3.7 Series (2026) =====
+    // ===== Gemini 3.5/3.6/3.7/3.8 Series (2026) =====
+    {
+        name: "Gemini Flash 3.8",
+        id: 'gemini-3.8-flash',
+        provider: LLMProvider.GoogleCloud,
+        format: LLMFormat.GoogleCloud,
+        flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking, LLMFlags.geminiThinkingNoMinimal, LLMFlags.hasFirstSystemPrompt],
+        parameters: ['reasoning_effort'],
+        tokenizer: LLMTokenizer.GoogleCloud,
+        recommended: true
+    },
     {
         name: "Gemini Flash 3.7",
         id: 'gemini-3.7-flash',

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -412,9 +412,9 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     console.log(arg.modelInfo);
 
     const isVertexGlobalOnlyModel = (modelId: string) => {
-        // Gemini 3 preview models and the 3.5/3.6/3.7 Flash family are not served from the regions
+        // Gemini 3 preview models and the 3.5/3.6/3.7/3.8 Flash family are not served from the regions
         // selectable in settings (us-central1, us-west1); route them through the global endpoint.
-        return /^gemini-3-.*-preview$/.test(modelId) || /^gemini-3\.[567]-flash/.test(modelId)
+        return /^gemini-3-.*-preview$/.test(modelId) || /^gemini-3\.[5678]-flash/.test(modelId)
     }
 
     async function generateToken(email:string,key:string){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds the newly released Google model `gemini-3.8-flash` as a built-in selectable model.

The existing Vertex derivation loop in `modellist.ts` picks up the entry automatically, so both the Gemini API and Vertex AI variants become available from a single definition.

At the moment the model is only served on Vertex AI. The Gemini API (AI Studio) does not accept requests for it yet, so the entry assumes the same spec as Vertex.

## Related Issues

None.

## Changes

**`src/ts/model/providers/google.ts`**
- Added the `gemini-3.8-flash` entry with the same flags and parameters as `gemini-3.7-flash`
- Kept `geminiThinkingNoMinimal`, since the model rejects the `minimal` thinking level and only accepts `low` / `medium` / `high`; the request layer maps a minimal setting to `low`
- Kept `parameters` limited to `reasoning_effort`: sampling parameters are unsupported from the 3.6 generation onward, and the model rejects non-zero penalty values

**`src/ts/process/request/google.ts`**
- Extended `isVertexGlobalOnlyModel` to route the new model through the Vertex AI `global` endpoint, since it is not served from the regions selectable in settings

## Impact

- One new selectable model appears for both the Gemini API and Vertex AI providers. Existing model entries and request behavior are unchanged.
- The Gemini API variant returns 404 until Google enables the model there; only the Vertex AI variant works right now.
- Users whose saved model is the Dynamic Model Registry's `dynamic_google_gemini-3.8-flash` need to re-select the model once, since the built-in entry now prevents that dynamic ID from being registered.
- Selecting the Minimal thinking effort sends `low` for this model, as the model has no minimal level.
- The model rejects requests ending with a model turn, like `gemini-3.7-flash`, so continue-style prefill is affected. This is pre-existing pipeline behavior and is out of scope here.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

The official model page is not published yet, and the Gemini API `ListModels` endpoint does not list `gemini-3.8-flash` (`generateContent` returns 404 on both `v1beta` and `v1`). The entry was therefore verified with live `generateContent` probes on the Vertex AI global endpoint, with `gemini-3.7-flash` as a control:

- `gemini-3.8-flash` returns HTTP 200 on `global` (non-streaming and SSE, `modelVersion: gemini-3.8-flash`) and 404 on `us-central1` / `us-west1`.
- `thinkingLevel: minimal` fails with `INVALID_ARGUMENT: Thinking level is unsupported: THINKING_LEVEL_MINIMAL`. `low` / `medium` / `high` succeed, and `thinkingBudget` is still accepted.
- Non-zero `presencePenalty` / `frequencyPenalty` fail with `INVALID_ARGUMENT: Penalty is not enabled for this model`.
- A request ending with a model turn fails with `INVALID_ARGUMENT: Requests ending with a model turn are not supported`, same as `gemini-3.7-flash`.

The Gemini API side is assumed to match the Vertex behavior above, as it did for the 3.5 / 3.6 / 3.7 entries. I will re-run the same probes against the Gemini API once the model is listed there and follow up if anything differs.
