### PR TITLE
fix: guard undefined pointer in touchend handler

### DIFF
--- a/src/ts/hotkey.ts
+++ b/src/ts/hotkey.ts
@@ -376,10 +376,11 @@ export function initMobileGesture(){
     document.addEventListener('touchend', (ev) => {
         for(const touch of ev.changedTouches){
             const d = pressingPointers.get(touch.identifier)
+            if(!d) continue
             const moveX = touch.clientX - d.x
             const moveY = touch.clientY - d.y
             pressingPointers.delete(touch.identifier)
-
+            
             if(moveX > 50 && Math.abs(moveY) < Math.abs(moveX)){
                 if(get(selectedCharID) === -1){
                     if(get(MobileGUIStack) > 0){


### PR DESCRIPTION
Fixes `TypeError: Cannot read properties of undefined (reading 'x')` at `src/ts/hotkey.ts` when `touchend` fires on BUTTON/INPUT/SELECT/TEXTAREA elements that were skipped in `touchstart`.

## PR Checklist

- Required Checks
    - [x] Have you added type definitions? (N/A — no new types introduced)
    - [x] Have you tested your changes? (`pnpm check`: 0 errors / 0 warnings. `pnpm test`: 230 passed / 3 skipped. Verified in Codespaces + Android Chrome via `pnpm dev` that the error no longer appears and swipe gestures still work.)
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following: (N/A — does not touch prompting or model handling)
    - [x] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following: (AI-assisted diagnosis; the change is one line)
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
        - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds a null guard in the mobile gesture `touchend` handler so touches that were intentionally not recorded in `touchstart` are skipped instead of throwing.

## Related Issues

None.

## Changes

In `initMobileGesture()` (`src/ts/hotkey.ts`), the `touchstart` listener returns early without recording the pointer when the target is a BUTTON, INPUT, SELECT, or TEXTAREA. The `touchend` listener then calls `pressingPointers.get(touch.identifier)` and immediately reads `d.x` / `d.y`, which throws when `d` is `undefined`.

Added one line after the lookup:

    const d = pressingPointers.get(touch.identifier)
    if(!d) continue

## Impact

- Fixes the error popup that appears on Android (web) every time a button or input field is tapped.
- Swipe gesture behaviour for MobileGUIStack / MobileSideBar is unchanged; only unrecorded touches are ignored.
- No effect on desktop, local, or node-hosted versions beyond removing the exception.

## Additional Notes

Environment where the error was reproduced:
- Risu version: 2026.8.250 (web)
- OS: Android 16
- Browser: Chrome 152 Mobile