### PR TITLE
feat: attach media files by dropping them on the chat input

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -62,6 +62,93 @@
     function scrollToBottom() {
         chatsInstance?.scrollToLatestMessage();
     }
+
+    async function appendPostFileResults(results: Awaited<ReturnType<typeof postChatFile>>) {
+        if(!results) return
+        for(const res of results){
+            if(res?.type === 'asset'){
+                fileInput.push(res.data)
+            }
+            if(res?.type === 'text'){
+                messageInput += `{{file::${res.name}::${res.data}}}`
+            }
+        }
+        updateInputSizeAll()
+    }
+
+    let chatFileDragDepth = $state(0)
+    const chatFileDropOverlayClass = 'z-10 pointer-events-none flex items-center justify-center rounded-md border-2 border-dashed border-textcolor bg-bgcolor/80 text-textcolor'
+
+    // Hardcoded intersection of the extensions postChatFile routes to postInlayAsset and the ones postInlayAsset accepts; replace with a shared source when the file upload system is reworked.
+    const chatDropFileExtensions = new Set([
+        'jpg',
+        'jpeg',
+        'png',
+        'webp',
+        'gif',
+        'avif',
+        'wav',
+        'mp3',
+        'ogg',
+        'flac',
+        'mp4',
+        'webm',
+    ])
+
+    function isChatDropFile(file: File) {
+        const extension = file.name.split('.').at(-1)?.toLowerCase()
+        return extension ? chatDropFileExtensions.has(extension) : false
+    }
+
+    function hasChatDropFileDrag(e: DragEvent) {
+        return Array.from(e.dataTransfer?.items ?? []).some((item) => {
+            return item.kind === 'file' && (
+                item.type.startsWith('image/') ||
+                item.type.startsWith('audio/') ||
+                item.type.startsWith('video/')
+            )
+        })
+    }
+
+    function handleChatFileDragEnter(e: DragEvent) {
+        if(!hasChatDropFileDrag(e)){
+            return
+        }
+        e.preventDefault()
+        chatFileDragDepth += 1
+    }
+
+    function handleChatFileDragOver(e: DragEvent) {
+        if(!hasChatDropFileDrag(e)){
+            return
+        }
+        e.preventDefault()
+        e.stopPropagation()
+        e.dataTransfer.dropEffect = 'copy'
+    }
+
+    function handleChatFileDragLeave(e: DragEvent) {
+        if(!hasChatDropFileDrag(e)){
+            return
+        }
+        chatFileDragDepth = Math.max(0, chatFileDragDepth - 1)
+    }
+
+    async function handleChatFileDrop(e: DragEvent) {
+        chatFileDragDepth = 0
+        const files = Array.from(e.dataTransfer?.files ?? []).filter(isChatDropFile)
+        if(files.length === 0){
+            return
+        }
+        e.preventDefault()
+        e.stopPropagation()
+        for(const file of files){
+            await appendPostFileResults(await postChatFile({
+                name: file.name,
+                data: new Uint8Array(await file.arrayBuffer())
+            }))
+        }
+    }
     $effect(() => {
         if(ScrollToMessageStore.value !== -1){
             const index = ScrollToMessageStore.value
@@ -594,110 +681,113 @@
                     </div>
                 {/if}
 
-                <textarea class="peer text-input-area focus:border-textcolor transition-colors outline-hidden text-textcolor p-2 min-w-0 border border-r-0 bg-transparent rounded-md rounded-r-none input-text text-xl grow ml-4 border-darkborderc resize-none overflow-y-hidden overflow-x-hidden max-w-full placeholder:text-sm"
-                          bind:value={messageInput}
-                          bind:this={inputEle}
-                          onkeydown={(e) => {
-                        if(e.key.toLocaleLowerCase() === "enter" && !e.isComposing){
-                            if(DBState.db.sendWithEnter && (!e.shiftKey)){
-                                send()
-                                e.preventDefault()
-                            }else if(!DBState.db.sendWithEnter && e.shiftKey){
-                                send()
-                                e.preventDefault()
-                            }
-                        }
-                        if(e.key.toLocaleLowerCase() === "m" && (e.ctrlKey)){
-                            reroll()
-                            e.preventDefault()
-                        }
-                    }}
-                          onpaste={(e) => {
-                        const items = e.clipboardData?.items
-                        if(!items){
-                            return
-                        }
-                        let canceled = false
-
-                        for(const item of items){
-                            if(item.kind === 'file' && item.type.startsWith('image')){
-                                if(!canceled){
+                <div
+                        class="relative flex grow min-w-0 ml-4 mr-2"
+                        ondragenter={handleChatFileDragEnter}
+                        ondragover={handleChatFileDragOver}
+                        ondragleave={handleChatFileDragLeave}
+                        ondrop={handleChatFileDrop}
+                >
+                    <textarea class="peer text-input-area focus:border-textcolor transition-colors outline-hidden text-textcolor p-2 min-w-0 border border-r-0 bg-transparent rounded-md rounded-r-none input-text text-xl grow border-darkborderc resize-none overflow-y-hidden overflow-x-hidden max-w-full placeholder:text-sm"
+                              bind:value={messageInput}
+                              bind:this={inputEle}
+                              onkeydown={(e) => {
+                            if(e.key.toLocaleLowerCase() === "enter" && !e.isComposing){
+                                if(DBState.db.sendWithEnter && (!e.shiftKey)){
+                                    send()
                                     e.preventDefault()
-                                    canceled = true
-                                }
-                                const file = item.getAsFile()
-                                if(file){
-                                    const reader = new FileReader()
-                                    reader.onload = async (e) => {
-                                        const buf = e.target?.result as ArrayBuffer
-                                        const uint8 = new Uint8Array(buf)
-                                        const results = await postChatFile({
-                                            name: file.name,
-                                            data: uint8
-                                        })
-                                        if(!results) return
-                                        for(const res of results){
-                                            if(res?.type === 'asset'){
-                                                fileInput.push(res.data)
-                                            }
-                                            if(res?.type === 'text'){
-                                                messageInput += `{{file::${res.name}::${res.data}}}`
-                                            }
-                                        }
-                                        updateInputSizeAll()
-                                    }
-                                    reader.readAsArrayBuffer(file)
+                                }else if(!DBState.db.sendWithEnter && e.shiftKey){
+                                    send()
+                                    e.preventDefault()
                                 }
                             }
-                        }
-                    }}
-                          oninput={()=>{updateInputSizeAll();updateInputTransateMessage(false)}}
-                          style:height={inputHeight}
-                ></textarea>
-
-
-                {#if $doingChat || doingChatInputTranslate}
-                    <button
-                            aria-labelledby="cancel"
-                            class="peer-focus:border-textcolor  flex justify-center border-y border-darkborderc items-center text-textcolor p-3 hover:bg-blue-500 hover:text-white transition-colors" onclick={abortChat}
-                            style:height={inputHeight}
-                    >
-                        <div class="loadmove chat-process-stage-{$chatProcessStage}" class:autoload={autoMode}></div>
-                    </button>
-                {:else}
-                    <button
-                            onclick={send}
-                            class="flex justify-center border-y border-darkborderc items-center text-textcolor p-3 peer-focus:border-textcolor hover:bg-blue-500 hover:text-white transition-colors button-icon-send"
-                            style:height={inputHeight}
-                    >
-                        <Send />
-                    </button>
-                {/if}
-                {#if DBState.db.characters[$selectedCharID]?.chaId !== '§playground'}
-                    <button
-                            onclick={(e) => {
-                            openMenu = !openMenu
-                            e.stopPropagation()
+                            if(e.key.toLocaleLowerCase() === "m" && (e.ctrlKey)){
+                                reroll()
+                                e.preventDefault()
+                            }
                         }}
-                            class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
-                            style:height={inputHeight}
-                    >
-                        <MenuIcon />
-                    </button>
-                {:else}
-                    <div onclick={(e) => {
-                        DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.push({
-                            role: 'char',
-                            data: ''
-                        })
-                        DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage] = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage]
-                    }}
-                         class="peer-focus:border-textcolor mr-2 flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
-                         style:height={inputHeight}
-                    >
-                        <Plus />
-                    </div>
-                {/if}
+                              onpaste={(e) => {
+                            const items = e.clipboardData?.items
+                            if(!items){
+                                return
+                            }
+                            let canceled = false
+
+                            for(const item of items){
+                                if(item.kind === 'file' && item.type.startsWith('image')){
+                                    if(!canceled){
+                                        e.preventDefault()
+                                        canceled = true
+                                    }
+                                    const file = item.getAsFile()
+                                    if(file){
+                                        const reader = new FileReader()
+                                        reader.onload = async (e) => {
+                                            const buf = e.target?.result as ArrayBuffer
+                                            const uint8 = new Uint8Array(buf)
+                                            await appendPostFileResults(await postChatFile({
+                                                name: file.name,
+                                                data: uint8
+                                            }))
+                                        }
+                                        reader.readAsArrayBuffer(file)
+                                    }
+                                }
+                            }
+                        }}
+                              oninput={()=>{updateInputSizeAll();updateInputTransateMessage(false)}}
+                              style:height={inputHeight}
+                    ></textarea>
+
+
+                    {#if $doingChat || doingChatInputTranslate}
+                        <button
+                                aria-labelledby="cancel"
+                                class="peer-focus:border-textcolor  flex justify-center border-y border-darkborderc items-center text-textcolor p-3 hover:bg-blue-500 hover:text-white transition-colors" onclick={abortChat}
+                                style:height={inputHeight}
+                        >
+                            <div class="loadmove chat-process-stage-{$chatProcessStage}" class:autoload={autoMode}></div>
+                        </button>
+                    {:else}
+                        <button
+                                onclick={send}
+                                class="flex justify-center border-y border-darkborderc items-center text-textcolor p-3 peer-focus:border-textcolor hover:bg-blue-500 hover:text-white transition-colors button-icon-send"
+                                style:height={inputHeight}
+                        >
+                            <Send />
+                        </button>
+                    {/if}
+                    {#if DBState.db.characters[$selectedCharID]?.chaId !== '§playground'}
+                        <button
+                                onclick={(e) => {
+                                openMenu = !openMenu
+                                e.stopPropagation()
+                            }}
+                                class="peer-focus:border-textcolor flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
+                                style:height={inputHeight}
+                        >
+                            <MenuIcon />
+                        </button>
+                    {:else}
+                        <div onclick={(e) => {
+                            DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.push({
+                                role: 'char',
+                                data: ''
+                            })
+                            DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage] = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage]
+                        }}
+                             class="peer-focus:border-textcolor flex border-y border-r border-darkborderc justify-center items-center text-textcolor p-3 rounded-r-md hover:bg-blue-500 hover:text-white transition-colors"
+                             style:height={inputHeight}
+                        >
+                            <Plus />
+                        </div>
+                    {/if}
+                    {#if chatFileDragDepth > 0}
+                        <div class="absolute inset-0 {chatFileDropOverlayClass}">
+                            <Plus />
+                        </div>
+                    {/if}
+                </div>
             </div>
             {#if DBState.db.useAutoTranslateInput && DBState.db.characters[$selectedCharID]?.chaId !== '§playground'}
                 <div class="flex items-center mt-2 mb-2">
@@ -727,7 +817,13 @@
             {/if}
 
             {#if fileInput.length > 0}
-                <div class="flex items-center ml-4 flex-wrap p-2 m-2 border-darkborderc border rounded-md">
+                <div
+                        class="relative flex items-center ml-4 flex-wrap p-2 m-2 border-darkborderc border rounded-md"
+                        ondragenter={handleChatFileDragEnter}
+                        ondragover={handleChatFileDragOver}
+                        ondragleave={handleChatFileDragLeave}
+                        ondrop={handleChatFileDrop}
+                >
                     {#each fileInput as file, i}
                         {#await getInlayAsset(file) then inlayAsset}
                             <div class="relative">
@@ -756,6 +852,11 @@
                             </div>
                         {/await}
                     {/each}
+                    {#if chatFileDragDepth > 0}
+                        <div class="absolute inset-0 {chatFileDropOverlayClass}">
+                            <Plus />
+                        </div>
+                    {/if}
                 </div>
 
             {/if}
@@ -1000,17 +1101,7 @@
                     </div>
 
                     <div class="flex items-center cursor-pointer hover:text-green-500 transition-colors" onclick={async () => {
-                        const results = await postChatFile(messageInput)
-                        if(!results) return
-                        for(const res of results){
-                            if(res?.type === 'asset'){
-                                fileInput.push(res.data)
-                            }
-                            if(res?.type === 'text'){
-                                messageInput += `{{file::${res.name}::${res.data}}}`
-                            }
-                        }
-                        updateInputSizeAll()
+                        await appendPostFileResults(await postChatFile(messageInput))
                     }}>
 
                         <ImagePlusIcon />

--- a/src/ts/process/files/inlays.ts
+++ b/src/ts/process/files/inlays.ts
@@ -37,7 +37,7 @@ export async function postInlayAsset(img:{
     data:Uint8Array
 }){
 
-    const extention = img.name.split('.').at(-1)
+    const extention = img.name.split('.').at(-1)?.toLowerCase()
     const imgObj = new Image()
 
     if(inlayImageExts.includes(extention)){

--- a/src/ts/process/files/multisend.ts
+++ b/src/ts/process/files/multisend.ts
@@ -232,7 +232,7 @@ export async function postChatFile(query:string|{
     const results: postFileResult[] = []
 
     for(const file of files){
-        const extention = file.name.split('.').at(-1)
+        const extention = file.name.split('.').at(-1)?.toLowerCase()
         console.log(extention)
 
         switch(extention){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Lets users drag media files from the OS onto the chat input bar (and onto the attachment preview row once something is attached) to attach them, the same way the "Post File" menu item and image paste already do.

Today, every file drop in the app goes to the character import handler in `App.svelte`, so an ordinary image dropped on the chat input ends in a "no data" import error. This PR gives the input bar and the attachment preview row their own drop target for media and leaves every other drop location as is.

<img width="1463" height="619" alt="2026-09-10 01 42 31" src="https://github.com/user-attachments/assets/e27fcf35-a141-403b-9952-223588cb6dab" />

## Related Issues

None.

## Changes

**`src/lib/ChatScreens/DefaultChatScreen.svelte`**
- Extract the shared `postChatFile` result handling (asset → `fileInput`, text → `{{file::...}}`) into `appendPostFileResults()`; the paste handler and the "Post File" menu item now call it
- Wrap the textarea and its buttons in a `relative` container that owns `dragenter` / `dragover` / `dragleave` / `drop`; the textarea's `ml-4` and the trailing button's `mr-2` move to that container so the overlay lines up with the input group
- Add the same handlers to the attachment preview row
- While a file drag with an `image/`, `audio/`, or `video/` MIME type is over either target, show a dashed overlay with a `Plus` icon on both targets, drawn with theme tokens only (`border-textcolor`, `bg-bgcolor/80`, `text-textcolor`). Hover has to go by MIME type because file names are not exposed until the drop
- Drop filters the files by extension, runs the accepted ones through `postChatFile` in order, and appends the results with `appendPostFileResults()`
- Accepted extensions are `jpg jpeg png webp gif avif wav mp3 ogg flac mp4 webm`, the set that both `postChatFile` and `postInlayAsset` currently handle; the constant carries a one-line note that it should be replaced by a shared source when the file upload code is reworked
- A drop with no accepted file is not intercepted: no `preventDefault`, no `stopPropagation`, so it reaches the existing `App.svelte` handler unchanged

**`src/ts/process/files/multisend.ts`, `src/ts/process/files/inlays.ts`**
- Compare the file extension case-insensitively in `postChatFile` and `postInlayAsset`. Both were exact-match while the picker's own filter already lowercases, so a `photo.JPG` chosen from the picker produced no attachment, and the drop path would have swallowed it the same way

## Impact

- A drop on the input bar or the preview row with no accepted media file (`.charx`, `.risup`, `.risum`, `.txt`, ...) still goes to the global import handler. A mixed drop attaches the media files and ignores the rest.
- A PNG or JPEG character card dropped on the input bar or the preview row now attaches as an inlay image instead of importing; dropping it on the sidebar or the chat body still imports.
- The attach path is the existing `postChatFile` → `postInlayAsset` → `fileInput` → `{{inlayed::...}}` pipeline; no new storage or send behavior.
- Uppercase extensions now behave like their lowercase forms in the picker and on drop: `.JPG`/`.PNG` attach (stored as PNG like every inlay image), `.MP3`/`.MP4` attach with a lowercase `ext`, and `.TXT`/`.PO` reach the same text and translation handlers they already reach with lowercase names. Paste is image-only as before.
- No new i18n strings, settings, dependencies, or window-level listeners. The overlay exists only while a media-typed file drag is over a target.
- Tauri has `dragDropEnabled: false`, the setting the existing `App.svelte` import-on-drop already relies on, so the desktop build uses the same DOM handlers. Mobile renders the same input bar; the handlers only react to file items with a media MIME type, so in-app touch drags (including the mobile drag polyfill) never trigger them.

## Additional Notes

Validated with:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

`pnpm build` completed with existing non-blocking warnings.

Manual pass in `pnpm dev`: image and audio drop on the input bar and the preview row, drag in and out without dropping, `.charx` and `.txt` drop falling through to the import handler, `fixedChatTextarea` on, sticker toggle visible, playground, a character with custom CSS, and a non-default theme preset. Paste and the "Post File" menu still attach as before.
