### PR TITLE
perf: snapshot only the requested character instead of the whole database

### DIFF
--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -737,12 +737,7 @@ export function getDatabase(options:getDatabaseOptions = {}):Database{
 }
 
 export function getCurrentCharacter(options:getDatabaseOptions = {}):character|groupChat{
-    const db = getDatabase(options)
-    if(!db.characters){
-        db.characters = []
-    }
-    const char = db.characters?.[get(selectedCharID)]
-    return char
+    return getCharacterByIndex(get(selectedCharID), options)
 }
 
 export function setCurrentCharacter(char:character|groupChat){
@@ -753,12 +748,12 @@ export function setCurrentCharacter(char:character|groupChat){
 }
 
 export function getCharacterByIndex(index:number,options:getDatabaseOptions = {}):character|groupChat{
-    const db = getDatabase(options)
-    if(!db.characters){
-        db.characters = []
+    if(!DBState.db.characters){
+        DBState.db.characters = []
     }
-    const char = db.characters?.[index]
-    return char
+    const char = DBState.db.characters[index]
+    // snapshot only the requested character instead of the whole database
+    return options.snapshot ? $state.snapshot(char) as character|groupChat : char
 }
 
 export function setCharacterByIndex(index:number,char:character|groupChat){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

`getCurrentCharacter({ snapshot: true })` and `getCharacterByIndex(i, { snapshot: true })` copied the **entire database** (every character and every chat) just to return one character. This PR copies only that one character, so the cost no longer grows with how many other characters the user has.

한국어 요약: getCurrentCharacter는 목적과는 다르게 데이터베이스 전체를 복사한 뒤 캐릭터 하나만 반환하는 형태였습니다.
2024-10-24에 svelte 5로 전환하는 대형 작업에서 전체 DB를 복사하는 snapshot 옵션을 그대로 넘겨 쓰면서 생긴 구조로 보입니다.
이 PR은 해당 부분을 v3 플러그인 API의 getCharacterFromIndex와 같은 방식으로 해당 캐릭터만 복사하도록 바꿨습니다.

## Related Issues

None

## Changes

- `src/ts/storage/database.svelte.ts`: `getCharacterByIndex` now reads `DBState.db.characters[index]` and calls `$state.snapshot` on that character only, instead of going through `getDatabase({ snapshot: true })`. `getCurrentCharacter` delegates to it.
- `getDatabase({ snapshot: true })` itself is unchanged.

The returned object is identical either way (a plain deep copy of the character). The same subtree pattern is already used in `apiV3/v3.svelte.ts` (`getCharacterFromIndex`, `getChatFromIndex`) and in `process/index.svelte.ts`.

## Impact

Callers that pass `snapshot: true`:

- Plugin V3 `risuai.getCharacter()` (`plugins.svelte.ts`)
- Character export in `realm.ts`

Measured from a V3 plugin with `risuai.getCharacter()`, median of 7 calls, headless Chromium, web build. The current character (1.1 MB) stays the same; only other characters are added.

| Database | Before | After |
|---|---|---|
| 1 character, 1.1 MB | 40 ms | 29 ms |
| 11 characters, 20 MB | 71–83 ms | 25–31 ms |
| 21 characters, 39 MB | 103–116 ms | 21–23 ms |
| 31 characters, 58 MB | 153–162 ms | 20–33 ms |

"Before" is on the same probe against a build from a few days earlier; "After" is this branch on top of current `main`. The remaining ~20–30 ms is copying the current character itself plus the postMessage hop to the plugin iframe.

No behavior change; non-snapshot callers still get the live reactive object as before.

## Additional Notes

None
